### PR TITLE
fix: handle null error field in farm list send response

### DIFF
--- a/src/travian_api/services/farm_list_service.py
+++ b/src/travian_api/services/farm_list_service.py
@@ -255,7 +255,7 @@ class FarmListService:
                     FarmListSendTargetResult(
                         id=t.get("id", 0),
                         status=t.get("status", "unknown"),
-                        error=t.get("error", ""),
+                        error=t.get("error") or "",
                     )
                 )
         return FarmListSendResult(targets=targets)


### PR DESCRIPTION
The Travian API returns null for the error field on successful send targets, which caused a Pydantic validation error. Use `or ""` fallback to coerce None to empty string.