### PR TITLE
feat(planner): resource distribution planner - design, review and planning backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ farm-list-creation/logs/run*.log
 farm-list-creation/progress.json
 scout-results*.md
 *-scout-results*.json
+
+# Local dev/production server logs (started by the agent on 8000/8001)
+.server-*.log
+.server-*.log.err

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,10 @@ src/travian_api/web/static/
 farm-list-creation/.travian_pw
 farm-list-creation/__pycache__/
 farm-list-creation/logs/run*.log
+
+# Live-account artifacts: run output containing real village ids, map
+# coordinates and third-party raid targets. Never commit these — this repo is
+# public, and the data is reconnaissance about live accounts.
+farm-list-creation/progress.json
+scout-results*.md
+*-scout-results*.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 .env
 *.env.local
 run.ps1
-start.bat
-start.sh
 STRATEGY.md
 agent-logs/
 

--- a/CC_PROMPT_create_v3_farm_lists.md
+++ b/CC_PROMPT_create_v3_farm_lists.md
@@ -13,7 +13,7 @@ You have full autonomy from start to finish. No user escalation. Make safe, cons
 The user sets these environment variables and ensures the data files are in the working directory:
 
 ```bash
-export TRAVIAN_USERNAME="REDACTED@example.com"
+export TRAVIAN_USERNAME="$TRAVIAN_USERNAME"  # set in your shell; never commit the real value
 export TRAVIAN_PASSWORD="<password from chat>"
 export TRAVIAN_SERVER="https://ts2.x1.europe.travian.com"
 ```

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,13 @@
+# The built web UI is a BUILD ARTIFACT, not source. It is produced fresh by
+# setup.py's build_py during wheel packaging (and shipped via package-data),
+# so it must never travel in an sdist — otherwise an sdist made from a
+# previously-built checkout could publish a stale UI that drifts from this
+# backend. Excluding it means an sdist install rebuilds the UI (npm present)
+# or serves the honest 503 fallback (npm absent), never stale assets.
+prune src/travian_api/web/static
+
+# Ship the frontend SOURCE so a wheel built from the sdist can rebuild the UI,
+# but not its build outputs or dependencies.
+graft frontend
+prune frontend/node_modules
+prune frontend/dist

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Python library, CLI, and self-hosted web UI for automating Travian Legends gam
 ### Prerequisites
 
 - **Python 3.11+** — [python.org/downloads](https://www.python.org/downloads/)
-- **Node.js 18+** — [nodejs.org](https://nodejs.org/)
+- **Node.js 20.19+ or 22.12+** — [nodejs.org](https://nodejs.org/) (the frontend build uses Vite 8, which needs exactly this range; the startup scripts enforce it)
 
 ### Setup & Run
 

--- a/docs/04-graphql-api.md
+++ b/docs/04-graphql-api.md
@@ -245,7 +245,7 @@ query($isAbandoned: Boolean!, $id: Int!) {
 
 **Fields:**
 - `time` — Unix timestamp (seconds)
-- `title` — Report subject (e.g., `"Chieftain\`s village raids Unoccupied oasis (�-108|142)"`)
+- `title` — Report subject (e.g., `"Chieftain\`s village raids Unoccupied oasis (−108|142)"`)
 - `defender.playerName` — Defender name
 - `defender.village` — `{id, name, x, y}` (null for oasis targets)
 - `resources` — **⚠️ Always returns `null`** — resource data must come from HTML

--- a/docs/12-reports-system.md
+++ b/docs/12-reports-system.md
@@ -554,7 +554,7 @@ The GraphQL API can fetch **metadata** for reports (but NOT resource data):
 
 **Fields:**
 - `time` — Unix timestamp (seconds)
-- `title` — Report subject line (e.g., "Chieftain`s village raids Unoccupied oasis (�-108|142)")
+- `title` — Report subject line (e.g., "Chieftain`s village raids Unoccupied oasis (−108|142)")
 - `defender.playerName` — Defender player name
 - `defender.village` — Defender village `{id, name, x, y}` (null for oasis targets)
 - `resources` — **⚠️ Always returns `null`** — use HTML parsing instead

--- a/docs/20-resource-production.md
+++ b/docs/20-resource-production.md
@@ -18,12 +18,41 @@ var resources = {
 
 | Key | l1 | l2 | l3 | l4 | l5 |
 |-----|----|----|----|----|-----|
-| **Resource** | Lumber | Clay | Iron | Crop | **Free Crop** |
-| `production` | Per-hour rate | Per-hour rate | Per-hour rate | Per-hour rate | Net crop (production - consumption) |
+| **Resource** | Lumber | Clay | Iron | Crop | see below |
+| `production` | Per-hour rate | Per-hour rate | Per-hour rate | **NET crop per hour** | not net crop — do not use |
 | `storage` | Current amount | Current amount | Current amount | Current amount | — |
 | `maxStorage` | Warehouse cap | Warehouse cap | Warehouse cap | Granary cap | — |
 
-> **`l5` (Free Crop)** = Net crop production after all consumption (troops, population). This is the crop balance. If negative, your village is starving.
+> ### ⚠️ `l4` is the crop balance, NOT `l5`
+>
+> **`production.l4` is the true net crop rate** — production minus all consumption
+> (population, constructions, and every troop actually feeding from this
+> village). It is what the granary drains or fills at, and it goes negative when
+> the village is starving. **This is the only field to use for starvation.**
+>
+> **`production.l5` is NOT net crop.** An earlier version of this document said
+> it was; that was wrong, and the mistake propagated into `Resources.free_crop`
+> and the Dashboard resource bar.
+>
+> Measured on a live starving village (`newdid=20003`), captured 2026-08:
+>
+> ```json
+> production: {"l1": 2875, "l2": 3750, "l3": 2175, "l4": -5556, "l5": 1481}
+> storage:    {"l1": 88652, "l2": 85167, "l3": 93880, "l4": 67397}
+> maxStorage: {"l1": 160000, "l2": 160000, "l3": 160000, "l4": 240000}
+> ```
+>
+> `l5` is **positive (+1481)** while the village is draining at **−5,556/h**.
+> Anything treating `l5` as the starvation signal reports this village as
+> healthy. Verified independently against the warehouse overview, which marked
+> this village `crit` with a 43,899 s countdown to an empty granary:
+> `67,397 / 5,556 = 12.13 h = 43,670 s` — a 0.5% match, the residual being the
+> few minutes between the two captures.
+>
+> What `l5` actually means is **unresolved**. From one sample,
+> `l5 - l4 = 7037` looks like it could be gross production or total consumption,
+> but a single data point cannot distinguish those. Treat it as unknown until
+> reconciled against `/production.php?t=balance`, which decomposes every term.
 
 ### Python — Quick Resource Fetch
 
@@ -42,6 +71,93 @@ print(f"Free Crop: {res['production']['l5']}/h")
 ```
 
 ---
+
+## Account-Wide Net Crop — Warehouse Overview (2 requests, all villages)
+
+`var resources` costs one request **per village**. The Central Village Overview
+carries the same net-crop information for every village at once.
+
+```
+/village/statistics/resources            -> absolute stocks per village
+/village/statistics/resources/warehouse  -> fill/empty countdown per village
+/village/statistics/resources/capacity   -> warehouse + granary caps (changes rarely; cache it)
+```
+
+`#warehouse` gives percentages, not absolutes, so pair it with the stocks table.
+The countdown is the server's own computation, which is why this needs no upkeep
+model:
+
+```
+crit present (draining):  net_crop = -stock / seconds * 3600
+crit absent  (filling):   net_crop = (granary_cap - stock) / seconds * 3600
+```
+
+For a **starving** village only stocks + warehouse are needed — capacity does not
+enter the formula. That makes "which villages are starving, and how fast" a
+**two-request** question for the whole account.
+
+### `#warehouse` markup
+
+```html
+<table id="warehouse">
+  <thead><tr>
+    <td>Village</td><td><i class="r1"></i></td><td><i class="r2"></i></td><td><i class="r3"></i></td>
+    <td><img class="clock"></td>            <!-- warehouse: first of lumber/clay/iron -->
+    <td><i class="r4"></i></td>
+    <td><img class="clock"></td>            <!-- granary: crop-specific -->
+  </tr></thead>
+  <tbody>
+    <!-- filling -->
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+      <td class="lum">18%</td><td class="clay">35%</td><td class="iron">0%</td>
+      <td class="max123"><span class="timer" counting="down" value="88017" data-value="88017">24:26:57</span></td>
+      <td class="crop">56%</td>
+      <td class="max4 lc"><span class="timer" counting="down" value="211328" data-value="211328">58:42:08</span></td>
+    </tr>
+    <!-- draining (starving) -->
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+      ...
+      <td class="max4 lc"><span class="crit">−</span>&nbsp;<span class="timer crit" value="43899" data-value="43899">12:11:39</span></td>
+    </tr>
+  </tbody>
+</table>
+```
+
+| Detail | Value |
+|--------|-------|
+| Raw seconds | `value` **and** `data-value` on `span.timer` — never parse the rendered `H:MM:SS` |
+| Direction | `class="crit"` (plus a `−` U+2212 prefix) = draining; absent = filling |
+| Crop column | the **second** clock (`td.max4`); the first (`td.max123`) is whichever of lumber/clay/iron fills first |
+| Village id | `newdid=` in the row's first-cell link |
+
+**Three parsing traps, all present in real markup:**
+
+1. Rows are **not** in village-id order — the header has `onclick="sortByColumnOrder(...)"` and the server honours the saved sort. Key on `newdid`, never on row index.
+2. The rows are malformed: `<tr class="hover" "="">`. `html.parser` tolerates it; do not switch parsers without re-testing.
+3. Percentages are integers, so `pct x capacity` carries up to ±0.5% error. Prefer absolute stocks from `/village/statistics/resources`.
+
+### Central Village Overview — full tab map
+
+Reached from the village-list header, legacy alias `dorf3.php`. **Travian Plus
+feature** — code must tolerate its absence and fall back to per-village `dorf1`.
+
+| Tab | Sub-tab | Path | Per-village data |
+|-----|---------|------|------------------|
+| Overview | — | `/village/statistics/overview` | attacks, buildings queued, troops training, merchants |
+| Resources | Resources | `/village/statistics/resources` | absolute stocks + merchants |
+| Resources | Warehouse | `/village/statistics/resources/warehouse` | **fill/empty countdowns** (net crop) |
+| Resources | Production | `/village/statistics/resources/production` | **GROSS** production — no troop feeding |
+| Resources | Capacity | `/village/statistics/resources/capacity` | warehouse + granary caps |
+| Culture points | — | `/village/statistics/culturepoints` | CP/day, celebrations, settlement slots |
+| Troops | Own troops | `/village/statistics/troops` | troop counts **by owning village** |
+| Troops | Troops in village | *(unconfirmed)* | troops **by station** + their crop upkeep |
+| Troops | Smithy / Hospital / Training | *(unconfirmed)* | research levels, wounded, training queues |
+
+> **Own troops vs Troops in village.** Consumption is charged where troops
+> *stand*, not where they were built. "Own troops" therefore cannot be used to
+> compute crop upkeep: a village's own army may be reinforcing elsewhere (eating
+> the host's crop), while foreign reinforcements eat this village's. "Troops in
+> village" is the station-keyed view and reports upkeep directly.
 
 ## Top Bar — Stock Bar (HTML)
 
@@ -323,7 +439,9 @@ for vid in [20030, 20031]:
 |------|--------|--------|
 | Current resource amounts | `var resources` on any page | Parse `storage.l1`–`l4` |
 | Production rates | `var resources` on any page | Parse `production.l1`–`l4` |
-| Free crop (net) | `var resources` on any page | Parse `production.l5` |
+| **Net crop / starvation (one village)** | `var resources` on any page | Parse `production.l4` — **not `l5`** |
+| **Net crop for ALL villages** | `/village/statistics/resources` + `.../warehouse` | Stocks ÷ countdown, sign from `crit` — 2 requests |
+| Gross crop production (no feeding) | `/village/statistics/resources/production` | Per-village table |
 | Warehouse capacity | `var resources` on any page | Parse `maxStorage.l1`–`l3` |
 | Granary capacity | `var resources` on any page | Parse `maxStorage.l4` |
 | Per-building breakdown | `/production.php?t={type}` | Parse `ProductionOverview.render()` viewData |

--- a/docs/25-resource-distribution-planner.md
+++ b/docs/25-resource-distribution-planner.md
@@ -1,0 +1,497 @@
+# Resource Distribution Planner — Profiling, Review & UI Design
+
+**Project:** `travian-auto-player` · **Server:** Europe 2, x1, 3 tribes · **Account:** `Chieftain` (Teutons)
+**Status:** pre-development. Part I is the operator's profiling doc. Parts II and III are a technical review of it.
+
+---
+
+# Part I — Profiling *(operator)*
+
+## 1. Purpose
+
+Replace manual resource-distribution planning with a tool that:
+
+1. reads current per-village production and state,
+2. takes role-based allocation targets from the user,
+3. computes a minimal-merchant, minimal-latency set of trade routes,
+4. assigns dispatch/arrival timing so no hub overflows,
+5. outputs a copy-paste setup sheet (later: applies routes in-game).
+
+Everything is expressed in **hourly rates**. All planning is read-only against the game at first; an "apply" path is a later phase.
+
+## 2. Domain model
+
+| Entity | Fields |
+|---|---|
+| **Village** | id, name, x, y, role, net production (W/C/I/Cr), current stock, warehouse_cap, granary_cap, marketplace_lvl, merchant_count, trade_office_lvl, priority_flag, allocation targets |
+| **ForeignTarget** | x, y, hourly crop owed, safety margin, paying village |
+| **Role** | name, allocation template (per-resource mode + value) |
+| **Route** | from, to, cargo (W/C/I/Cr per send), cycle_h, dispatch_min, arrival_min, merchants |
+| **Plan** | snapshot timestamp, route set, merchant pool per village, warnings, infeasibilities |
+
+**Village roles observed in practice:** feeder (base template), capital/NPC hub, army/hammer village (negative net crop), crop hub, sub-hub, stranded/isolated.
+
+## 3. Verified game mechanics — ground truth
+
+### 3.1 Merchants
+
+| Property | Value | Notes |
+|---|---|---|
+| Capacity | `Base_Merchant_Size × (1 + 0.2 × trade_office_lvl)` | `Base_Merchant_Size` configurable, default 2200 |
+| Speed | 12 fields/hour | Teuton |
+| Count per village | derived from Marketplace level | not always 20 — observed 13 and 19 |
+| Reserve | 2 idle per village (config) | usable = count − reserve |
+
+> ⚠️ **Both constants in this row are disputed — see Review R1. Do not build on them until settled.**
+
+### 3.2 Gold Club trade routes
+
+- Cycle length must be a whole number of hours (1–24). No 30-minute or 80-minute cycles.
+- One sender village per route.
+- **UNVERIFIED:** whether Gold Club caps the number of trade routes per village.
+
+### 3.3 Production data
+
+- The account-wide Production tab reports **GROSS** crop. Using gross as net is a silent, catastrophic error — it inverts the sign on army villages.
+- Net production for all villages is obtainable cheaply — see Review R2 for the actual cost and its caveats.
+- Trade-in-transit contaminates Capacity-tab readings.
+
+### 3.4 Distance
+
+Toroidal Euclidean over the map wrap:
+
+```
+dx = min(|x1-x2|, MAP_SPAN - |x1-x2|)
+dy = min(|y1-y2|, MAP_SPAN - |y1-y2|)
+dist_fields = sqrt(dx² + dy²)
+ow_min      = dist_fields / speed_fields_per_h × 60
+rt_min      = 2 × ow_min
+```
+
+### 3.5 Topology rules (user-imposed)
+
+- No waterfall for W/C/I — materials must not chain A→B→C.
+- Crop relay through a sub-hub is permitted.
+- Max end-to-end latency target: 2h (configurable); far villages may exceed it when geometry forbids compliance.
+
+## 4. System decomposition
+
+| # | Subsystem | Depends on |
+|---|---|---|
+| 1 | State & Fetch | — |
+| 2 | Allocation Input | 1 |
+| 3 | Flow Optimizer | 1, 2 |
+| 4 | Schedule Solver | 3 |
+| 5 | NPC / Storage / Apply / Monitor | 1, 3, 4 |
+
+Subsystems 1–3 alone replace all manual planning.
+
+## 5. §1 — State & Fetch
+
+```
+FETCH-A   per village: net_W, net_C, net_I, net_Cr
+FETCH-B   per village: x, y, marketplace_lvl, merchant_count, warehouse_cap, granary_cap
+OWNED     trade_office_lvl — seeded by a one-off scan, user-editable, defaults to 0, never rounds up
+CONFIG    base_merchant_size, speed_fields_per_h, merchant_reserve, max_latency_h, map_span
+DERIVED   merchant_cap, dist, ow_min, rt_min
+```
+
+### 5.2 Trade Office handling — rounding rule
+
+| Cached TO | Consequence |
+|---|---|
+| too low | over-provisions merchants. Wasteful, every route still fits. **Safe.** |
+| too high | under-provisions. Cargo exceeds assigned merchants, budget breached invisibly. **Unsafe.** |
+
+Unknown TO = 0; all inference rounds **down**.
+
+### 5.3 TO as a decision surface
+
+Show TO alongside what upgrading buys, so the field doubles as "which Trade Office to build next":
+
+| V | TO | Cap/merchant | Merchants used | At TO+1 | At TO+5 |
+|---|---|---|---|---|---|
+| 16 | 0 | 2,200 | 9 | 2,640 → 8 | 4,400 → 6 |
+| 05 | 11 | 7,040 | 16 | 7,480 → 15 | 9,240 → 12 |
+
+**Staleness nag (no request):** if a village's TO is unchanged for N days *and* its routes are over-provisioned relative to neighbours, flag "verify TO?".
+
+### 5.4 Validation on every fetch
+
+- reject all-zero payloads (observed in practice)
+- flag villages missing from the response
+- flag villages present but absent from OWNED state → new village, prompt for a TO scan
+- warn if snapshot age exceeds N minutes
+- assert `sum(per-village) == reported account total` per resource
+
+## 6. §2 — Configuration
+
+Open: is `Base_Merchant_Size` per-tribe or per-server? Prefer reading `merchant_count` directly over deriving it from `marketplace_lvl`.
+
+## 7. §3 — Allocation Input
+
+### 7.1 Modes — per resource type per village
+
+| Mode | Meaning |
+|---|---|
+| `percentage` | share of total account production of that resource |
+| `absolute` | fixed net/hour |
+| `remainder` | receives everything unallocated. Exactly one village per resource. |
+| `sustain + X%` | for negative-net-crop villages: cover the deficit plus X% headroom |
+| `role template` | named bundle of the above, applied to many villages |
+
+Mixed modes within one village are normal.
+
+### 7.2 Requirements
+
+- Live unallocated counter per resource.
+- Role assignment with per-village override.
+- **Display shipped alongside target.** `shipped = target − own_production`. Showing only the target caused the same error twice.
+- Slack routed to the `remainder` village; hard warning if none set.
+- Layout toggle: current production vs post-distribution retention.
+- Per-village `priority_flag` + acceptable-occupied-merchants ceiling.
+
+### 7.3 Foreign targets
+
+`x, y, hourly_crop, safety_margin_pct, paying_village`. Crop only. Payment must run continuously; first payment lands after full one-way travel (cold-start warning). Apply a safety margin. These merchants are permanently committed at the paying village.
+
+## 8. §4 — Flow Optimizer
+
+### 8.1 Cost model
+
+```
+ow_min  = dist_fields / speed_fields_per_h × 60
+rt_min  = 2 × ow_min
+batch   = hourly_cargo × cycle_h
+m_send  = ceil(batch / merchant_cap[sender])
+sets    = ceil(rt_min / (cycle_h × 60))
+pool    = m_send × sets
+```
+
+The double ceiling makes `pool` non-monotonic in `cycle_h`. Sweep 1..24 per route; never assume a direction.
+
+Worked example (V10 → V02, 9,323/h, rt 532 min, cap 5,720) — *arithmetic independently re-verified, see R4*:
+
+| cycle | m_send | sets | pool |
+|---|---|---|---|
+| 1h | 2 | 9 | 18 |
+| 2h | 4 | 5 | 20 |
+| **3h** | **5** | **3** | **15** |
+| 4h | 7 | 3 | 21 |
+
+### 8.2 Hard constraints
+
+| Constraint | Rule |
+|---|---|
+| Cycle length | integer hours 1–24 |
+| Merchants per village | `Σ pool ≤ merchant_count − reserve` |
+| Waterfall | forbidden for W/C/I; permitted for crop via sub-hub |
+| Two-way pairs | never ship the same resource both directions between one pair — net it out |
+| Latency | prefer ≤ `max_latency_h`; flag geometry-forced violations |
+
+### 8.3 Objective
+
+1. minimise total merchants committed
+2. minimise maximum end-to-end latency
+3. maximise free merchants at `priority_flag` villages
+4. minimise route count
+
+### 8.4 Escalation ladder
+
+sweep other cycles → reroute via nearer hub → split cargo → recommend TO upgrade (show Δmerchants) → declare infeasible, strand the village.
+
+### 8.5 Hub logic
+
+Neighbours consolidate at a hub; the hub makes the long haul with full merchants. Hub assignment is discrete and interacts with the per-village cap.
+
+## 9. §5 — Schedule Solver
+
+- derive `dispatch_min = (desired_arrival_min − ow_min) mod 60`
+- stagger arrivals at each hub ≥ N minutes apart
+- enforce collect-then-ship ordering at hubs
+- reserve a clear slot for the manual NPC burst
+- emit the "hourly beat" table per hub
+
+> ⚠️ **The 60-minute beat cannot represent multi-hour cycles — see Review R5.**
+
+## 10. §6 — Storage Safety
+
+`fill_time_h = (capacity − current_stock) / net_inflow_per_h`; warn under 18h. Special case: a lumpy NPC batch overflows while continuous-rate checks pass — model batches as discrete events.
+
+## 11. §7 — NPC Subsystem
+
+| Feature | Detail |
+|---|---|
+| Trigger | crop stock ≥ threshold (currently 300k at the capital) |
+| Split ratio | configurable, bias mode (e.g. iron-heavy 30/20/50) |
+| Post-NPC ship | large manual burst; may need several back-to-back sends |
+| Merchant headroom | reserve capacity at the NPC village for the burst |
+| Frequency estimate | retention → NPCs/day → gold cost/day |
+| Sink-capacity warning | ~93k/h produced vs 48k/h absorbed → surplus accumulates |
+
+## 12. §8 — Output & Apply
+
+**Phase 1:** setup sheet, one row per route: `from | to | cargo | cycle | dispatch | arrival | merchants`, plus merchant pool per village, warnings, infeasibilities. Integer cargo, sum-preserving rounding. Diff against the currently configured route set. Idempotent re-plan.
+
+**Phase 2 (apply):** blocked on the Gold Club route cap. All HTTP through the existing stealth chain; no parallel requests; captcha = immediate clean stop.
+
+## 13. §9 — Validation & Monitoring
+
+Expected vs actual stock trajectory; detect silently failing routes, new/chiefed villages, production drift; alert on divergence rather than silently re-planning.
+
+## 14. Hardness
+
+Multi-commodity min-cost flow with integer cycle and merchant variables plus per-node capacity — NP-hard in general. N=20 is small, so: cluster → assign hubs → per-route cycle sweep → local improvement. MILP (HiGHS/CBC via PuLP) later.
+
+## 15. Known issues & guards
+
+| # | Failure | Guard |
+|---|---|---|
+| 1 | Shipped the target instead of the gap | assert `shipped == target − own_production` |
+| 2 | Two-way pair with opposite cargo | forbid duplicate (pair, resource); net before emitting |
+| 3 | Gross crop treated as net | never read crop from the Production tab |
+| 4 | Merchant base size wrong (1000 → 1600 → 2200) | config value; verify empirically |
+| 5 | Non-integer cycles proposed | clamp to integer hours at generation |
+| 6 | Exceeded the 20-merchant cap | hard constraint + reserve, per village |
+| 7 | All-zero export accepted | payload validation |
+| 8 | Unroutable village (105 fields, ~55 merchants) | feasibility check → strand |
+| 9 | Percentages summed to 96%, slack unassigned | require a `remainder` village per resource |
+| 10 | Village count churn 5 → 20 | idempotent re-plan, route diffing |
+| 11 | TO unknown for new villages | default 0, flag, never round up |
+| 12 | Continuous-rate check passed while a batch overflowed | model NPC batches as discrete events |
+
+## 16. Open questions
+
+| # | Question | Blocks |
+|---|---|---|
+| 1 | Does Gold Club cap trade routes per village? | apply layer |
+| 2 | `merchant_count` — read directly or derive? | §1 |
+| 3 | Is `Base_Merchant_Size` per-tribe or per-server? | see R1 — blocks everything |
+| 4 | Map span for toroidal wrap on Europe 2 | distance correctness |
+
+## 17. Build order
+
+| Phase | Deliverable |
+|---|---|
+| 1 | §1 State & Fetch |
+| 2 | §3 Allocation Input |
+| 3 | §4 Flow Optimizer |
+| 4 | §5 Schedule Solver |
+| 5 | NPC, storage, apply, monitor |
+
+## Appendix A — Regression fixture
+
+The current 20-village plan is the optimizer's golden test case: net production, coords, TO levels, allocation targets in; route set, per-village merchant pool, total ~115 merchants, all villages ≤ 18 out. Exercises: an army village with large negative net crop, a `remainder` village, a stranded village, two sub-hubs, a priority village held at 3/20, a foreign crop tribute, sub-20-merchant villages, and unknown TO defaulting to 0.
+
+---
+
+# Part II — Technical review
+
+Findings are ordered by how much damage they do if left unaddressed.
+
+## R1 — BLOCKER: the merchant capacity constants look doubly wrong
+
+§3.1 uses `Base_Merchant_Size = 2200` with `1 + 0.2 × TO`. Published Travian values for **Teutons** are **base 1000** and **+10% per Trade Office level** — the +20% figure is the **Roman** rate.
+
+Both errors push the same way: they overstate capacity, which under-provisions merchants — the direction §5.2 itself labels **unsafe**.
+
+Compare V05 (TO 11) from §5.3:
+
+| Formula | Capacity/merchant |
+|---|---|
+| doc: `2200 × (1 + 0.2 × 11)` | **7,040** |
+| stock Teuton: `1000 × (1 + 0.1 × 11)` | **2,100** |
+
+A 3.35× overstatement. Every route sized against it needs ~3× the budgeted merchants — precisely known-issue #6.
+
+The correction history in issue #4 (`1000 → 1600 → 2200`) is itself the tell. Under the Teuton +10% rule those are exactly `TO 0 → TO 6 → TO 12` on a base of 1000. That is the signature of **sampling different villages and mistaking a Trade Office bonus for the base** — after which the formula applies the same bonus a second time.
+
+Other multipliers that could legitimately produce a non-stock number, and which are **not** constants:
+
+- **Trade artifacts** multiply merchant capacity, can be lost or captured, and some are account-wide while others are single-village.
+- Server speed multiplies capacity, but Europe 2 is x1.
+
+**Decisive test — zero requests.** Open the Marketplace in two villages with *different* TO levels and read the capacity the game states. Two observations solve `cap = base × (1 + k × TO)` for both unknowns:
+
+```
+k    = (cap_b − cap_a) / (cap_a × b − cap_b × a)     # a, b = the two TO levels
+base = cap_a / (1 + k × a)
+```
+
+Pick a TO-0 village for one sample and `base = cap` directly. **Nothing downstream should be built until this is pinned**, and the resolved values belong in a test fixture, not a config default.
+
+## R2 — §3.3's "single request" for net production is optimistic
+
+The claim "net production for all villages is obtainable in a single request (solved)" overstates a result that is real but narrower:
+
+- It is **two** requests, not one: `/village/statistics/resources` (stocks) + `/village/statistics/resources/warehouse` (countdown). Net crop is derived, not read.
+- Only the **draining** branch is verified. `net = −stock / t` was confirmed on village 20003 to 0.5%. The **filling** branch `net = (capacity − stock) / t` is **unvalidated** and currently disagrees with gross production on village 02 by a wide margin.
+- It needs the **Capacity** tab too for filling villages, so realistically **three** requests until capacity is cached.
+- The whole path is **Travian Plus gated**. Without Plus it collapses to one `dorf1` per village.
+
+FETCH-A should therefore be specced as *2–3 requests, Plus-dependent, with a per-village `dorf1` fallback*, and the filling branch marked unproven. See `docs/20-resource-production.md`.
+
+Related trap, already burned once: **net crop is `production.l4`, never `l5`.** `l5` reads positive on a starving village.
+
+## R3 — Trade Office fetch research *(the question asked)*
+
+**Answer: there is no account-wide source. The floor is one request per village, and it is a one-off.**
+
+Checked and ruled out:
+
+| Candidate | Verdict |
+|---|---|
+| Central Village Overview tabs | Overview / Resources / Culture points / Troops only — no building levels |
+| "Buildings and Resource Fields Statistics" support page | a static reference calculator of costs and effects, not a view of your account |
+| GraphQL | no building fields; `docs/04` and `docs/20` both confirm production/building data is HTML-only |
+| Troops → Smithy sub-tab | per-village *research* levels, not building levels |
+
+**But the scan is cheaper than §5.1 implies, and needs no new code.** `parse_dorf2` already returns every village-centre building with its `gid` and level, and Trade Office is `gid 28`, Marketplace `gid 17`. So:
+
+- one `dorf2` per village — **N requests, not 2N** (no `dorf1` needed; both buildings are in the village centre)
+- the same sweep yields **Marketplace level for free**, settling open question #2 without a second mechanism
+- and warehouse/granary levels (`gid 10`/`11`) if capacity is ever wanted from levels rather than the Capacity tab
+
+At 22 villages that is a 22-request one-off, re-run only when a village is added. Treating TO as OWNED state (§5.2) is the right call; the scan just costs half what the doc budgets.
+
+**Cheaper long-term option, phase 2 only:** once routes are applied, capacity is *observable* — Travian reports how many merchants a given cargo consumed, so `cap = cargo / merchants` recovers it with zero extra requests and self-heals when a TO is upgraded. That also removes the staleness nag in §5.3 entirely. Worth designing toward.
+
+## R4 — The optimizer cost model is correct (verified)
+
+I re-derived the §8.1 worked example independently and it reproduces exactly, including the non-monotonicity:
+
+| cycle | batch | `m_send` | `sets` | pool |
+|---|---|---|---|---|
+| 1h | 9,323 | ⌈1.63⌉=2 | ⌈8.87⌉=9 | 18 |
+| 2h | 18,646 | ⌈3.26⌉=4 | ⌈4.43⌉=5 | 20 |
+| 3h | 27,969 | ⌈4.89⌉=5 | ⌈2.96⌉=3 | **15** |
+| 4h | 37,292 | ⌈6.52⌉=7 | ⌈2.22⌉=3 | 21 |
+
+`sets = ceil(rt / cycle)` is also right at the boundary: at `rt = 360, cycle = 180` it gives 2, and the first set returns exactly as the third dispatch is due, so 2 suffices. The sweep-don't-assume conclusion stands.
+
+## R5 — MAJOR: the "hourly beat" cannot express the schedule it is scheduling
+
+§9 emits a minute-of-hour table and computes `dispatch_min = (arrival − ow) mod 60`. That is only well-defined when every cycle is 1 hour. A 3-hour route fires once per three hours; a 60-minute table either shows it three times (wrong) or once without saying which hour (ambiguous). The optimizer's own best answer in §8.1 is a 3h cycle, so this is not a corner case.
+
+**Fix — constrain `cycle_h` to divisors of 24: {1, 2, 3, 4, 6, 8, 12, 24}.** Then every cycle divides the day, the beat is a single repeating **24-hour** table, and the schedule is exactly representable. Over the free sweep this costs only cycles 5, 7, 9–11, 13–23; since `pool` is non-monotonic the optimizer can still evaluate them and *report* "a 5h cycle would save 2 merchants but breaks the daily beat", leaving it as an explicit user choice rather than a silent constraint.
+
+Without this restriction the beat's LCM is unbounded and the output table is not a schedule.
+
+## R6 — Dispatch phase may not be a free variable
+
+§9 assumes `dispatch_min` is chosen. In Gold Club, a trade route's phase is set by **when the route is created** — it repeats every N hours from that moment. If so, the planner cannot set dispatch minutes; it can only tell the operator **what time to create each route**, and the sheet needs a "create at HH:MM" column rather than a "dispatch" column.
+
+This is unverified and sits directly under the schedule solver. It should join open question #1 as an empirical check before §5 is built — and it is cheap to answer by creating one route and observing.
+
+## R7 — Storage safety only models the filling direction
+
+§10's `fill_time_h = (capacity − stock) / net_inflow` returns a negative number for a village with negative net crop, which is the *starving* case and the one that actually kills troops. It needs the second branch — `empty_time_h = stock / −net` — and the warning threshold applies to both. This is the same l4/l5 trap resurfacing in a different module, which argues for a single shared `crop_status()` helper rather than per-module arithmetic. One now exists in `web/routes/status_export.py`.
+
+## R8 — Routes persist; plans do not
+
+§13 alerts on production drift, but an applied trade route keeps shipping at its configured cargo regardless. If a sender's production falls — troops rebuilt, an oasis lost, a village chiefed — the route drains the sender's stock and the tool only *notices*. Two guards worth speccing now, because they are cheap at design time and expensive to retrofit:
+
+1. size routes against **sustainable surplus with margin**, not the instantaneous snapshot rate
+2. make drift beyond X% **trigger a re-plan proposal** with a route diff, not just an alert
+
+## R9 — Smaller notes
+
+- **§3.1 speed 12 f/h is tribe-specific.** Correct for Teutons; if the tool ever handles another account it belongs with the base capacity in a per-tribe table, not in global CONFIG.
+- **Open question #4 (map span) is answerable from data you already hold** — village coordinates and any map-scan output bound it; `docs/05-map-system.md` covers the map system.
+- **Appendix A's fixture must be frozen, not live.** The account has already gone 20 → 22 villages; a golden test that reads current state stops being a regression test.
+- **Merchant reserve interacts with foreign tribute.** §7.3's permanently committed merchants must be subtracted *before* the reserve, or a tribute-paying village silently ends up with no idle merchants.
+- **§7.2's "shipped vs target" is the highest-value guard in the document** (it caused the same error twice). It should be enforced in the data model — store the gap and derive the target — not left to a UI label.
+
+---
+
+# Part III — UI design
+
+## Principle: encode the invariants in the widgets
+
+Six of the twelve known issues are data-entry or bookkeeping errors. Validation messages do not prevent those; **input types that cannot express the error** do. Three examples that drive the whole design:
+
+| Issue | Structural fix |
+|---|---|
+| #9 slack unassigned | `remainder` is a **radio group per resource column** — cannot pick two, warns loudly at zero |
+| #1 shipped vs target | the grid's **primary number is the gap**; the target is the dimmed secondary |
+| #11 unknown TO | TO cells with no scan render as a distinct *unknown* state, not as `0` |
+
+## Layout: five stages, one persistent state
+
+Left rail with five stages; every stage is re-enterable and shares one persisted plan document, so a re-plan never means re-entry (#10).
+
+```
+Snapshot → Allocate → Optimize → Beat → Sheet
+```
+
+A persistent header carries: snapshot age (amber past N minutes), **request cost of the last refresh**, and a single Refresh button labelled with what it will cost — `Refresh (2 requests)`. Making the cost visible in the button is the whole ethos of this tool.
+
+### Stage 1 — Snapshot
+
+One table, one row per village. Columns: name · coords · role · net W/C/I/Cr · stock/cap with fill-or-empty time · merchants free/total · TO · distance to assigned hub.
+
+- **Net crop is signed and coloured**, negative in red with the empty-time beside it. Never show an unsigned crop rate.
+- **Owned vs fetched is visible.** Fetched cells are plain; owned/editable cells (TO, role, priority flag) carry a subtle edit affordance. That makes §5.2's safety model legible instead of documentation.
+- **TO cell has three states:** a number, `0 (assumed)`, and `unknown — scan`. The third is not silently treated as 0 in the UI even though the optimizer floors it, so the user can see what the plan is guessing.
+- Row action **"Scan buildings (1 request)"** for a single village; a header action for a full sweep with the cost stated (`Scan 22 villages (22 requests)`).
+- Validation from §5.4 appears **on the offending row**, not in a list underneath.
+
+### Stage 2 — Allocate
+
+A spreadsheet grid, because that is what it replaces and the muscle memory is worth keeping. Rows = villages, columns = W/C/I/Cr.
+
+Each cell shows two lines:
+
+```
+  +827/h        ← SHIP (large) — the number that becomes cargo
+  target 1,014  ← dimmed secondary
+```
+
+- **Column header is the live allocation meter**: `Iron — 96% allocated · 4% unassigned → V02`. Green at exactly 100% with a remainder set; amber with slack; red over 100%.
+- **`remainder` is a radio in the column header**, so exactly-one is structural.
+- **Role dropdown per row**; cells overridden away from the template get a small marker so deviations are visible at a glance.
+- `sustain + X%` cells render the derived figure inline: `sustain −5,556/h + 13% → ship 6,278/h`.
+- **Foreign targets are a separate section below the grid**, never rows in it — they are not villages and giving them village rows invites treating them as such.
+
+### Stage 3 — Optimize
+
+Two panes.
+
+**Left — merchant budget per village.** A horizontal stacked bar per village: committed / tribute / reserve / free, with the cap as a hard line. Over-cap bars turn red and jump to the top. This is the constraint the user actually reasons about, so it deserves the primary visual.
+
+**Right — routes**, grouped by hub. Each route row expands to show **the cycle sweep that produced it**:
+
+```
+V10 → V02   9,323/h   cycle 3h   5 merchants × 3 sets = 15
+  1h 18 │ 2h 20 │ ▸3h 15◂ │ 4h 21 │ 6h 18 │ 8h 24 …
+```
+
+Explainability is not decoration here. The operator did this by hand and will not trust a solver that shows only its answer; seeing the non-monotonic curve is what makes the choice believable.
+
+**Infeasible villages get their own panel**, each with the escalation ladder's next step spelled out — *"needs ~55 merchants at 105 fields; recommend local consumption"* or *"Trade Office +2 → fits in 17"*.
+
+### Stage 4 — Beat
+
+A **24-hour** timeline per hub (per R5, not 60 minutes), arrivals as markers, the hub's own outbound as a distinct mark, and the reserved NPC slot as a shaded band. Collect-then-ship violations draw as a red overlap. If R6 confirms that phase is fixed at creation, this stage's output column is **"create route at HH:MM"**.
+
+### Stage 5 — Sheet
+
+The diff, not the plan: **Create / Edit / Delete** against the currently configured route set, so the user only touches what changed. Per-row copy buttons, and one "copy all creates" action. Unchanged routes collapse into a single line: `14 routes unchanged`.
+
+## Cross-cutting
+
+- **Every number carries its unit and sign convention.** Rates are `/h`, stocks are absolute, cargo is per-send. Mixing these is how #1 happened.
+- **Nothing auto-refreshes.** Requests are the scarce resource; every fetch is a deliberate, priced click.
+- **Warnings live where the problem is**, with a severity split between "will break" (red, blocks Sheet) and "worth knowing" (amber).
+- **The plan document is local and versioned**, so re-planning after a village count change is a diff rather than a re-entry.
+
+---
+
+## Immediate next actions
+
+| # | Action | Cost | Unblocks |
+|---|---|---|---|
+| 1 | Read merchant capacity in two villages with different TO | 0 requests | **R1 — everything** |
+| 2 | Capture Resources + Capacity + one *filling* village `dorf1` together | 0 requests | R2 filling branch |
+| 3 | One-off `dorf2` sweep for TO + Marketplace | N requests | §1 OWNED state |
+| 4 | Create one trade route and observe its phase and any per-village cap | in-game | R6, open question #1 |

--- a/docs/25-resource-distribution-planner.md
+++ b/docs/25-resource-distribution-planner.md
@@ -358,11 +358,11 @@ I re-derived the §8.1 worked example independently and it reproduces exactly, i
 
 Without this restriction the beat's LCM is unbounded and the output table is not a schedule.
 
-## R6 — Dispatch phase may not be a free variable
+## R6 — Dispatch phase IS a free variable (resolved)
 
-§9 assumes `dispatch_min` is chosen. In Gold Club, a trade route's phase is set by **when the route is created** — it repeats every N hours from that moment. If so, the planner cannot set dispatch minutes; it can only tell the operator **what time to create each route**, and the sheet needs a "create at HH:MM" column rather than a "dispatch" column.
+§9 assumes `dispatch_min` is chosen. This is correct: per current official documentation ([Trade Routes](https://support.travian.com/en/articles/60-trade-routes)), a Gold Club route has an explicit **Send at / Deliver at** scheduled time plus a separate repeat interval — the phase is a route field, **not** the wall-clock instant the form is submitted. So the planner's `dispatch_minute` maps directly to the route's "Send at" field, and the sheet's column is labelled **Send at**, not "create at".
 
-This is unverified and sits directly under the schedule solver. It should join open question #1 as an empirical check before §5 is built — and it is cheap to answer by creating one route and observing.
+Consequence for cold-start: `first_delivery_hours` is a WORST-CASE upper bound (a full cycle plus travel, if the route is created just after its send time), used only to bound the manual-coverage window — not a fixed startup. An earlier revision wrongly told the operator to press create at the dispatch clock; that has been corrected.
 
 ## R7 — Storage safety only models the filling direction
 

--- a/docs/25-resource-distribution-planner.md
+++ b/docs/25-resource-distribution-planner.md
@@ -289,36 +289,17 @@ The current 20-village plan is the optimizer's golden test case: net production,
 
 Findings are ordered by how much damage they do if left unaddressed.
 
-## R1 — BLOCKER: the merchant capacity constants look doubly wrong
+## R1 — RESOLVED: the constants were right, the review was wrong
 
-§3.1 uses `Base_Merchant_Size = 2200` with `1 + 0.2 × TO`. Published Travian values for **Teutons** are **base 1000** and **+10% per Trade Office level** — the +20% figure is the **Roman** rate.
+**Measured: a TO 13 village carries 7,920 per merchant.** `2200 × (1 + 0.2 × 13) = 7920` exactly. §3.1 stands.
 
-Both errors push the same way: they overstate capacity, which under-provisions merchants — the direction §5.2 itself labels **unsafe**.
+The review argued the profile's `base 2200` / `+20%` had to be mistaken, because published Teuton values are `base 1000` / `+10%` and `+20%` is the Roman rate — which would have made the profile overstate capacity 3.35× and under-provision every route. That reasoning was sound but the premise was not: **Europe 2 is not a stock server.** Stock Teuton predicts 2,300 at TO 13; the game reports 7,920.
 
-Compare V05 (TO 11) from §5.3:
+Two things survive the correction:
 
-| Formula | Capacity/merchant |
-|---|---|
-| doc: `2200 × (1 + 0.2 × 11)` | **7,040** |
-| stock Teuton: `1000 × (1 + 0.1 × 11)` | **2,100** |
+**The measured model is pinned by a single data point.** Any `base × (1 + 13k) = 7920` fits it — `2200/0.20` is the natural reading and matches the profile's own empirical history, but a second village at a *different* Trade Office level would nail it. `calibrate()` exists for that, and the constant is `EUROPE2_TEUTON` rather than a hardcoded literal so a Trade artifact or server change can be re-derived rather than hunted down.
 
-A 3.35× overstatement. Every route sized against it needs ~3× the budgeted merchants — precisely known-issue #6.
-
-The correction history in issue #4 (`1000 → 1600 → 2200`) is itself the tell. Under the Teuton +10% rule those are exactly `TO 0 → TO 6 → TO 12` on a base of 1000. That is the signature of **sampling different villages and mistaking a Trade Office bonus for the base** — after which the formula applies the same bonus a second time.
-
-Other multipliers that could legitimately produce a non-stock number, and which are **not** constants:
-
-- **Trade artifacts** multiply merchant capacity, can be lost or captured, and some are account-wide while others are single-village.
-- Server speed multiplies capacity, but Europe 2 is x1.
-
-**Decisive test — zero requests.** Open the Marketplace in two villages with *different* TO levels and read the capacity the game states. Two observations solve `cap = base × (1 + k × TO)` for both unknowns:
-
-```
-k    = (cap_b − cap_a) / (cap_a × b − cap_b × a)     # a, b = the two TO levels
-base = cap_a / (1 + k × a)
-```
-
-Pick a TO-0 village for one sample and `base = cap` directly. **Nothing downstream should be built until this is pinned**, and the resolved values belong in a test fixture, not a config default.
+**§5.3's Trade Office table is stale.** It lists V16 at TO 0 and V05 at TO 11; both are actually **TO 13**. Every merchant figure in that table is therefore wrong independently of the formula, and it is exactly the drift the §5.3 staleness nag is designed to catch — the hand-maintained field had already diverged before the tool existed.
 
 ## R2 — §3.3's "single request" for net production is optimistic
 
@@ -489,9 +470,9 @@ The diff, not the plan: **Create / Edit / Delete** against the currently configu
 
 ## Immediate next actions
 
-| # | Action | Cost | Unblocks |
-|---|---|---|---|
-| 1 | Read merchant capacity in two villages with different TO | 0 requests | **R1 — everything** |
-| 2 | Capture Resources + Capacity + one *filling* village `dorf1` together | 0 requests | R2 filling branch |
-| 3 | One-off `dorf2` sweep for TO + Marketplace | N requests | §1 OWNED state |
-| 4 | Create one trade route and observe its phase and any per-village cap | in-game | R6, open question #1 |
+| # | Action | Cost | Unblocks | Status |
+|---|---|---|---|---|
+| 1 | Read merchant capacity at two *different* TO levels | 0 requests | pins the measured model exactly | partial — 7,920 @ TO 13 |
+| 2 | Capture Resources + Capacity + one *filling* village `dorf1` together | 0 requests | R2 filling branch | open |
+| 3 | One-off `dorf2` sweep for TO + Marketplace | N requests | §1 OWNED state, and refreshes the stale §5.3 levels | open |
+| 4 | Create one trade route and observe its phase and any per-village cap | in-game | R6, open question #1 | open |

--- a/farm-list-creation/plan-final.md
+++ b/farm-list-creation/plan-final.md
@@ -16,7 +16,7 @@ go/no-go execution spec.
 
 ## Locked parameters
 - Server: `https://ts2.x1.europe.travian.com` (env `TRAVIAN_SERVER` if set, else literal).
-- User: env `TRAVIAN_USERNAME` (= REDACTED@example.com). Password: env `TRAVIAN_PASSWORD` (REQUIRED).
+- User: env `TRAVIAN_USERNAME` (REQUIRED). Password: env `TRAVIAN_PASSWORD` (REQUIRED). Both come from the environment; neither is recorded here.
 - Sender village: **V3**, located by coords (23,88) in `auth_state.villages`; name cross-checked == "V3".
 - Tribe sanity: tribe_id == 2 (Teutons). Log-only.
 - Troops: raid lists → `{t1:2, t2..t10:0}`; HighRisk lists → `units=None` (all-zero). `active=False`. `force=False`.

--- a/farm-list-creation/plan-v1.md
+++ b/farm-list-creation/plan-v1.md
@@ -47,7 +47,7 @@ TravianSession(user_id=99001, server_url=SERVER, username=USER, password=PWD)
 
 - `SERVER` = `https://ts2.x1.europe.travian.com` (mission + JSON meta), read from
   `TRAVIAN_SERVER` env if present, else this literal.
-- `USER` = `TRAVIAN_USERNAME` env (= REDACTED@example.com).
+- `USER` = `TRAVIAN_USERNAME` env (read from the environment, never hardcoded).
 - `PWD`  = `TRAVIAN_PASSWORD` env. **Required.** If missing → stop cleanly (see §7).
 - After connect, `session.auth_state.villages` is populated. **Find V3** by
   matching coords (23,88) — and cross-check name == "V3". Call

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -7,7 +7,13 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 export default defineConfig([
   globalIgnores(['dist']),
   {
+    // Config/tooling files run in Node, not the browser.
+    files: ['*.config.{js,mjs}'],
+    languageOptions: { globals: globals.node },
+  },
+  {
     files: ['**/*.{js,jsx}'],
+    ignores: ['*.config.{js,mjs}'],
     extends: [
       js.configs.recommended,
       reactHooks.configs.flat.recommended,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ const Sessions = lazy(() => import('./pages/Sessions'))
 const OasisRaider = lazy(() => import('./pages/OasisRaider'))
 const FarmBuilder = lazy(() => import('./pages/FarmBuilder'))
 const RaidOptimizer = lazy(() => import('./pages/RaidOptimizer'))
+const ResourcePlanner = lazy(() => import('./pages/ResourcePlanner'))
 
 export const TabContext = createContext(null)
 
@@ -91,6 +92,7 @@ export default function App() {
               <Route path="/scout" element={<GuardedPage><AutoScout /></GuardedPage>} />
               <Route path="/oasis-raider" element={<GuardedPage><OasisRaider /></GuardedPage>} />
               <Route path="/raid-optimizer" element={<GuardedPage><RaidOptimizer /></GuardedPage>} />
+              <Route path="/resource-planner" element={<GuardedPage><ResourcePlanner /></GuardedPage>} />
               <Route path="/queue" element={<GuardedPage><BuildQueue /></GuardedPage>} />
               <Route path="/logs" element={<GuardedPage><Logs /></GuardedPage>} />
               <Route path="/sessions" element={<GuardedPage><Sessions /></GuardedPage>} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,11 +25,46 @@ const ResourcePlanner = lazy(() => import('./pages/ResourcePlanner'))
 
 export const TabContext = createContext(null)
 
-function LoadingScreen() {
+function LoadingScreen({ retryAttempt = 0, retryLimit = 0 }) {
+  // A bare spinner cannot distinguish "starting up" from "the backend is down".
+  // Once a retry is in flight, say so and show which attempt this is.
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-base gap-4">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-base gap-4 p-6 text-center">
       <span className="logo-text-lg">Travian Auto Player</span>
       <div className="spinner spinner-lg" />
+      {retryAttempt > 0 && (
+        <div className="max-w-sm">
+          <p className="text-warning text-sm font-semibold">Server unavailable — restoring session</p>
+          <p className="text-secondary text-xs mt-1">
+            Retrying (attempt {retryAttempt} of {retryLimit}) · next try in ~5s. Your saved sign-in
+            is kept.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AuthOutageScreen({ onRetry }) {
+  // Automatic retries were exhausted while the stored token was KEPT: this is an
+  // outage, not a credential rejection, so do not present the ordinary login
+  // screen as if the sign-in were invalid.
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-base gap-4 p-6 text-center">
+      <span className="logo-text-lg">Travian Auto Player</span>
+      <div className="max-w-sm">
+        <p className="text-warning text-sm font-semibold">⚠ Cannot reach the server</p>
+        <p className="text-secondary text-xs mt-1">
+          Your session could not be verified because the backend did not respond. Your saved
+          sign-in has NOT been cleared — retry once the server is back.
+        </p>
+      </div>
+      <button className="btn-primary btn-sm" onClick={onRetry}>
+        Retry
+      </button>
+      <a className="text-secondary text-xs underline" href="/login">
+        Sign in with a different account
+      </a>
     </div>
   )
 }
@@ -56,6 +91,10 @@ export default function App() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   const initialCheckDone = useAuthStore((s) => s.initialCheckDone)
   const checkAuth = useAuthStore((s) => s.checkAuth)
+  const authRetryAttempt = useAuthStore((s) => s.authRetryAttempt)
+  const authRetryLimit = useAuthStore((s) => s.authRetryLimit)
+  const authOutage = useAuthStore((s) => s.authOutage)
+  const retryAuth = useAuthStore((s) => s.retryAuth)
   const tabId = useMemo(() => {
     try { return crypto.randomUUID() } catch { return Math.random().toString(36).slice(2) + Date.now().toString(36) }
   }, [])
@@ -67,7 +106,17 @@ export default function App() {
   if (!initialCheckDone) {
     return (
       <TabContext.Provider value={tabId}>
-        <LoadingScreen />
+        <LoadingScreen retryAttempt={authRetryAttempt} retryLimit={authRetryLimit} />
+      </TabContext.Provider>
+    )
+  }
+
+  // Outage (retries exhausted, token kept) — explain it and offer Retry rather
+  // than routing to /login, which would read as "your credentials were wrong".
+  if (authOutage && !isAuthenticated) {
+    return (
+      <TabContext.Provider value={tabId}>
+        <AuthOutageScreen onRetry={retryAuth} />
       </TabContext.Provider>
     )
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,7 +45,7 @@ function LoadingScreen({ retryAttempt = 0, retryLimit = 0 }) {
   )
 }
 
-function AuthOutageScreen({ onRetry }) {
+function AuthOutageScreen({ onRetry, onSignInAsOther }) {
   // Automatic retries were exhausted while the stored token was KEPT: this is an
   // outage, not a credential rejection, so do not present the ordinary login
   // screen as if the sign-in were invalid.
@@ -62,9 +62,14 @@ function AuthOutageScreen({ onRetry }) {
       <button className="btn-primary btn-sm" onClick={onRetry}>
         Retry
       </button>
-      <a className="text-secondary text-xs underline" href="/login">
-        Sign in with a different account
-      </a>
+      {/* Must CLEAR the session, not navigate: this screen renders ahead of the
+          router, so an <a href="/login"> would full-reload, find the token still
+          in storage, fail its retries again and land right back here — an
+          inescapable loop when /users/me is persistently broken. logout() drops
+          the token and the outage flag, so the login route can actually render. */}
+      <button className="text-secondary text-xs underline bg-transparent border-0 cursor-pointer" onClick={onSignInAsOther}>
+        Sign out and sign in with a different account
+      </button>
     </div>
   )
 }
@@ -95,6 +100,7 @@ export default function App() {
   const authRetryLimit = useAuthStore((s) => s.authRetryLimit)
   const authOutage = useAuthStore((s) => s.authOutage)
   const retryAuth = useAuthStore((s) => s.retryAuth)
+  const logout = useAuthStore((s) => s.logout)
   const tabId = useMemo(() => {
     try { return crypto.randomUUID() } catch { return Math.random().toString(36).slice(2) + Date.now().toString(36) }
   }, [])
@@ -116,7 +122,7 @@ export default function App() {
   if (authOutage && !isAuthenticated) {
     return (
       <TabContext.Provider value={tabId}>
-        <AuthOutageScreen onRetry={retryAuth} />
+        <AuthOutageScreen onRetry={retryAuth} onSignInAsOther={logout} />
       </TabContext.Provider>
     )
   }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -20,14 +20,22 @@ function logSource(url) {
   return 'api'
 }
 
-const SENSITIVE_URLS = ['/users/login', '/users/register', '/travian/connect', '/travian/servers']
 const SENSITIVE_KEYS = ['password', 'access_token', 'token', 'jwt']
 
+// Every body is redacted, not just an allowlist of URLs: the allowlist missed
+// /recon/credentials and logged a plaintext password into the log store,
+// where the Logs page displays and exports it. Recursive, because FastAPI
+// validation errors echo the submitted body back inside nested `input`
+// objects — a 422 on a credentials endpoint would otherwise re-leak the
+// password through the error path.
 function redactSensitive(data) {
+  if (Array.isArray(data)) return data.map(redactSensitive)
   if (!data || typeof data !== 'object') return data
-  const copy = { ...data }
-  for (const key of SENSITIVE_KEYS) {
-    if (key in copy) copy[key] = '[REDACTED]'
+  const copy = {}
+  for (const [key, value] of Object.entries(data)) {
+    copy[key] = SENSITIVE_KEYS.includes(key.toLowerCase())
+      ? '[REDACTED]'
+      : redactSensitive(value)
   }
   return copy
 }
@@ -48,10 +56,7 @@ api.interceptors.request.use((config) => {
   }
   const method = (config.method || 'get').toUpperCase()
   const url = config.url || ''
-  const isSensitive = SENSITIVE_URLS.some(s => url.includes(s))
-  const body = config.data
-    ? summarizeData(isSensitive ? redactSensitive(config.data) : config.data, 500)
-    : null
+  const body = config.data ? summarizeData(redactSensitive(config.data), 500) : null
   useLogStore.getState().addLog('info', logSource(url), `>> ${method} ${url}`, body)
   return config
 })
@@ -63,8 +68,7 @@ api.interceptors.response.use(
     const method = (response.config.method || 'get').toUpperCase()
     const url = response.config.url || ''
     const status = response.status
-    const isSensitive = SENSITIVE_URLS.some(s => url.includes(s))
-    const data = isSensitive ? redactSensitive(response.data) : response.data
+    const data = redactSensitive(response.data)
 
     // Build detail summary
     let detail = null
@@ -83,7 +87,7 @@ api.interceptors.response.use(
     const method = (error.config?.method || 'get').toUpperCase()
     const status = error.response?.status
     const detail = error.response?.data
-      ? summarizeData(error.response.data, 500)
+      ? summarizeData(redactSensitive(error.response.data), 500)
       : error.message
     useLogStore.getState().addLog('error', logSource(url), `<< ${method} ${url} ${status || 'ERR'}`, detail)
 

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -19,6 +19,7 @@ const navItems = [
   { to: '/scout', label: 'Auto Scout', icon: '🔭' },
   { to: '/oasis-raider', label: 'Oasis Raider', icon: '🏕' },
   { to: '/raid-optimizer', label: 'Raid Optimizer', icon: '🧮' },
+  { to: '/resource-planner', label: 'Resource Planner', icon: '⚖️' },
   { to: '/queue', label: 'Build Queue', icon: '📋' },
   { to: '/logs', label: 'Activity Log', icon: '📊' },
   { to: '/sessions', label: 'Sessions', icon: '📡' },

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -4,6 +4,7 @@ import useAuthStore from '../stores/authStore'
 import useGameStore from '../stores/gameStore'
 import useLogStore from '../stores/logStore'
 import { connectLogStream, disconnectLogStream } from '../logStream'
+import { useToast } from './Toast'
 import MobileNav from './MobileNav'
 import VillageSelector from './VillageSelector'
 // ToastContainer is mounted in App.jsx (global, works for all routes)
@@ -38,6 +39,7 @@ export default function Layout() {
   const playerName = useGameStore((s) => s.playerName)
   const checkStatus = useGameStore((s) => s.checkStatus)
   const disconnect = useGameStore((s) => s.disconnect)
+  const toast = useToast()
 
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
@@ -92,7 +94,14 @@ export default function Layout() {
   }
 
   const handleDisconnect = async () => {
-    await disconnect()
+    try {
+      await disconnect()
+    } catch (err) {
+      // Typically a 409: operations are still running and the backend kept
+      // the session alive. Navigating to /connect would lie about the state.
+      toast.error(err.response?.data?.detail || 'Disconnect failed — still connected')
+      return
+    }
     navigate('/connect', { replace: true })
   }
 

--- a/frontend/src/components/MobileNav.jsx
+++ b/frontend/src/components/MobileNav.jsx
@@ -22,6 +22,7 @@ const moreTabs = [
   { to: '/oasis-raider', label: 'Oasis Raider', icon: '🏕' },
   { to: '/farm-builder', label: 'Farm Builder', icon: '🔨' },
   { to: '/raid-optimizer', label: 'Raid Optimizer', icon: '🧮' },
+  { to: '/resource-planner', label: 'Planner', icon: '⚖️' },
   { to: '/logs', label: 'Logs', icon: '📊' },
   { to: '/sessions', label: 'Sessions', icon: '📡' },
 ]

--- a/frontend/src/components/ResourceBar.jsx
+++ b/frontend/src/components/ResourceBar.jsx
@@ -56,10 +56,14 @@ export default function ResourceBar({ resources }) {
       {resourceConfig.map((cfg) => (
         <SingleBar key={cfg.key} config={cfg} resources={resources} />
       ))}
-      {resources.free_crop != null && (
-        <div className={`mt-2 pt-2 border-t-default text-xs flex items-center gap-1 ${resources.free_crop > 0 ? 'text-success' : 'text-danger'}`}>
+      {/* crop_per_hour (production.l4) is the true net rate. free_crop (l5) was
+          used here and is not net — it reads positive on a starving village, so
+          this bar showed green while the granary drained. */}
+      {resources.crop_per_hour != null && (
+        <div className={`mt-2 pt-2 border-t-default text-xs flex items-center gap-1 ${resources.crop_per_hour >= 0 ? 'text-success' : 'text-danger'}`}>
           <span>🌿</span>
-          <span>Free Crop: {formatNumber(resources.free_crop)}</span>
+          <span>Net Crop: {formatNumber(resources.crop_per_hour)}/h</span>
+          {resources.crop_per_hour < 0 && <span>— starving</span>}
         </div>
       )}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -327,41 +327,56 @@ h1, h2, h3 {
 .text-warning { color: var(--warning); }
 .text-info { color: var(--info); }
 
-/* Theme-aware status borders. Needed because Tailwind opacity modifiers
+/* Theme-aware status border. Needed because Tailwind opacity modifiers
    (e.g. `border-warning/40`) only apply to Tailwind-generated utilities, not to
    the semantic classes above — a bare `border-warning` would render colorless. */
 .border-warning { border-color: var(--warning); }
-.border-danger { border-color: var(--danger); }
 
 /* ── Wide-table mobile ergonomics ──
    A dense editor table (village × mode/value/ship/rest) cannot fit a 390px
    viewport. Rather than clip it, the row's identity column is pinned while the
    rest scrolls horizontally, so an edited field is always attributable to the
    right village. Opaque background + z-index so scrolled cells pass underneath,
-   not through. */
-.sticky-col {
-  position: sticky;
-  left: 0;
-  z-index: 2;
-  background-color: var(--bg-card);
-  /* Hairline separator marks where the pinned column ends and the scrolling
-     region begins — the visual cue that more columns exist off to the right. */
-  box-shadow: 1px 0 0 var(--border);
-}
-thead .sticky-col { z-index: 3; }
+   not through.
 
-/* Comfortable touch targets on coarse pointers (WCAG 2.5.5 / 44px), without
-   inflating the desktop layout. */
+   Deliberately scoped to narrow viewports: at desktop widths the table does not
+   overflow, so pinning there would only add a permanent hairline and — because
+   the opaque background must win over the row tint — drop the identity cell out
+   of the hover/selected highlight used to confirm batch-apply targets. */
+@media (max-width: 640px) {
+  .sticky-col {
+    position: sticky;
+    left: 0;
+    z-index: 2;
+    background-color: var(--bg-card);
+    /* Hairline separator marks where the pinned column ends and the scrolling
+       region begins — the cue that more columns exist off to the right. */
+    box-shadow: 1px 0 0 var(--border);
+  }
+  thead .sticky-col { z-index: 3; }
+}
+
+/* Touch targets on coarse pointers, without inflating the desktop layout.
+   Text/select controls get the 44px comfortable size (WCAG 2.5.5); the per-row
+   checkbox/radio get 24px — the WCAG 2.5.8 (AA) minimum — plus roomy cell
+   padding for the surrounding hit area, because a 44px-wide native checkbox on
+   every row eats ~13% of a 390px viewport. `min-height` is set on the controls
+   themselves, not on .touch-target, since the class sits on a <tr> and
+   min-height does not apply to table rows. */
 @media (pointer: coarse) {
-  .touch-target,
-  .touch-target input[type="checkbox"],
   .touch-target select,
   .touch-target input[type="number"],
   .touch-target input[type="text"] {
     min-height: 44px;
   }
-  .touch-target input[type="checkbox"] {
-    min-width: 44px;
+  .touch-target input[type="checkbox"],
+  .touch-target input[type="radio"] {
+    width: 24px;
+    height: 24px;
+  }
+  .touch-target > td {
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -327,6 +327,44 @@ h1, h2, h3 {
 .text-warning { color: var(--warning); }
 .text-info { color: var(--info); }
 
+/* Theme-aware status borders. Needed because Tailwind opacity modifiers
+   (e.g. `border-warning/40`) only apply to Tailwind-generated utilities, not to
+   the semantic classes above — a bare `border-warning` would render colorless. */
+.border-warning { border-color: var(--warning); }
+.border-danger { border-color: var(--danger); }
+
+/* ── Wide-table mobile ergonomics ──
+   A dense editor table (village × mode/value/ship/rest) cannot fit a 390px
+   viewport. Rather than clip it, the row's identity column is pinned while the
+   rest scrolls horizontally, so an edited field is always attributable to the
+   right village. Opaque background + z-index so scrolled cells pass underneath,
+   not through. */
+.sticky-col {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background-color: var(--bg-card);
+  /* Hairline separator marks where the pinned column ends and the scrolling
+     region begins — the visual cue that more columns exist off to the right. */
+  box-shadow: 1px 0 0 var(--border);
+}
+thead .sticky-col { z-index: 3; }
+
+/* Comfortable touch targets on coarse pointers (WCAG 2.5.5 / 44px), without
+   inflating the desktop layout. */
+@media (pointer: coarse) {
+  .touch-target,
+  .touch-target input[type="checkbox"],
+  .touch-target select,
+  .touch-target input[type="number"],
+  .touch-target input[type="text"] {
+    min-height: 44px;
+  }
+  .touch-target input[type="checkbox"] {
+    min-width: 44px;
+  }
+}
+
 .bg-base { background-color: var(--bg-base); }
 .bg-surface { background-color: var(--bg-surface); }
 .bg-card { background-color: var(--bg-card); }

--- a/frontend/src/pages/AutoScout.jsx
+++ b/frontend/src/pages/AutoScout.jsx
@@ -90,6 +90,9 @@ function BackgroundAccountPanel({ disabled }) {
   }
 
   const locked = disabled || busy
+  // The recon account is shared, process-global state; only the instance
+  // operator may see its username or manage it, so hide controls that would 403.
+  const manageable = status?.manageable !== false
 
   return (
     <div className="ml-6 mt-2 p-3 rounded border border-gray-700 bg-black/20 max-w-xl">
@@ -97,7 +100,7 @@ function BackgroundAccountPanel({ disabled }) {
         <span className="text-secondary">Background account:</span>
         {status?.configured ? (
           <>
-            <span className="font-mono">{status.username}</span>
+            <span className="font-mono">{status.username ?? 'configured'}</span>
             <span className="text-secondary">
               ({status.source === 'stored' ? 'saved here' : 'from .env'})
             </span>
@@ -106,20 +109,26 @@ function BackgroundAccountPanel({ disabled }) {
           <span className="text-amber-400">not configured</span>
         )}
         <span className="flex-1" />
-        <button className="btn-secondary btn-sm" onClick={() => setEditing(!editing)} disabled={locked}>
-          {status?.configured ? 'Change' : 'Set'}
-        </button>
-        <button className="btn-secondary btn-sm" onClick={test} disabled={locked || !status?.configured}>
-          Test
-        </button>
-        {status?.source === 'stored' && (
-          <button className="btn-secondary btn-sm" onClick={clear} disabled={locked}>
-            Clear
-          </button>
+        {manageable ? (
+          <>
+            <button className="btn-secondary btn-sm" onClick={() => setEditing(!editing)} disabled={locked}>
+              {status?.configured ? 'Change' : 'Set'}
+            </button>
+            <button className="btn-secondary btn-sm" onClick={test} disabled={locked || !status?.configured}>
+              Test
+            </button>
+            {status?.source === 'stored' && (
+              <button className="btn-secondary btn-sm" onClick={clear} disabled={locked}>
+                Clear
+              </button>
+            )}
+          </>
+        ) : (
+          <span className="text-secondary">managed by the instance operator</span>
         )}
       </div>
 
-      {editing && (
+      {editing && manageable && (
         <div className="mt-3 flex flex-col gap-2">
           <input
             className="input-field text-xs"

--- a/frontend/src/pages/AutoScout.jsx
+++ b/frontend/src/pages/AutoScout.jsx
@@ -27,6 +27,9 @@ function loadJson(key, fallback) {
 // restarting. Saving here applies to the running server immediately.
 function BackgroundAccountPanel({ disabled }) {
   const toast = useToast()
+  // The recon account exists on one world; saving records which, so it is
+  // never used to mask reads on a different server.
+  const serverUrl = useGameStore((s) => s.serverUrl)
   const [status, setStatus] = useState(null)
   const [editing, setEditing] = useState(false)
   const [username, setUsername] = useState('')
@@ -51,7 +54,11 @@ function BackgroundAccountPanel({ disabled }) {
     }
     setBusy(true)
     try {
-      const res = await api.put('/recon/credentials', { username: username.trim(), password })
+      const res = await api.put('/recon/credentials', {
+        username: username.trim(),
+        password,
+        server_url: serverUrl ?? undefined,
+      })
       setStatus(res.data)
       setPassword('')
       setEditing(false)

--- a/frontend/src/pages/BuildQueue.jsx
+++ b/frontend/src/pages/BuildQueue.jsx
@@ -389,6 +389,15 @@ export default function BuildQueue() {
   const [localVillageId, setLocalVillageId] = useState(null)
   const villageId = localVillageId || globalActiveVillageId
 
+  // Drop a local selection that does not belong to the connected account:
+  // after reconnecting to a different world the old id could collide with a
+  // different village or not exist, targeting the wrong village in-game.
+  useEffect(() => {
+    if (localVillageId && !villages.some((v) => v.id === localVillageId)) {
+      setLocalVillageId(null)
+    }
+  }, [villages, localVillageId])
+
   // Local building/queue state (fetched per-village, not from global store)
   const [buildings, setBuildings] = useState([])
   const [buildingsLoading, setBuildingsLoading] = useState(false)
@@ -480,6 +489,7 @@ export default function BuildQueue() {
   // Validate
   const handleValidate = async () => {
     if (queueItems.length === 0) { toast.warning('Queue is empty'); return }
+    if (!villageId) { toast.error('Select a village first'); return }
     try {
       const res = await api.post('/queue/validate', { yaml_content: generatedYaml })
       setValidationResult(res.data)
@@ -541,6 +551,7 @@ export default function BuildQueue() {
 
   // Execute
   const startExecution = useCallback(() => {
+    if (!villageId) { toast.error('Select a village first'); return }
     setShowConfirm(false)
     timersRef.current.forEach(({ type, id }) => type === 'interval' ? clearInterval(id) : clearTimeout(id))
     timersRef.current = []
@@ -558,7 +569,7 @@ export default function BuildQueue() {
       use_video: useVideo,
       verbose,
     })
-  }, [generatedYaml, pollInterval, useVideo, verbose, queueItems.length, queueOp, addMessage])
+  }, [villageId, generatedYaml, pollInterval, useVideo, verbose, queueItems.length, queueOp, addMessage, toast])
 
   const handleStop = () => {
     queueOp.stop()

--- a/frontend/src/pages/BuildQueue.jsx
+++ b/frontend/src/pages/BuildQueue.jsx
@@ -389,14 +389,21 @@ export default function BuildQueue() {
   const [localVillageId, setLocalVillageId] = useState(null)
   const villageId = localVillageId || globalActiveVillageId
 
-  // Drop a local selection that does not belong to the connected account:
-  // after reconnecting to a different world the old id could collide with a
-  // different village or not exist, targeting the wrong village in-game.
+  // Reset the tab-local selection whenever the connected ACCOUNT changes, not
+  // just when the id is absent: a different world can hold the same numeric
+  // village id, so keeping it would silently target a colliding village.
+  const serverUrl = useGameStore((s) => s.serverUrl)
+  const playerName = useGameStore((s) => s.playerName)
+  const accountKey = serverUrl && playerName ? `${serverUrl}|${playerName}` : null
+  const accountKeyRef = useRef(accountKey)
   useEffect(() => {
-    if (localVillageId && !villages.some((v) => v.id === localVillageId)) {
+    if (accountKeyRef.current !== accountKey) {
+      accountKeyRef.current = accountKey
+      setLocalVillageId(null)
+    } else if (localVillageId && !villages.some((v) => v.id === localVillageId)) {
       setLocalVillageId(null)
     }
-  }, [villages, localVillageId])
+  }, [accountKey, villages, localVillageId])
 
   // Local building/queue state (fetched per-village, not from global store)
   const [buildings, setBuildings] = useState([])

--- a/frontend/src/pages/BuildQueue.jsx
+++ b/frontend/src/pages/BuildQueue.jsx
@@ -451,7 +451,10 @@ export default function BuildQueue() {
     }
   }, [])
 
-  useEffect(() => { fetchLocalData(villageId) }, [villageId, fetchLocalData])
+  // Re-fetch on account change too: a different world can share the numeric
+  // village id, so villageId alone would leave the old account's buildings
+  // and queue on screen.
+  useEffect(() => { fetchLocalData(villageId) }, [villageId, accountKey, fetchLocalData])
 
   const handleVillageSwitch = (id) => {
     setLocalVillageId(id)

--- a/frontend/src/pages/BuildQueue.jsx
+++ b/frontend/src/pages/BuildQueue.jsx
@@ -429,15 +429,22 @@ export default function BuildQueue() {
   const [validationResult, setValidationResult] = useState(null)
   const [showConfirm, setShowConfirm] = useState(false)
 
+  // Only the latest fetch may commit: a slower response from the previous
+  // village/account must not overwrite the current one after a switch.
+  const fetchTokenRef = useRef('')
+
   // Fetch buildings + queue for the selected village (no global switch)
   const fetchLocalData = useCallback(async (vid) => {
     if (!vid) return
+    const token = `${vid}::${accountKeyRef.current}`
+    fetchTokenRef.current = token
     setBuildingsLoading(true)
     try {
       const [bRes, qRes] = await Promise.all([
         api.get(`/buildings?village_id=${vid}`),
         api.get(`/buildings/queue?village_id=${vid}`),
       ])
+      if (fetchTokenRef.current !== token) return
       const arr = Array.isArray(bRes.data) ? bRes.data
         : Array.isArray(bRes.data?.buildings) ? bRes.data.buildings : []
       setBuildings(arr)

--- a/frontend/src/pages/Buildings.jsx
+++ b/frontend/src/pages/Buildings.jsx
@@ -238,6 +238,19 @@ function formatMarkdown(data) {
       lines.push('### Troops', '', '*No troops at rally point*', '')
     }
 
+    // Crop balance first — a starving village is the most actionable fact here.
+    // `crop.net_per_hour` comes from production.l4, the only true net rate.
+    const crop = v.crop
+    if (crop?.starving) {
+      lines.push(
+        `> ⚠️ **STARVING** — net crop ${crop.net_per_hour.toLocaleString()}/h` +
+          (crop.hours_until_empty != null
+            ? `, granary empty in ${crop.hours_until_empty}h`
+            : ''),
+        '',
+      )
+    }
+
     // Production
     const r = v.resources || {}
     lines.push(
@@ -248,7 +261,7 @@ function formatMarkdown(data) {
       `| Lumber | ${(r.lumber_per_hour || 0).toLocaleString()} |`,
       `| Clay | ${(r.clay_per_hour || 0).toLocaleString()} |`,
       `| Iron | ${(r.iron_per_hour || 0).toLocaleString()} |`,
-      `| Crop | ${(r.crop_per_hour || 0).toLocaleString()} |`,
+      `| Crop (net of feeding) | ${(r.crop_per_hour || 0).toLocaleString()} |`,
       '',
     )
 

--- a/frontend/src/pages/Buildings.jsx
+++ b/frontend/src/pages/Buildings.jsx
@@ -323,7 +323,11 @@ export default function Buildings() {
     fetchingSlotRef.current = slotId
     setDetailLoading(true)
     try {
-      const res = await api.get(`/buildings/${slotId}`)
+      // The backend's session default is forever the login village (switching
+      // is client-side only), so the selected village must travel explicitly.
+      const res = await api.get(`/buildings/${slotId}`, {
+        params: activeVillageId != null ? { village_id: activeVillageId } : {},
+      })
       if (fetchingSlotRef.current === slotId) {
         setDetail(res.data)
       }
@@ -337,7 +341,7 @@ export default function Buildings() {
         setDetailLoading(false)
       }
     }
-  }, [toast])
+  }, [toast, activeVillageId])
 
   const handleSlotClick = (slotId) => {
     if (selectedSlot === slotId) {
@@ -369,12 +373,14 @@ export default function Buildings() {
         await api.post('/buildings/upgrade', {
           slot_id: pendingAction.slotId,
           allow_gold: false,
+          village_id: activeVillageId ?? undefined,
         })
         toast.success('Upgrade started!')
       } else if (pendingAction.type === 'construct') {
         await api.post('/buildings/construct', {
           slot_id: pendingAction.slotId,
           building_name: pendingAction.buildingName,
+          village_id: activeVillageId ?? undefined,
         })
         toast.success('Construction started!')
       }

--- a/frontend/src/pages/Buildings.jsx
+++ b/frontend/src/pages/Buildings.jsx
@@ -320,7 +320,11 @@ export default function Buildings() {
   }, [fetchBuildings, fetchQueue, activeVillageId])
 
   const fetchDetail = useCallback(async (slotId) => {
-    fetchingSlotRef.current = slotId
+    // Key the in-flight request by slot AND village: the same slot id exists in
+    // every village, so a slower response from the previous village must not
+    // repopulate the sidebar after a switch.
+    const token = `${slotId}::${activeVillageId ?? ''}`
+    fetchingSlotRef.current = token
     setDetailLoading(true)
     try {
       // The backend's session default is forever the login village (switching
@@ -328,16 +332,16 @@ export default function Buildings() {
       const res = await api.get(`/buildings/${slotId}`, {
         params: activeVillageId != null ? { village_id: activeVillageId } : {},
       })
-      if (fetchingSlotRef.current === slotId) {
+      if (fetchingSlotRef.current === token) {
         setDetail(res.data)
       }
     } catch {
-      if (fetchingSlotRef.current === slotId) {
+      if (fetchingSlotRef.current === token) {
         toast.error('Failed to load building details')
         setDetail(null)
       }
     } finally {
-      if (fetchingSlotRef.current === slotId) {
+      if (fetchingSlotRef.current === token) {
         setDetailLoading(false)
       }
     }

--- a/frontend/src/pages/Military.jsx
+++ b/frontend/src/pages/Military.jsx
@@ -10,6 +10,7 @@ export default function Military() {
   const toast = useToast()
   const tribeId = useGameStore((s) => s.tribeId)
   const connected = useGameStore((s) => s.connected)
+  const activeVillageId = useGameStore((s) => s.activeVillageId)
 
   // Scout state
   const [scoutX, setScoutX] = useState('')
@@ -84,6 +85,9 @@ export default function Military() {
         y: parseInt(scoutY, 10),
         amount: parseInt(scoutAmount, 10) || 1,
         type: scoutType,
+        // The backend default is forever the login village (switching is
+        // client-side only), so the selected village must travel explicitly.
+        village_id: activeVillageId ?? undefined,
       })
       setScoutResult({ success: true, data: res.data })
       toast.success('Scouts sent successfully!')
@@ -129,6 +133,7 @@ export default function Military() {
         x: parseInt(raidX, 10),
         y: parseInt(raidY, 10),
         troops,
+        village_id: activeVillageId ?? undefined,
       })
       setRaidResult({ success: true, data: res.data })
       toast.success('Raid sent successfully!')

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -143,6 +143,9 @@ function ReportDetail({ detail, loading }) {
 
 function RaidTargetAnalyzer() {
   const toast = useToast()
+  // The backend session default is forever the login village (switching is
+  // client-side only), so this tab's selection must travel explicitly.
+  const activeVillageId = useGameStore((s) => s.activeVillageId)
   const [collapsed, setCollapsed] = useState(true)
   const [minResources, setMinResources] = useState(200)
   const [analyzerMaxAge, setAnalyzerMaxAge] = useState(24)
@@ -184,6 +187,7 @@ function RaidTargetAnalyzer() {
 
     ws.onopen = () => {
       ws.send(JSON.stringify({
+        village_id: activeVillageId ?? undefined,
         min_resources: minResources,
         max_report_age_hours: analyzerMaxAge,
         max_pages: analyzerMaxPages,

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -796,7 +796,7 @@ export default function ResourcePlanner() {
                       <span className={settled ? 'text-success' : 'text-danger'}>
                         {fmt(slack)}/h unassigned
                         {remainder != null
-                          ? ` → village ${remainder}`
+                          ? ` → ${villages.find((v) => v.village_id === remainder)?.name ?? `village ${remainder}`}`
                           : ' · no remainder village set'}
                       </span>
                     </div>
@@ -1017,7 +1017,10 @@ export default function ResourcePlanner() {
                   <ul className="text-xs list-disc list-inside space-y-0.5">
                     {plan.shortfalls.map((s, i) => (
                       <li key={i}>
-                        {RESOURCE_LABEL[s.resource]} · village {s.village_id} short{' '}
+                        {RESOURCE_LABEL[s.resource]} ·{' '}
+                        {villages.find((v) => v.village_id === s.village_id)?.name ??
+                          `village ${s.village_id}`}{' '}
+                        short{' '}
                         {fmt(s.per_hour)}/h — {s.reason}
                       </li>
                     ))}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -9,9 +9,39 @@ import api from '../api'
 // snapshot the client sends, so rehydrating another account's villages would
 // generate a route sheet from the wrong account's data.
 const LS_TRADE_OFFICE = 'planner_trade_office'
-const LS_ALLOCATIONS = 'planner_allocations'
+const LS_ALLOCATIONS = 'planner_allocations' // legacy single-plan key (migrated)
 const LS_SNAPSHOT = 'planner_snapshot'
 const LS_MERCHANT = 'planner_merchant_model'
+// Named allocation profiles (e.g. Day / Night). Trade Office and the merchant
+// model stay account-wide — only the allocations differ per profile, so
+// switching a profile is free: it re-plans from the same snapshot with no
+// extra Travian request.
+const LS_PROFILES = 'planner_profiles'
+const LS_ACTIVE_PROFILE = 'planner_active_profile'
+const DEFAULT_PROFILE = 'Day'
+const EMPTY_ALLOC = Object.freeze({}) // stable reference for a profile with no entries
+
+// Drop allocation entries for villages no longer in the snapshot; a stale id
+// would 400 every plan call. Applied to every profile on fetch.
+function pruneAllocations(alloc, ids) {
+  const pruned = {}
+  for (const [resource, per] of Object.entries(alloc ?? {})) {
+    const kept = Object.fromEntries(
+      Object.entries(per).filter(([vid]) => ids.has(Number(vid)))
+    )
+    if (Object.keys(kept).length) pruned[resource] = kept
+  }
+  return pruned
+}
+
+// Load persisted profiles, migrating a legacy single-plan account into a
+// "Day" profile so no existing work is lost.
+function loadProfiles(accountKey) {
+  const stored = loadJson(`${LS_PROFILES}::${accountKey}`, null)
+  if (stored && typeof stored === 'object' && Object.keys(stored).length) return stored
+  const legacy = loadJson(`${LS_ALLOCATIONS}::${accountKey}`, null)
+  return { [DEFAULT_PROFILE]: legacy && typeof legacy === 'object' ? legacy : {} }
+}
 
 // Merchant capacity is server-calibrated (Europe 2 is not a stock server — see
 // docs/25), so it cannot be derived from tribe and defaults to the operator's
@@ -120,8 +150,23 @@ export default function ResourcePlanner() {
   const [stage, setStage] = useState('snapshot')
   const [snapshot, setSnapshot] = useState(null)
   const [tradeOffice, setTradeOffice] = useState({})
-  const [allocations, setAllocations] = useState({})
+  const [profiles, setProfiles] = useState({ [DEFAULT_PROFILE]: {} })
+  const [activeProfile, setActiveProfile] = useState(DEFAULT_PROFILE)
   const [merchantModel, setMerchantModel] = useState(DEFAULT_MERCHANT_MODEL)
+
+  // The active profile's allocations, exposed with the same shape the rest of
+  // the component already uses, so the Allocate grid and plan build unchanged.
+  const allocations = profiles[activeProfile] ?? EMPTY_ALLOC
+  const setAllocations = useCallback(
+    (updater) => {
+      setProfiles((prev) => {
+        const current = prev[activeProfile] ?? {}
+        const next = typeof updater === 'function' ? updater(current) : updater
+        return { ...prev, [activeProfile]: next }
+      })
+    },
+    [activeProfile]
+  )
   // Persisting is enabled only after this account's stored state has been
   // loaded, so the initial defaults can never overwrite it.
   const [hydratedKey, setHydratedKey] = useState(null)
@@ -148,15 +193,19 @@ export default function ResourcePlanner() {
       // the previous account's villages would act on stale data.
       setSnapshot(null)
       setTradeOffice({})
-      setAllocations({})
+      setProfiles({ [DEFAULT_PROFILE]: {} })
+      setActiveProfile(DEFAULT_PROFILE)
       setMerchantModel(DEFAULT_MERCHANT_MODEL)
       setPlan(null)
       setHydratedKey(null)
       return
     }
+    const loaded = loadProfiles(accountKey)
+    const storedActive = loadJson(`${LS_ACTIVE_PROFILE}::${accountKey}`, DEFAULT_PROFILE)
     setSnapshot(loadJson(`${LS_SNAPSHOT}::${accountKey}`, null))
     setTradeOffice(loadJson(`${LS_TRADE_OFFICE}::${accountKey}`, {}))
-    setAllocations(loadJson(`${LS_ALLOCATIONS}::${accountKey}`, {}))
+    setProfiles(loaded)
+    setActiveProfile(loaded[storedActive] ? storedActive : Object.keys(loaded)[0])
     setMerchantModel(loadJson(`${LS_MERCHANT}::${accountKey}`, DEFAULT_MERCHANT_MODEL))
     setPlan(null)
     setHydratedKey(accountKey)
@@ -166,8 +215,12 @@ export default function ResourcePlanner() {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_TRADE_OFFICE), tradeOffice)
   }, [tradeOffice, hydratedKey, accountKey, storageKey])
   useEffect(() => {
-    if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_ALLOCATIONS), allocations)
-  }, [allocations, hydratedKey, accountKey, storageKey])
+    if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_PROFILES), profiles)
+  }, [profiles, hydratedKey, accountKey, storageKey])
+  useEffect(() => {
+    if (hydratedKey && hydratedKey === accountKey)
+      saveJson(storageKey(LS_ACTIVE_PROFILE), activeProfile)
+  }, [activeProfile, hydratedKey, accountKey, storageKey])
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_MERCHANT), merchantModel)
   }, [merchantModel, hydratedKey, accountKey, storageKey])
@@ -190,17 +243,13 @@ export default function ResourcePlanner() {
       setPlan(null)
       // Villages get lost, chiefed or renamed between fetches; allocations kept
       // for ids no longer in the snapshot would fail every future plan call.
+      // Prune every profile, not just the active one.
       const ids = new Set(res.data.villages.map((v) => v.village_id))
-      setAllocations((prev) => {
-        const pruned = {}
-        for (const [resource, per] of Object.entries(prev)) {
-          const kept = Object.fromEntries(
-            Object.entries(per).filter(([vid]) => ids.has(Number(vid)))
-          )
-          if (Object.keys(kept).length) pruned[resource] = kept
-        }
-        return pruned
-      })
+      setProfiles((prev) =>
+        Object.fromEntries(
+          Object.entries(prev).map(([name, alloc]) => [name, pruneAllocations(alloc, ids)])
+        )
+      )
       const fresh = res.data.villages.filter((v) => tradeOffice[v.village_id] == null)
       toast.success(
         `Read ${res.data.villages.length} villages in ${res.data.requests_used} requests` +
@@ -328,6 +377,75 @@ export default function ResourcePlanner() {
     return total - assigned
   }
 
+  // ── Profile management ─────────────────────────────────────────────
+  // A built plan belongs to the profile it was built from, so switching or
+  // editing the set clears it.
+  const profileNames = Object.keys(profiles)
+
+  const switchProfile = (name) => {
+    if (!profiles[name] || name === activeProfile) return
+    setActiveProfile(name)
+    setPlan(null)
+  }
+
+  const addProfile = () => {
+    const name = (window.prompt('New profile name', 'Night') || '').trim()
+    if (!name) return
+    if (profiles[name]) {
+      toast.error(`Profile "${name}" already exists`)
+      return
+    }
+    setProfiles((prev) => ({ ...prev, [name]: {} }))
+    setActiveProfile(name)
+    setPlan(null)
+  }
+
+  const duplicateProfile = () => {
+    const name = (window.prompt(`Duplicate "${activeProfile}" as`, `${activeProfile} copy`) || '').trim()
+    if (!name) return
+    if (profiles[name]) {
+      toast.error(`Profile "${name}" already exists`)
+      return
+    }
+    setProfiles((prev) => ({
+      ...prev,
+      [name]: JSON.parse(JSON.stringify(prev[activeProfile] ?? {})),
+    }))
+    setActiveProfile(name)
+    setPlan(null)
+  }
+
+  const renameProfile = () => {
+    const name = (window.prompt('Rename profile', activeProfile) || '').trim()
+    if (!name || name === activeProfile) return
+    if (profiles[name]) {
+      toast.error(`Profile "${name}" already exists`)
+      return
+    }
+    setProfiles((prev) => {
+      const next = {}
+      for (const [k, v] of Object.entries(prev)) next[k === activeProfile ? name : k] = v
+      return next
+    })
+    setActiveProfile(name)
+  }
+
+  const deleteProfile = () => {
+    if (profileNames.length <= 1) {
+      toast.error('Keep at least one profile')
+      return
+    }
+    if (!window.confirm(`Delete profile "${activeProfile}"?`)) return
+    const fallback = profileNames.find((n) => n !== activeProfile)
+    setProfiles((prev) => {
+      const next = { ...prev }
+      delete next[activeProfile]
+      return next
+    })
+    setActiveProfile(fallback)
+    setPlan(null)
+  }
+
   const stages = [
     { id: 'snapshot', label: 'Snapshot' },
     { id: 'allocate', label: 'Allocate' },
@@ -351,6 +469,44 @@ export default function ResourcePlanner() {
             {planning ? 'Planning…' : 'Build plan (0 requests)'}
           </button>
         </div>
+      </div>
+
+      {/* Named allocation profiles (e.g. Day / Night). Only the allocations
+          differ per profile; the snapshot and merchant model are shared, so
+          switching re-plans from the same data with no extra request. */}
+      <div className="flex items-center gap-2 mb-3 text-xs flex-wrap">
+        <span className="text-secondary uppercase">Plan profile</span>
+        <select
+          aria-label="Allocation profile"
+          className="input-field text-xs py-1"
+          value={activeProfile}
+          onChange={(e) => switchProfile(e.target.value)}
+        >
+          {profileNames.map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+        <button className="btn-secondary btn-xs" onClick={addProfile}>
+          + New
+        </button>
+        <button className="btn-secondary btn-xs" onClick={duplicateProfile}>
+          Duplicate
+        </button>
+        <button className="btn-secondary btn-xs" onClick={renameProfile}>
+          Rename
+        </button>
+        <button
+          className="btn-secondary btn-xs"
+          onClick={deleteProfile}
+          disabled={profileNames.length <= 1}
+        >
+          Delete
+        </button>
+        <span className="text-secondary">
+          each profile builds its own routes — switching is free (no request)
+        </span>
       </div>
 
       <nav className="flex gap-1 mb-4 border-b border-gray-700" aria-label="Planner stages">
@@ -678,7 +834,9 @@ export default function ResourcePlanner() {
               </div>
 
               <div className="card p-4 overflow-x-auto">
-                <h3 className="font-semibold mb-2">Setup sheet</h3>
+                <h3 className="font-semibold mb-2">
+                  Setup sheet <span className="text-secondary">· {activeProfile}</span>
+                </h3>
                 <table className="w-full text-xs">
                   <thead className="text-secondary uppercase">
                     <tr>

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -501,8 +501,11 @@ export default function ResourcePlanner() {
   const targetFor = (resource, v) => {
     const own = v[`${resource}_per_hour`]
     const a = allocations[resource]?.[v.village_id] ?? { mode: 'keep', value: 0 }
+    // Unreadable rate: the backend drops this village's allocation entirely
+    // (with a warning) rather than plan blind, so showing any target here --
+    // even an absolute one -- would promise something the plan will not do.
+    if (own == null && a.mode !== 'remainder') return null
     if (a.mode === 'remainder') return explicitTotal(resource)
-    if (own == null) return a.mode === 'absolute' ? Number(a.value) || 0 : null
     if (a.mode === 'absolute') return Number(a.value) || 0
     if (a.mode === 'percentage') return (totals[resource].total * (Number(a.value) || 0)) / 100
     if (a.mode === 'sustain') return own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
@@ -1082,6 +1085,11 @@ export default function ResourcePlanner() {
                         const isRest = remainderFor(resource) === v.village_id
                         return (
                           <td key={resource} className="text-right px-3 py-1.5 align-top">
+                            {/* A sign change is the story worth telling:
+                                -2,500/h own plus +4,000/h shipped IS +1,500/h,
+                                and a starving village turning surplus (or the
+                                reverse) must read as that transition, not as a
+                                bare final number. */}
                             <div
                               className={`font-mono ${
                                 after == null
@@ -1092,7 +1100,23 @@ export default function ResourcePlanner() {
                               }`}
                               title={own == null ? 'own production unknown' : `own ${fmt(own)}/h`}
                             >
-                              {after == null ? '?' : `${fmt(after)}/h`}
+                              {after == null ? (
+                                '?'
+                              ) : own != null && own < 0 !== after < 0 && Math.abs(ship) >= 1 ? (
+                                <>
+                                  <span className={own < 0 ? 'text-danger' : ''}>{fmt(own)}</span>
+                                  <span
+                                    className={
+                                      after >= 0 ? 'text-success mx-0.5' : 'text-danger mx-0.5'
+                                    }
+                                  >
+                                    {'\u2192'}
+                                  </span>
+                                  {`${fmt(after)}/h`}
+                                </>
+                              ) : (
+                                `${fmt(after)}/h`
+                              )}
                               {isRest && (
                                 <span className="ml-1 text-[10px] uppercase text-amber-300/80 font-sans">
                                   rest
@@ -1131,9 +1155,10 @@ export default function ResourcePlanner() {
                 </tfoot>
               </table>
               <p className="text-secondary text-[11px] mt-2">
-                Top line: retention after distribution (red = still negative). Bottom line: what
-                ships in (+) or out (−) to make it true. “rest” absorbs whatever the others leave
-                unassigned.
+                Top line: retention after distribution (red = still negative; a green arrow
+                marks a village whose crop crosses from starving to surplus — e.g. −2,500/h own
+                +4,000/h shipped → 1,500/h). Bottom line: what ships in (+) or out (−) to make it
+                true. “rest” absorbs whatever the others leave unassigned.
               </p>
             </div>
           )}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -1,9 +1,13 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useToast } from '../components/Toast'
+import useGameStore from '../stores/gameStore'
 import api from '../api'
 
 // Owned state the game will not tell us, kept per village. Trade Office level
 // changes only when the operator builds one, so it is stored rather than fetched.
+// Keys are namespaced per (server, player): the plan endpoint trusts the
+// snapshot the client sends, so rehydrating another account's villages would
+// generate a route sheet from the wrong account's data.
 const LS_TRADE_OFFICE = 'planner_trade_office'
 const LS_ALLOCATIONS = 'planner_allocations'
 const LS_SNAPSHOT = 'planner_snapshot'
@@ -26,6 +30,7 @@ function loadJson(key, fallback) {
 }
 
 function saveJson(key, value) {
+  if (!key) return // not connected yet — nothing to namespace the state under
   try {
     localStorage.setItem(key, JSON.stringify(value))
   } catch {
@@ -102,16 +107,40 @@ function BudgetBar({ budget }) {
 
 export default function ResourcePlanner() {
   const toast = useToast()
+  const serverUrl = useGameStore((s) => s.serverUrl)
+  const playerName = useGameStore((s) => s.playerName)
+  const accountKey = serverUrl && playerName ? `${serverUrl}|${playerName}` : null
   const [stage, setStage] = useState('snapshot')
-  const [snapshot, setSnapshot] = useState(() => loadJson(LS_SNAPSHOT, null))
-  const [tradeOffice, setTradeOffice] = useState(() => loadJson(LS_TRADE_OFFICE, {}))
-  const [allocations, setAllocations] = useState(() => loadJson(LS_ALLOCATIONS, {}))
+  const [snapshot, setSnapshot] = useState(null)
+  const [tradeOffice, setTradeOffice] = useState({})
+  const [allocations, setAllocations] = useState({})
+  // Persisting is enabled only after this account's stored state has been
+  // loaded, so the initial defaults can never overwrite it.
+  const [hydratedKey, setHydratedKey] = useState(null)
   const [plan, setPlan] = useState(null)
   const [fetching, setFetching] = useState(false)
   const [planning, setPlanning] = useState(false)
 
-  useEffect(() => saveJson(LS_TRADE_OFFICE, tradeOffice), [tradeOffice])
-  useEffect(() => saveJson(LS_ALLOCATIONS, allocations), [allocations])
+  const storageKey = useCallback(
+    (base) => (accountKey ? `${base}::${accountKey}` : null),
+    [accountKey]
+  )
+
+  useEffect(() => {
+    if (!accountKey) return
+    setSnapshot(loadJson(`${LS_SNAPSHOT}::${accountKey}`, null))
+    setTradeOffice(loadJson(`${LS_TRADE_OFFICE}::${accountKey}`, {}))
+    setAllocations(loadJson(`${LS_ALLOCATIONS}::${accountKey}`, {}))
+    setPlan(null)
+    setHydratedKey(accountKey)
+  }, [accountKey])
+
+  useEffect(() => {
+    if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_TRADE_OFFICE), tradeOffice)
+  }, [tradeOffice, hydratedKey, accountKey, storageKey])
+  useEffect(() => {
+    if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_ALLOCATIONS), allocations)
+  }, [allocations, hydratedKey, accountKey, storageKey])
 
   // Memoised so it does not become a fresh array on every render, which would
   // re-run the plan callback and the totals memo for no reason.
@@ -122,7 +151,7 @@ export default function ResourcePlanner() {
     try {
       const res = await api.get('/distribution/snapshot', { timeout: 0 })
       setSnapshot(res.data)
-      saveJson(LS_SNAPSHOT, res.data)
+      saveJson(storageKey(LS_SNAPSHOT), res.data)
       setPlan(null)
       // Villages get lost, chiefed or renamed between fetches; allocations kept
       // for ids no longer in the snapshot would fail every future plan call.

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -11,6 +11,13 @@ import api from '../api'
 const LS_TRADE_OFFICE = 'planner_trade_office'
 const LS_ALLOCATIONS = 'planner_allocations'
 const LS_SNAPSHOT = 'planner_snapshot'
+const LS_MERCHANT = 'planner_merchant_model'
+
+// Merchant capacity is server-calibrated (Europe 2 is not a stock server — see
+// docs/25), so it cannot be derived from tribe and defaults to the operator's
+// calibrated Europe 2 Teuton values. Travel SPEED, by contrast, is tribe-derived
+// server-side and travels in the snapshot.
+const DEFAULT_MERCHANT_MODEL = { base_capacity: 2200, bonus_per_to_level: 0.2 }
 
 const RESOURCES = ['lumber', 'clay', 'iron', 'crop']
 const RESOURCE_LABEL = { lumber: 'Lumber', clay: 'Clay', iron: 'Iron', crop: 'Crop' }
@@ -114,6 +121,7 @@ export default function ResourcePlanner() {
   const [snapshot, setSnapshot] = useState(null)
   const [tradeOffice, setTradeOffice] = useState({})
   const [allocations, setAllocations] = useState({})
+  const [merchantModel, setMerchantModel] = useState(DEFAULT_MERCHANT_MODEL)
   // Persisting is enabled only after this account's stored state has been
   // loaded, so the initial defaults can never overwrite it.
   const [hydratedKey, setHydratedKey] = useState(null)
@@ -141,6 +149,7 @@ export default function ResourcePlanner() {
       setSnapshot(null)
       setTradeOffice({})
       setAllocations({})
+      setMerchantModel(DEFAULT_MERCHANT_MODEL)
       setPlan(null)
       setHydratedKey(null)
       return
@@ -148,6 +157,7 @@ export default function ResourcePlanner() {
     setSnapshot(loadJson(`${LS_SNAPSHOT}::${accountKey}`, null))
     setTradeOffice(loadJson(`${LS_TRADE_OFFICE}::${accountKey}`, {}))
     setAllocations(loadJson(`${LS_ALLOCATIONS}::${accountKey}`, {}))
+    setMerchantModel(loadJson(`${LS_MERCHANT}::${accountKey}`, DEFAULT_MERCHANT_MODEL))
     setPlan(null)
     setHydratedKey(accountKey)
   }, [accountKey])
@@ -158,6 +168,9 @@ export default function ResourcePlanner() {
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_ALLOCATIONS), allocations)
   }, [allocations, hydratedKey, accountKey, storageKey])
+  useEffect(() => {
+    if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_MERCHANT), merchantModel)
+  }, [merchantModel, hydratedKey, accountKey, storageKey])
 
   // Memoised so it does not become a fresh array on every render, which would
   // re-run the plan callback and the totals memo for no reason.
@@ -231,6 +244,12 @@ export default function ResourcePlanner() {
           trade_office_level: Number(tradeOffice[v.village_id] ?? 0),
         })),
         allocations: sendAllocations,
+        // Geometry comes from the snapshot (map span + tribe-derived merchant
+        // speed); the merchant capacity model is the operator's calibration.
+        map_span: snapshot?.map_span,
+        speed_fields_per_hour: snapshot?.speed_fields_per_hour,
+        merchant_base_capacity: Number(merchantModel.base_capacity) || undefined,
+        trade_office_bonus_per_level: Number(merchantModel.bonus_per_to_level) || undefined,
       })
       if (requestedFor !== currentAccountKey()) return
       setPlan(res.data)
@@ -240,7 +259,7 @@ export default function ResourcePlanner() {
     } finally {
       setPlanning(false)
     }
-  }, [villages, tradeOffice, allocations, toast, accountKey, currentAccountKey])
+  }, [villages, tradeOffice, allocations, toast, accountKey, currentAccountKey, snapshot, merchantModel])
 
   // Live unallocated counter, so slack is visible while typing rather than
   // discovered later (profile known issue #9).
@@ -422,6 +441,46 @@ export default function ResourcePlanner() {
               ))}
             </ul>
           )}
+
+          {/* Merchant model: speed is tribe-derived server-side (shown, not
+              editable); capacity is server-calibrated, so the operator sets it. */}
+          <div className="mt-4 flex items-center gap-4 flex-wrap text-xs border-t border-gray-800 pt-3">
+            <span className="text-secondary uppercase">Merchant model</span>
+            <span className="text-secondary">
+              Speed:{' '}
+              <span className="font-mono text-white">
+                {snapshot?.speed_fields_per_hour ?? '—'}
+              </span>{' '}
+              fields/h (from tribe)
+            </span>
+            <label className="flex items-center gap-1">
+              <span className="text-secondary">Base capacity</span>
+              <input
+                type="number"
+                min="1"
+                aria-label="Merchant base capacity"
+                className="input-field w-24 text-right py-1"
+                value={merchantModel.base_capacity}
+                onChange={(e) =>
+                  setMerchantModel((m) => ({ ...m, base_capacity: Number(e.target.value) }))
+                }
+              />
+            </label>
+            <label className="flex items-center gap-1">
+              <span className="text-secondary">Bonus / TO level</span>
+              <input
+                type="number"
+                min="0"
+                step="0.05"
+                aria-label="Trade Office bonus per level"
+                className="input-field w-20 text-right py-1"
+                value={merchantModel.bonus_per_to_level}
+                onChange={(e) =>
+                  setMerchantModel((m) => ({ ...m, bonus_per_to_level: Number(e.target.value) }))
+                }
+              />
+            </label>
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -33,6 +33,18 @@ function saveJson(key, value) {
   }
 }
 
+/** FastAPI puts validation failures in `detail` as an ARRAY of error objects;
+ *  rendering that raw crashes React. Reduce whatever came back to a string. */
+function errorDetail(err, fallback) {
+  const detail = err.response?.data?.detail
+  if (typeof detail === 'string') return detail
+  if (Array.isArray(detail)) {
+    const msgs = detail.map((d) => d?.msg).filter(Boolean)
+    if (msgs.length) return msgs.join(' · ')
+  }
+  return fallback
+}
+
 const fmt = (n) => (n == null ? '—' : Math.round(n).toLocaleString())
 const signed = (n) => (n == null ? '—' : `${n > 0 ? '+' : ''}${Math.round(n).toLocaleString()}`)
 
@@ -112,13 +124,26 @@ export default function ResourcePlanner() {
       setSnapshot(res.data)
       saveJson(LS_SNAPSHOT, res.data)
       setPlan(null)
+      // Villages get lost, chiefed or renamed between fetches; allocations kept
+      // for ids no longer in the snapshot would fail every future plan call.
+      const ids = new Set(res.data.villages.map((v) => v.village_id))
+      setAllocations((prev) => {
+        const pruned = {}
+        for (const [resource, per] of Object.entries(prev)) {
+          const kept = Object.fromEntries(
+            Object.entries(per).filter(([vid]) => ids.has(Number(vid)))
+          )
+          if (Object.keys(kept).length) pruned[resource] = kept
+        }
+        return pruned
+      })
       const fresh = res.data.villages.filter((v) => tradeOffice[v.village_id] == null)
       toast.success(
         `Read ${res.data.villages.length} villages in ${res.data.requests_used} requests` +
           (fresh.length ? ` · ${fresh.length} need a Trade Office level` : '')
       )
     } catch (err) {
-      toast.error(err.response?.data?.detail || 'Could not read account state')
+      toast.error(errorDetail(err, 'Could not read account state'))
     } finally {
       setFetching(false)
     }
@@ -131,18 +156,32 @@ export default function ResourcePlanner() {
     }
     setPlanning(true)
     try {
+      // Send only entries the planner can act on: `keep` equals the backend
+      // default, and a village whose rate is unknown for this resource is not
+      // plannable — a stale or inert entry must not fail the whole plan.
+      const sendAllocations = {}
+      for (const [resource, per] of Object.entries(allocations)) {
+        const usable = {}
+        for (const [vid, a] of Object.entries(per)) {
+          if (a.mode === 'keep') continue
+          const v = villages.find((x) => x.village_id === Number(vid))
+          if (!v || v[`${resource}_per_hour`] == null) continue
+          usable[vid] = a
+        }
+        if (Object.keys(usable).length) sendAllocations[resource] = usable
+      }
       const res = await api.post('/distribution/plan', {
         snapshot: villages,
         config: villages.map((v) => ({
           village_id: v.village_id,
           trade_office_level: Number(tradeOffice[v.village_id] ?? 0),
         })),
-        allocations,
+        allocations: sendAllocations,
       })
       setPlan(res.data)
       setStage('plan')
     } catch (err) {
-      toast.error(err.response?.data?.detail || 'Could not build a plan')
+      toast.error(errorDetail(err, 'Could not build a plan'))
     } finally {
       setPlanning(false)
     }
@@ -199,14 +238,16 @@ export default function ResourcePlanner() {
     const { total } = totals[resource]
     let assigned = 0
     for (const v of villages) {
-      const a = per[v.village_id]
-      if (!a || a.mode === 'remainder') continue
+      // A village with no entry keeps its own production — the same default the
+      // backend resolves — so an untouched account shows 0 unassigned, not the
+      // whole account total.
+      const a = per[v.village_id] ?? { mode: 'keep', value: 0 }
+      if (a.mode === 'remainder') continue
+      const own = v[`${resource}_per_hour`] ?? 0
       if (a.mode === 'absolute') assigned += Number(a.value) || 0
       else if (a.mode === 'percentage') assigned += (total * (Number(a.value) || 0)) / 100
-      else if (a.mode === 'sustain') {
-        const own = v[`${resource}_per_hour`] ?? 0
-        assigned += own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
-      } else assigned += v[`${resource}_per_hour`] ?? 0
+      else if (a.mode === 'sustain') assigned += own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
+      else assigned += own
     }
     return total - assigned
   }
@@ -228,7 +269,7 @@ export default function ResourcePlanner() {
           {/* Every fetch is priced in the label — requests are the scarce
               resource, so the cost is stated before it is spent. */}
           <button className="btn-primary btn-sm" onClick={fetchSnapshot} disabled={fetching}>
-            {fetching ? 'Reading…' : 'Fetch state (4 requests)'}
+            {fetching ? 'Reading…' : 'Fetch state (3–4 requests)'}
           </button>
           <button className="btn-secondary btn-sm" onClick={buildPlan} disabled={planning}>
             {planning ? 'Planning…' : 'Build plan (0 requests)'}
@@ -257,8 +298,9 @@ export default function ResourcePlanner() {
         <div className="card p-6 text-center text-secondary">
           <p>No account state yet.</p>
           <p className="text-xs mt-1">
-            Fetching reads production, stocks and granary countdowns for every village in four
-            requests — net crop included, so army villages are not mistaken for healthy ones.
+            Fetching reads production, stocks and granary countdowns for every village in three
+            to four requests — net crop included, so army villages are not mistaken for healthy
+            ones.
           </p>
         </div>
       )}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -1216,11 +1216,16 @@ export default function ResourcePlanner() {
                     {plan.rows.map((row, i) => (
                       <tr key={i} className="border-t border-gray-800">
                         <td className="py-1 px-2">
-                          {villages.find((v) => v.village_id === row.origin)?.name ?? row.origin}
+                          {/* Server-resolved names: the snapshot cannot know
+                              foreign tributes, whose negative ids rendered as
+                              "-1" here before the plan carried names itself. */}
+                          {row.origin_name ||
+                            (villages.find((v) => v.village_id === row.origin)?.name ?? row.origin)}
                         </td>
                         <td className="px-2">
-                          {villages.find((v) => v.village_id === row.destination)?.name ??
-                            row.destination}
+                          {row.destination_name ||
+                            (villages.find((v) => v.village_id === row.destination)?.name ??
+                              row.destination)}
                         </td>
                         <td className="px-2 font-mono">
                           {Object.entries(row.cargo)
@@ -1248,8 +1253,9 @@ export default function ResourcePlanner() {
                     {plan.shortfalls.map((s, i) => (
                       <li key={i}>
                         {RESOURCE_LABEL[s.resource]} ·{' '}
-                        {villages.find((v) => v.village_id === s.village_id)?.name ??
-                          `village ${s.village_id}`}{' '}
+                        {s.village_name ||
+                          (villages.find((v) => v.village_id === s.village_id)?.name ??
+                            `village ${s.village_id}`)}{' '}
                         short{' '}
                         {fmt(s.per_hour)}/h — {s.reason}
                       </li>

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -198,6 +198,10 @@ export default function ResourcePlanner() {
   const [profiles, setProfiles] = useState({ [DEFAULT_PROFILE]: {} })
   const [activeProfile, setActiveProfile] = useState(DEFAULT_PROFILE)
   const [merchantModel, setMerchantModel] = useState(DEFAULT_MERCHANT_MODEL)
+  // Per-resource checkbox selection for batch edits: { [resource]: number[] }.
+  // Transient (not persisted); reset on account change and on a fresh snapshot
+  // so it never targets villages from a previous account/snapshot.
+  const [selected, setSelected] = useState({})
 
   // The active profile's allocations, exposed with the same shape the rest of
   // the component already uses, so the Allocate grid and plan build unchanged.
@@ -243,6 +247,7 @@ export default function ResourcePlanner() {
       setProfiles({ [DEFAULT_PROFILE]: {} })
       setActiveProfile(DEFAULT_PROFILE)
       setMerchantModel(DEFAULT_MERCHANT_MODEL)
+      setSelected({})
       setPlan(null)
       setHydratedKey(null)
       return
@@ -254,6 +259,7 @@ export default function ResourcePlanner() {
     setProfiles(loaded)
     setActiveProfile(loaded[storedActive] ? storedActive : Object.keys(loaded)[0])
     setMerchantModel(loadJson(`${LS_MERCHANT}::${accountKey}`, DEFAULT_MERCHANT_MODEL))
+    setSelected({})
     setPlan(null)
     setHydratedKey(accountKey)
   }, [accountKey])
@@ -288,6 +294,8 @@ export default function ResourcePlanner() {
       setSnapshot(res.data)
       saveJson(`${LS_SNAPSHOT}::${requestedFor}`, res.data)
       setPlan(null)
+      // A new snapshot can have different village ids — drop stale selections.
+      setSelected({})
       // Villages get lost, chiefed or renamed between fetches; allocations kept
       // for ids no longer in the snapshot would fail every future plan call.
       // Prune every profile, not just the active one.
@@ -397,8 +405,6 @@ export default function ResourcePlanner() {
     })
   }
 
-  // Per-resource checkbox selection for batch edits: { [resource]: number[] }.
-  const [selected, setSelected] = useState({})
   const isSelected = (resource, vid) => (selected[resource] ?? []).includes(vid)
   const someSelected = (resource) => (selected[resource] ?? []).length > 0
   const allSelected = (resource) =>

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -9,6 +9,7 @@ import api from '../api'
 // snapshot the client sends, so rehydrating another account's villages would
 // generate a route sheet from the wrong account's data.
 const LS_TRADE_OFFICE = 'planner_trade_office'
+const LS_FOREIGN = 'planner_foreign_targets'
 const LS_ALLOCATIONS = 'planner_allocations' // legacy single-plan key (migrated)
 const LS_SNAPSHOT = 'planner_snapshot'
 const LS_MERCHANT = 'planner_merchant_model'
@@ -115,28 +116,83 @@ function CropCell({ village }) {
 function BudgetBar({ budget }) {
   const spare = Math.max(budget.spare, 1)
   const usedPct = Math.min(100, Math.round((budget.committed / spare) * 100))
+  // Over-budget villages open by default. "over by 2" says what happened but
+  // not what to do about it, and the same excess means different things when
+  // the trip is the cost than when the Trade Office is.
+  const [open, setOpen] = useState(false)
+  const legs = budget.legs ?? []
   return (
-    <div className="flex items-center gap-2">
-      <div
-        className="h-2 w-28 rounded bg-black/40 overflow-hidden"
-        role="img"
-        aria-label={`${budget.committed} of ${budget.spare} merchants committed`}
-      >
+    <div className="flex-1">
+      <div className="flex items-center gap-2">
         <div
-          className={`h-full ${budget.over_budget ? 'bg-red-500' : 'bg-emerald-500'}`}
-          style={{ width: `${usedPct}%` }}
-        />
-      </div>
-      <span className="font-mono text-xs">
-        {budget.committed}/{budget.spare}
-      </span>
-      {budget.over_budget && (
-        <span className="text-danger text-xs">
-          over by {budget.committed - budget.spare}
-          {budget.trade_office_levels_needed != null
-            ? ` · Trade Office +${budget.trade_office_levels_needed} would fit`
-            : ' · no upgrade fixes this'}
+          className="h-2 w-28 rounded bg-black/40 overflow-hidden shrink-0"
+          role="img"
+          aria-label={`${budget.committed} of ${budget.spare} merchants committed`}
+        >
+          <div
+            className={`h-full ${budget.over_budget ? 'bg-red-500' : 'bg-emerald-500'}`}
+            style={{ width: `${usedPct}%` }}
+          />
+        </div>
+        <span className="font-mono text-xs shrink-0">
+          {budget.committed}/{budget.spare}
         </span>
+        {budget.over_budget && (
+          <span className="text-danger text-xs">
+            over by {budget.committed - budget.spare}
+            {budget.trade_office_levels_needed != null
+              ? ` · Trade Office +${budget.trade_office_levels_needed} would fit`
+              : ' · no upgrade fixes this'}
+          </span>
+        )}
+        {legs.length > 0 && (
+          <button
+            type="button"
+            className="text-secondary hover:text-white text-xs underline shrink-0"
+            aria-expanded={open}
+            onClick={() => setOpen((v) => !v)}
+          >
+            {open ? 'hide' : budget.over_budget ? 'why?' : 'routes'}
+          </button>
+        )}
+      </div>
+
+      {open && (
+        <div className="mt-1 mb-2 ml-2 pl-3 border-l border-gray-700">
+          {budget.explanation && (
+            <p className="text-xs text-amber-200 mb-1">{budget.explanation}</p>
+          )}
+          <table className="text-xs w-full max-w-2xl">
+            <thead className="text-secondary uppercase">
+              <tr>
+                <th className="text-left pr-3 font-normal">To</th>
+                <th className="text-right pr-3 font-normal">Cargo/h</th>
+                <th className="text-right pr-3 font-normal">Distance</th>
+                <th className="text-right pr-3 font-normal">One way</th>
+                <th className="text-right pr-3 font-normal">Cycle</th>
+                <th className="text-right font-normal">Merchants</th>
+              </tr>
+            </thead>
+            <tbody className="font-mono">
+              {legs.map((leg, i) => (
+                <tr key={i}>
+                  <td className="pr-3">{leg.destination}</td>
+                  <td className="text-right pr-3">{fmt(leg.per_hour)}</td>
+                  <td className="text-right pr-3">{Math.round(leg.distance_fields)}f</td>
+                  <td className="text-right pr-3">{leg.one_way_hours.toFixed(1)}h</td>
+                  <td className="text-right pr-3">{leg.cycle_hours}h</td>
+                  <td className="text-right">
+                    {leg.merchants_per_send}×{leg.sets_in_flight} = {leg.merchants}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="text-secondary text-xs mt-1">
+            A merchant is busy for the whole round trip, so a long haul keeps several sends in
+            the air at once — that multiplier, not just the cargo, is what spends merchants.
+          </p>
+        </div>
       )}
     </div>
   )
@@ -198,6 +254,10 @@ export default function ResourcePlanner() {
   const [profiles, setProfiles] = useState({ [DEFAULT_PROFILE]: {} })
   const [activeProfile, setActiveProfile] = useState(DEFAULT_PROFILE)
   const [merchantModel, setMerchantModel] = useState(DEFAULT_MERCHANT_MODEL)
+  // Villages outside the account that are owed crop. Hand-entered, because
+  // nothing in the game tells us about them, and cached per account like the
+  // Trade Office levels are.
+  const [foreignTargets, setForeignTargets] = useState([])
   // Per-resource checkbox selection for batch edits: { [resource]: number[] }.
   // Transient (not persisted); reset on account change and on a fresh snapshot
   // so it never targets villages from a previous account/snapshot.
@@ -245,6 +305,7 @@ export default function ResourcePlanner() {
       setSnapshot(null)
       setTradeOffice({})
       setProfiles({ [DEFAULT_PROFILE]: {} })
+      setForeignTargets([])
       setActiveProfile(DEFAULT_PROFILE)
       setMerchantModel(DEFAULT_MERCHANT_MODEL)
       setSelected({})
@@ -256,6 +317,7 @@ export default function ResourcePlanner() {
     const storedActive = loadJson(`${LS_ACTIVE_PROFILE}::${accountKey}`, DEFAULT_PROFILE)
     setSnapshot(loadJson(`${LS_SNAPSHOT}::${accountKey}`, null))
     setTradeOffice(loadJson(`${LS_TRADE_OFFICE}::${accountKey}`, {}))
+    setForeignTargets(loadJson(`${LS_FOREIGN}::${accountKey}`, []))
     setProfiles(loaded)
     setActiveProfile(loaded[storedActive] ? storedActive : Object.keys(loaded)[0])
     setMerchantModel(loadJson(`${LS_MERCHANT}::${accountKey}`, DEFAULT_MERCHANT_MODEL))
@@ -267,6 +329,9 @@ export default function ResourcePlanner() {
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_TRADE_OFFICE), tradeOffice)
   }, [tradeOffice, hydratedKey, accountKey, storageKey])
+  useEffect(() => {
+    if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_FOREIGN), foreignTargets)
+  }, [foreignTargets, hydratedKey, accountKey, storageKey])
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_PROFILES), profiles)
   }, [profiles, hydratedKey, accountKey, storageKey])
@@ -348,6 +413,17 @@ export default function ResourcePlanner() {
           trade_office_level: Number(tradeOffice[v.village_id] ?? 0),
         })),
         allocations: sendAllocations,
+        // Only complete rows go to the planner: a half-typed target would
+        // 422 the whole plan, and the operator is mid-edit, not in error.
+        foreign_targets: foreignTargets
+          .filter((t) => t.name.trim() && Number(t.crop_per_hour) > 0)
+          .map((t) => ({
+            name: t.name.trim(),
+            x: Number(t.x) || 0,
+            y: Number(t.y) || 0,
+            crop_per_hour: Number(t.crop_per_hour),
+            safety_margin_pct: Number(t.safety_margin_pct) || 0,
+          })),
         // Geometry defaults to the snapshot (map span + tribe-derived x1
         // merchant speed) but the operator can override both for non-Europe 2
         // worlds (x2/x3 speed, larger maps) — no extra Travian requests.
@@ -369,7 +445,17 @@ export default function ResourcePlanner() {
     } finally {
       setPlanning(false)
     }
-  }, [villages, tradeOffice, allocations, toast, accountKey, currentAccountKey, snapshot, merchantModel])
+  }, [
+    villages,
+    tradeOffice,
+    allocations,
+    toast,
+    accountKey,
+    currentAccountKey,
+    snapshot,
+    merchantModel,
+    foreignTargets,
+  ])
 
   // Live unallocated counter, so slack is visible while typing rather than
   // discovered later (profile known issue #9).
@@ -770,6 +856,150 @@ export default function ResourcePlanner() {
               />
             </label>
           </div>
+
+          {/* Villages outside the account that are owed crop. Kept in their own
+              section rather than as rows in the village table: a tribute is not
+              a village, and giving it a village row invites treating it as one.
+              Saved as you type, like every other field here. */}
+          <div className="mt-4 border-t border-gray-800 pt-3">
+            <div className="flex items-center justify-between flex-wrap gap-2 mb-2">
+              <div>
+                <span className="text-secondary text-xs uppercase">Crop owed to other players</span>
+                <p className="text-secondary text-xs mt-0.5">
+                  Shipped like any other demand and taken out of the account crop pool. The
+                  planner picks the supplier, and prefers a single one.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="btn-secondary text-xs py-1"
+                onClick={() =>
+                  setForeignTargets((prev) => [
+                    ...prev,
+                    { name: '', x: 0, y: 0, crop_per_hour: '', safety_margin_pct: 5 },
+                  ])
+                }
+              >
+                + Add target
+              </button>
+            </div>
+
+            {foreignTargets.length === 0 ? (
+              <p className="text-secondary text-xs italic">
+                None. Add one if you have promised crop to an ally or a sitter.
+              </p>
+            ) : (
+              <table className="w-full text-xs">
+                <thead className="text-secondary uppercase">
+                  <tr>
+                    <th className="text-left py-1 px-2">Village</th>
+                    <th className="text-right px-2">X</th>
+                    <th className="text-right px-2">Y</th>
+                    <th className="text-right px-2">Crop/h owed</th>
+                    <th
+                      className="text-right px-2"
+                      title="Ship this much above the promise, so travel and rounding cannot leave it short"
+                    >
+                      Margin %
+                    </th>
+                    <th className="text-right px-2">Ships/h</th>
+                    <th className="px-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {foreignTargets.map((t, i) => {
+                    const owed = Number(t.crop_per_hour) || 0
+                    const ships = owed * (1 + (Number(t.safety_margin_pct) || 0) / 100)
+                    const incomplete = !String(t.name).trim() || owed <= 0
+                    const patch = (field, value) =>
+                      setForeignTargets((prev) =>
+                        prev.map((row, j) => (j === i ? { ...row, [field]: value } : row))
+                      )
+                    return (
+                      <tr
+                        key={i}
+                        className="group border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/15 transition-colors"
+                      >
+                        <td className="py-1 px-2 border-l-2 border-l-transparent group-focus-within:border-l-amber-400">
+                          <input
+                            type="text"
+                            aria-label={`Foreign target ${i + 1} name`}
+                            placeholder="Ally name"
+                            className="input-field w-36 text-xs py-0.5"
+                            value={t.name}
+                            onChange={(e) => patch('name', e.target.value)}
+                          />
+                        </td>
+                        <td className="text-right px-2">
+                          <input
+                            type="number"
+                            aria-label={`Foreign target ${i + 1} x coordinate`}
+                            className="input-field w-16 text-right text-xs py-0.5"
+                            value={t.x}
+                            onChange={(e) => patch('x', e.target.value)}
+                          />
+                        </td>
+                        <td className="text-right px-2">
+                          <input
+                            type="number"
+                            aria-label={`Foreign target ${i + 1} y coordinate`}
+                            className="input-field w-16 text-right text-xs py-0.5"
+                            value={t.y}
+                            onChange={(e) => patch('y', e.target.value)}
+                          />
+                        </td>
+                        <td className="text-right px-2">
+                          <input
+                            type="number"
+                            min="0"
+                            aria-label={`Foreign target ${i + 1} crop per hour`}
+                            placeholder="0"
+                            className="input-field w-24 text-right text-xs py-0.5"
+                            value={t.crop_per_hour}
+                            onChange={(e) => patch('crop_per_hour', e.target.value)}
+                          />
+                        </td>
+                        <td className="text-right px-2">
+                          <input
+                            type="number"
+                            min="0"
+                            max="100"
+                            aria-label={`Foreign target ${i + 1} safety margin`}
+                            className="input-field w-16 text-right text-xs py-0.5"
+                            value={t.safety_margin_pct}
+                            onChange={(e) => patch('safety_margin_pct', e.target.value)}
+                          />
+                        </td>
+                        <td className="text-right px-2 font-mono text-secondary">
+                          {ships > 0 ? fmt(ships) : '—'}
+                        </td>
+                        <td className="px-2 text-right whitespace-nowrap">
+                          {incomplete && (
+                            <span
+                              className="text-amber-300 mr-2"
+                              title="Needs a name and a crop rate before the planner uses it"
+                            >
+                              draft
+                            </span>
+                          )}
+                          <button
+                            type="button"
+                            aria-label={`Remove foreign target ${i + 1}`}
+                            className="text-danger hover:underline"
+                            onClick={() =>
+                              setForeignTargets((prev) => prev.filter((_, j) => j !== i))
+                            }
+                          >
+                            remove
+                          </button>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
         </div>
       )}
 
@@ -955,8 +1185,8 @@ export default function ResourcePlanner() {
                   {plan.budgets
                     .filter((b) => b.committed > 0 || b.over_budget)
                     .map((b) => (
-                      <div key={b.village_id} className="flex items-center gap-3 text-xs">
-                        <span className="w-28 truncate">
+                      <div key={b.village_id} className="flex items-start gap-3 text-xs">
+                        <span className="w-28 truncate shrink-0">
                           {villages.find((v) => v.village_id === b.village_id)?.name ??
                             b.village_id}
                         </span>

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -60,6 +60,20 @@ const hhmmToMinutes = (t) => {
   return Number.isFinite(h) && Number.isFinite(m) ? h * 60 + m : null
 }
 
+// Only complete rows go to the backend: a half-typed target would 422 the
+// whole request, and the operator is mid-edit, not in error. Shared by the
+// plan build and the full-day check so both see the same tributes.
+const usableForeignTargets = (targets) =>
+  targets
+    .filter((t) => t.name.trim() && Number(t.crop_per_hour) > 0)
+    .map((t) => ({
+      name: t.name.trim(),
+      x: Number(t.x) || 0,
+      y: Number(t.y) || 0,
+      crop_per_hour: Number(t.crop_per_hour),
+      safety_margin_pct: Number(t.safety_margin_pct) || 0,
+    }))
+
 const RESOURCES = ['lumber', 'clay', 'iron', 'crop']
 const RESOURCE_LABEL = { lumber: 'Lumber', clay: 'Clay', iron: 'Iron', crop: 'Crop' }
 
@@ -401,6 +415,13 @@ export default function ResourcePlanner() {
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_WINDOWS), profileWindows)
   }, [profileWindows, hydratedKey, accountKey, storageKey])
+  // A day-check result is a pure function of these inputs; the moment any of
+  // them changes it describes a day that will never happen. Without this, the
+  // green all-clear banner could sit on screen after the operator changed
+  // everything it was computed from, mixing eras with the live Crop-now column.
+  useEffect(() => {
+    setDayCheck(null)
+  }, [profiles, profileWindows, cropCeilings, snapshot, foreignTargets])
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey)
       saveJson(storageKey(LS_CROP_CEILING), cropCeilings)
@@ -486,17 +507,7 @@ export default function ResourcePlanner() {
           trade_office_level: Number(tradeOffice[v.village_id] ?? 0),
         })),
         allocations: sendAllocations,
-        // Only complete rows go to the planner: a half-typed target would
-        // 422 the whole plan, and the operator is mid-edit, not in error.
-        foreign_targets: foreignTargets
-          .filter((t) => t.name.trim() && Number(t.crop_per_hour) > 0)
-          .map((t) => ({
-            name: t.name.trim(),
-            x: Number(t.x) || 0,
-            y: Number(t.y) || 0,
-            crop_per_hour: Number(t.crop_per_hour),
-            safety_margin_pct: Number(t.safety_margin_pct) || 0,
-          })),
+        foreign_targets: usableForeignTargets(foreignTargets),
         // Geometry defaults to the snapshot (map span + tribe-derived x1
         // merchant speed) but the operator can override both for non-Europe 2
         // worlds (x2/x3 speed, larger maps) — no extra Travian requests.
@@ -643,7 +654,11 @@ export default function ResourcePlanner() {
       // whole account total.
       const a = per[v.village_id] ?? { mode: 'keep', value: 0 }
       if (a.mode === 'remainder') continue
-      const own = v[`${resource}_per_hour`] ?? 0
+      const own = v[`${resource}_per_hour`]
+      // A village whose rate could not be read has its allocation DROPPED by
+      // the backend (with a warning), so counting it here skews the unassigned
+      // counter and, through it, the remainder village's displayed target.
+      if (own == null) continue
       if (a.mode === 'absolute') assigned += Number(a.value) || 0
       else if (a.mode === 'percentage') assigned += (total * (Number(a.value) || 0)) / 100
       else if (a.mode === 'sustain') assigned += own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
@@ -695,6 +710,9 @@ export default function ResourcePlanner() {
       const res = await api.post('/distribution/day-check', {
         snapshot: villages,
         segments,
+        // The same tributes the plan ships: without them the day picture is
+        // optimistic by 24x the tribute.
+        foreign_targets: usableForeignTargets(foreignTargets),
         crop_ceilings: ceilings,
       })
       if (requestedFor !== currentAccountKey()) return
@@ -751,6 +769,17 @@ export default function ResourcePlanner() {
       for (const [k, v] of Object.entries(prev)) next[k === activeProfile ? name : k] = v
       return next
     })
+    // The hours belong to the profile, not to its old name. Left keyed by the
+    // old name they orphan in localStorage -- and worse, resurrect: a FUTURE
+    // profile that happens to reuse the name silently inherits hours the user
+    // never set for it.
+    setProfileWindows((prev) => {
+      if (!(activeProfile in prev)) return prev
+      const next = { ...prev }
+      next[name] = next[activeProfile]
+      delete next[activeProfile]
+      return next
+    })
     setActiveProfile(name)
   }
 
@@ -762,6 +791,12 @@ export default function ResourcePlanner() {
     if (!window.confirm(`Delete profile "${activeProfile}"?`)) return
     const fallback = profileNames.find((n) => n !== activeProfile)
     setProfiles((prev) => {
+      const next = { ...prev }
+      delete next[activeProfile]
+      return next
+    })
+    setProfileWindows((prev) => {
+      if (!(activeProfile in prev)) return prev
       const next = { ...prev }
       delete next[activeProfile]
       return next
@@ -1428,11 +1463,14 @@ export default function ResourcePlanner() {
                             </td>
                             <td
                               className={`text-right px-2 font-mono ${
+                                // Either direction of drift needs attention:
+                                // up walks into the cap or the alert, down
+                                // walks toward an empty granary. Green would
+                                // read as "fine" about a village slowly
+                                // starving.
                                 Math.abs(t.daily_net) < 1
                                   ? 'text-secondary/60'
-                                  : t.daily_net > 0
-                                    ? 'text-orange-200'
-                                    : 'text-success'
+                                  : 'text-orange-200'
                               }`}
                             >
                               {signed(t.daily_net)}
@@ -1521,7 +1559,11 @@ export default function ResourcePlanner() {
                           target = (totals[resource].total * (Number(a.value) || 0)) / 100
                         else if (a.mode === 'sustain')
                           target = own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
-                        const ship = a.mode === 'remainder' ? null : target - (own ?? 0)
+                        // An unreadable rate means the backend drops this
+                        // allocation: promising a Ship/h figure here would be
+                        // cargo the plan never routes.
+                        const ship =
+                          a.mode === 'remainder' || own == null ? null : target - own
                         return (
                           <tr
                             key={v.village_id}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -12,6 +12,11 @@ const LS_TRADE_OFFICE = 'planner_trade_office'
 const LS_FOREIGN = 'planner_foreign_targets'
 const LS_ALLOCATIONS = 'planner_allocations' // legacy single-plan key (migrated)
 const LS_SNAPSHOT = 'planner_snapshot'
+// When the snapshot was fetched (client receipt time, ms). A snapshot carries
+// fast-changing production/stock/merchant state, so a restored one must show its
+// age and go stale rather than pass silently as live.
+const LS_SNAPSHOT_AT = 'planner_snapshot_at'
+const SNAPSHOT_TTL_MS = 30 * 60 * 1000 // 30 minutes
 const LS_MERCHANT = 'planner_merchant_model'
 // Named allocation profiles (e.g. Day / Night). Trade Office and the merchant
 // model stay account-wide — only the allocations differ per profile, so
@@ -72,6 +77,7 @@ const usableForeignTargets = (targets) =>
       y: Number(t.y) || 0,
       crop_per_hour: Number(t.crop_per_hour),
       safety_margin_pct: Number(t.safety_margin_pct) || 0,
+      route_eligible: Boolean(t.route_eligible),
     }))
 
 const RESOURCES = ['lumber', 'clay', 'iron', 'crop']
@@ -326,7 +332,14 @@ export default function ResourcePlanner() {
   const [cropCeilings, setCropCeilings] = useState({})
   const [dayCheck, setDayCheck] = useState(null)
   const [dayChecking, setDayChecking] = useState(false)
+  // Invalidates an in-flight day-check when its inputs change, so a stale
+  // response cannot resurrect a result computed from pre-edit inputs.
+  const dayCheckInputRev = useRef(0)
   const [snapshot, setSnapshot] = useState(null)
+  // Client receipt time of the current snapshot, and an explicit opt-in to plan
+  // from a stale one (see SNAPSHOT_TTL_MS).
+  const [snapshotFetchedAt, setSnapshotFetchedAt] = useState(null)
+  const [useStaleSnapshot, setUseStaleSnapshot] = useState(false)
   const [tradeOffice, setTradeOffice] = useState({})
   const [profiles, setProfiles] = useState({ [DEFAULT_PROFILE]: {} })
   const [activeProfile, setActiveProfile] = useState(DEFAULT_PROFILE)
@@ -380,6 +393,8 @@ export default function ResourcePlanner() {
       // Disconnected: the page stays routable, so showing (or planning from)
       // the previous account's villages would act on stale data.
       setSnapshot(null)
+      setSnapshotFetchedAt(null)
+      setUseStaleSnapshot(false)
       setTradeOffice({})
       setProfiles({ [DEFAULT_PROFILE]: {} })
       setForeignTargets([])
@@ -393,6 +408,8 @@ export default function ResourcePlanner() {
     const loaded = loadProfiles(accountKey)
     const storedActive = loadJson(`${LS_ACTIVE_PROFILE}::${accountKey}`, DEFAULT_PROFILE)
     setSnapshot(loadJson(`${LS_SNAPSHOT}::${accountKey}`, null))
+    setSnapshotFetchedAt(loadJson(`${LS_SNAPSHOT_AT}::${accountKey}`, null))
+    setUseStaleSnapshot(false)
     setTradeOffice(loadJson(`${LS_TRADE_OFFICE}::${accountKey}`, {}))
     setForeignTargets(loadJson(`${LS_FOREIGN}::${accountKey}`, []))
     setProfileWindows(loadJson(`${LS_WINDOWS}::${accountKey}`, {}))
@@ -420,6 +437,11 @@ export default function ResourcePlanner() {
   // green all-clear banner could sit on screen after the operator changed
   // everything it was computed from, mixing eras with the live Crop-now column.
   useEffect(() => {
+    // Bump the revision so a day-check request already in flight cannot install
+    // its stale result after these inputs changed (same discipline as the route
+    // sheet below). Clearing the visible result alone does not stop an
+    // in-progress request from resurrecting a pre-edit "all clear".
+    dayCheckInputRev.current += 1
     setDayCheck(null)
   }, [profiles, profileWindows, cropCeilings, snapshot, foreignTargets])
   // Same rule for the route sheet, with higher stakes: its rows are copied
@@ -466,8 +488,12 @@ export default function ResourcePlanner() {
     try {
       const res = await api.get('/distribution/snapshot', { timeout: 0 })
       if (requestedFor !== currentAccountKey()) return
+      const fetchedAt = Date.now()
       setSnapshot(res.data)
+      setSnapshotFetchedAt(fetchedAt)
+      setUseStaleSnapshot(false)
       saveJson(`${LS_SNAPSHOT}::${requestedFor}`, res.data)
+      saveJson(`${LS_SNAPSHOT_AT}::${requestedFor}`, fetchedAt)
       setPlan(null)
       // A new snapshot can have different village ids — drop stale selections.
       setSelected({})
@@ -695,6 +721,7 @@ export default function ResourcePlanner() {
 
   const runDayCheck = async () => {
     const requestedFor = accountKey
+    const requestedRev = dayCheckInputRev.current
     const segments = []
     const skipped = []
     for (const name of profileNames) {
@@ -734,7 +761,10 @@ export default function ResourcePlanner() {
         foreign_targets: usableForeignTargets(foreignTargets),
         crop_ceilings: ceilings,
       })
+      // Drop the response if the account switched OR any day-check input changed
+      // while it was in flight — otherwise a pre-edit "all clear" resurfaces.
       if (requestedFor !== currentAccountKey()) return
+      if (requestedRev !== dayCheckInputRev.current) return
       setDayCheck({ ...res.data, skipped })
     } catch (err) {
       toast.error(errorDetail(err, 'Full-day check failed'))
@@ -830,6 +860,20 @@ export default function ResourcePlanner() {
     { id: 'plan', label: 'Plan' },
   ]
 
+  // A snapshot carries fast-changing production/stock/merchant state; once it is
+  // older than the TTL (or its receipt time is unknown, e.g. an older cache),
+  // treat it as stale so it is not silently planned from as if it were live.
+  const snapshotAgeMs = snapshot ? (snapshotFetchedAt ? Date.now() - snapshotFetchedAt : null) : null
+  const snapshotStale = !!snapshot && (snapshotFetchedAt == null || snapshotAgeMs > SNAPSHOT_TTL_MS)
+  const snapshotAgeLabel =
+    snapshotAgeMs == null
+      ? 'age unknown'
+      : snapshotAgeMs < 60_000
+        ? 'just now'
+        : snapshotAgeMs < 3_600_000
+          ? `${Math.round(snapshotAgeMs / 60_000)}m old`
+          : `${Math.round(snapshotAgeMs / 3_600_000)}h old`
+
   return (
     <div className="p-6 max-w-7xl mx-auto">
       <div className="flex justify-between items-center mb-4 gap-3 flex-wrap">
@@ -838,16 +882,44 @@ export default function ResourcePlanner() {
           <span className="text-secondary text-xs">
             {villages.length ? `${villages.length} villages` : 'no snapshot yet'}
           </span>
+          {snapshot && (
+            <span className={`text-xs ${snapshotStale ? 'text-orange-200' : 'text-secondary'}`}>
+              · {snapshotAgeLabel}
+            </span>
+          )}
           {/* Every fetch is priced in the label — requests are the scarce
               resource, so the cost is stated before it is spent. */}
           <button className="btn-primary btn-sm" onClick={fetchSnapshot} disabled={fetching}>
             {fetching ? 'Reading…' : 'Fetch state (3–4 requests)'}
           </button>
-          <button className="btn-secondary btn-sm" onClick={buildPlan} disabled={planning}>
+          <button
+            className="btn-secondary btn-sm"
+            onClick={buildPlan}
+            disabled={planning || (snapshotStale && !useStaleSnapshot)}
+          >
             {planning ? 'Planning…' : 'Build plan (0 requests)'}
           </button>
         </div>
       </div>
+
+      {snapshotStale && (
+        <div className="card p-3 mb-4 border border-orange-200/40">
+          <p className="text-orange-200 text-xs">
+            This snapshot is {snapshotAgeLabel}
+            {snapshotFetchedAt == null && ' (restored from a previous session)'} — production,
+            stocks and free merchants may have changed. Fetch fresh state before building, or
+            acknowledge to plan from it anyway.
+          </p>
+          <label className="text-secondary text-xs flex items-center gap-1.5 mt-1.5">
+            <input
+              type="checkbox"
+              checked={useStaleSnapshot}
+              onChange={(e) => setUseStaleSnapshot(e.target.checked)}
+            />
+            Plan from this stale snapshot anyway
+          </label>
+        </div>
+      )}
 
       {/* Named allocation profiles (e.g. Day / Night). Only the allocations
           differ per profile; the snapshot and merchant model are shared, so
@@ -1112,8 +1184,10 @@ export default function ResourcePlanner() {
               <div>
                 <span className="text-secondary text-xs uppercase">Crop owed to other players</span>
                 <p className="text-secondary text-xs mt-0.5">
-                  Shipped like any other demand and taken out of the account crop pool. The
-                  planner picks the supplier, and prefers a single one.
+                  Travian only allows a Gold Club trade route to your own, Wonder, or
+                  alliance/confederacy artifact villages. Tick “route-eligible” only for those —
+                  the planner then ships it like any other demand. An ordinary ally/sitter village
+                  is reported as a manual transfer and is left out of the route plan.
                 </p>
               </div>
               <button
@@ -1122,7 +1196,14 @@ export default function ResourcePlanner() {
                 onClick={() =>
                   setForeignTargets((prev) => [
                     ...prev,
-                    { name: '', x: 0, y: 0, crop_per_hour: '', safety_margin_pct: 5 },
+                    {
+                      name: '',
+                      x: 0,
+                      y: 0,
+                      crop_per_hour: '',
+                      safety_margin_pct: 5,
+                      route_eligible: false,
+                    },
                   ])
                 }
               >
@@ -1149,6 +1230,12 @@ export default function ResourcePlanner() {
                       Margin %
                     </th>
                     <th className="text-right px-2">Ships/h</th>
+                    <th
+                      className="text-center px-2"
+                      title="Tick only for your own, Wonder, or alliance/confederacy artifact villages — the only destinations Travian allows a Gold Club route to. Others are manual transfers."
+                    >
+                      Route?
+                    </th>
                     <th className="px-2"></th>
                   </tr>
                 </thead>
@@ -1218,6 +1305,15 @@ export default function ResourcePlanner() {
                         </td>
                         <td className="text-right px-2 font-mono text-secondary">
                           {ships > 0 ? fmt(ships) : '—'}
+                        </td>
+                        <td className="text-center px-2">
+                          <input
+                            type="checkbox"
+                            aria-label={`Foreign target ${i + 1} is eligible for a trade route`}
+                            title="Own / Wonder / alliance-artifact village only. Unticked = manual transfer, left out of the route plan."
+                            checked={Boolean(t.route_eligible)}
+                            onChange={(e) => patch('route_eligible', e.target.checked)}
+                          />
                         </td>
                         <td className="px-2 text-right whitespace-nowrap">
                           {incomplete && (
@@ -1724,7 +1820,7 @@ export default function ResourcePlanner() {
                       <th className="text-left px-2">To</th>
                       <th className="text-left px-2">Cargo per send</th>
                       <th className="text-right px-2">Cycle</th>
-                      <th className="text-right px-2">Create at</th>
+                      <th className="text-right px-2">Send at</th>
                       <th className="text-right px-2">Arrives</th>
                       <th className="text-right px-2">Merchants</th>
                     </tr>
@@ -1768,8 +1864,9 @@ export default function ResourcePlanner() {
                   </tbody>
                 </table>
                 <p className="text-secondary text-xs mt-2">
-                  A Gold Club route repeats from the moment it is created, so “create at” is the
-                  clock time to press create — not a field you can set afterwards.
+                  “Send at” is the route's scheduled send time — enter it in the trade route's
+                  <span className="whitespace-nowrap"> Send at</span> field; the repeat interval is
+                  set separately. It is not the wall-clock instant you must press create.
                 </p>
               </div>
 

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -432,7 +432,12 @@ export default function ResourcePlanner() {
   useEffect(() => {
     planInputRev.current += 1
     setPlan(null)
-  }, [allocations, tradeOffice, merchantModel, foreignTargets, villages])
+    // Depends on `snapshot`, not the derived `villages`: `villages` is declared
+    // further down, and naming it here would evaluate this dependency array in
+    // its temporal dead zone — a ReferenceError that drops the whole planner
+    // into the error boundary. `villages` is `snapshot?.villages ?? []`, so
+    // snapshot changing is exactly the signal we want.
+  }, [allocations, tradeOffice, merchantModel, foreignTargets, snapshot])
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey)
       saveJson(storageKey(LS_CROP_CEILING), cropCeilings)

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -127,7 +127,16 @@ export default function ResourcePlanner() {
   )
 
   useEffect(() => {
-    if (!accountKey) return
+    if (!accountKey) {
+      // Disconnected: the page stays routable, so showing (or planning from)
+      // the previous account's villages would act on stale data.
+      setSnapshot(null)
+      setTradeOffice({})
+      setAllocations({})
+      setPlan(null)
+      setHydratedKey(null)
+      return
+    }
     setSnapshot(loadJson(`${LS_SNAPSHOT}::${accountKey}`, null))
     setTradeOffice(loadJson(`${LS_TRADE_OFFICE}::${accountKey}`, {}))
     setAllocations(loadJson(`${LS_ALLOCATIONS}::${accountKey}`, {}))

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -146,7 +146,7 @@ const signed = (n) => (n == null ? '—' : `${n > 0 ? '+' : ''}${Math.round(n).t
 function CropCell({ village }) {
   if (village.crop_per_hour == null) {
     return (
-      <span className="text-amber-300" title="Rate could not be derived — not treated as zero">
+      <span className="text-orange-200" title="Rate could not be derived — not treated as zero">
         unknown
       </span>
     )
@@ -209,7 +209,7 @@ function BudgetBar({ budget }) {
       {open && (
         <div className="mt-1 mb-2 ml-2 pl-3 border-l border-gray-700">
           {budget.explanation && (
-            <p className="text-xs text-amber-200 mb-1">{budget.explanation}</p>
+            <p className="text-xs text-orange-200 mb-1">{budget.explanation}</p>
           )}
           <table className="text-xs w-full max-w-2xl">
             <thead className="text-secondary uppercase">
@@ -872,7 +872,7 @@ export default function ResourcePlanner() {
             aria-current={stage === s.id ? 'page' : undefined}
             className={`px-4 py-2 text-sm rounded-t ${
               stage === s.id
-                ? 'bg-black/40 text-white border-b-2 border-amber-400'
+                ? 'bg-black/40 text-white border-b-2 border-violet-400'
                 : 'text-secondary hover:text-white'
             }`}
           >
@@ -916,9 +916,9 @@ export default function ResourcePlanner() {
               {villages.map((v) => (
                 <tr
                   key={v.village_id}
-                  className="group border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/15 transition-colors"
+                  className="group border-t border-gray-800 hover:bg-white/5 focus-within:bg-violet-400/15 transition-colors"
                 >
-                  <td className="py-1.5 px-2 border-l-2 border-l-transparent group-focus-within:border-l-amber-400">
+                  <td className="py-1.5 px-2 border-l-2 border-l-transparent group-focus-within:border-l-violet-400">
                     {v.name}{' '}
                     <span className="text-secondary text-xs">
                       ({v.x}|{v.y})
@@ -974,7 +974,7 @@ export default function ResourcePlanner() {
             </tbody>
           </table>
           {snapshot?.warnings?.length > 0 && (
-            <ul className="mt-3 text-xs text-amber-300 list-disc list-inside">
+            <ul className="mt-3 text-xs text-orange-200 list-disc list-inside">
               {snapshot.warnings.map((w, i) => (
                 <li key={i}>{w}</li>
               ))}
@@ -1110,9 +1110,9 @@ export default function ResourcePlanner() {
                     return (
                       <tr
                         key={i}
-                        className="group border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/15 transition-colors"
+                        className="group border-t border-gray-800 hover:bg-white/5 focus-within:bg-violet-400/15 transition-colors"
                       >
-                        <td className="py-1 px-2 border-l-2 border-l-transparent group-focus-within:border-l-amber-400">
+                        <td className="py-1 px-2 border-l-2 border-l-transparent group-focus-within:border-l-violet-400">
                           <input
                             type="text"
                             aria-label={`Foreign target ${i + 1} name`}
@@ -1168,7 +1168,7 @@ export default function ResourcePlanner() {
                         <td className="px-2 text-right whitespace-nowrap">
                           {incomplete && (
                             <span
-                              className="text-amber-300 mr-2"
+                              className="text-orange-200 mr-2"
                               title="Needs a name and a crop rate before the planner uses it"
                             >
                               draft
@@ -1209,7 +1209,7 @@ export default function ResourcePlanner() {
                 aria-pressed={allocView === key}
                 className={`text-xs px-3 py-1.5 rounded border transition-colors ${
                   allocView === key
-                    ? 'border-amber-400/60 bg-amber-400/15 text-amber-200'
+                    ? 'border-violet-400/60 bg-violet-400/15 text-violet-200'
                     : 'border-gray-700 text-secondary hover:text-white hover:border-gray-500'
                 }`}
                 onClick={() => setAllocView(key)}
@@ -1293,7 +1293,7 @@ export default function ResourcePlanner() {
                                 `${fmt(after)}/h`
                               )}
                               {isRest && (
-                                <span className="ml-1 text-[10px] uppercase text-amber-300/80 font-sans">
+                                <span className="ml-1 text-[10px] uppercase text-violet-300/80 font-sans">
                                   rest
                                 </span>
                               )}
@@ -1306,7 +1306,7 @@ export default function ResourcePlanner() {
                                   ? 'text-secondary/60'
                                   : ship > 0
                                     ? 'text-success'
-                                    : 'text-amber-300'
+                                    : 'text-orange-200'
                               }`}
                             >
                               {ship == null ? '—' : Math.abs(ship) < 1 ? '·' : signed(ship)}
@@ -1361,14 +1361,14 @@ export default function ResourcePlanner() {
               </div>
 
               {dayCheck?.skipped?.length > 0 && (
-                <p className="text-amber-300 text-xs mb-2">
+                <p className="text-orange-200 text-xs mb-2">
                   Skipped {dayCheck.skipped.join(', ')} — no hours set. Give each profile its
                   window in the bar above.
                 </p>
               )}
 
               {dayCheck?.warnings?.length > 0 && (
-                <ul className="text-xs text-amber-300 list-disc list-inside mb-3 space-y-0.5">
+                <ul className="text-xs text-orange-200 list-disc list-inside mb-3 space-y-0.5">
                   {dayCheck.warnings.map((w, i) => (
                     <li key={i}>{w}</li>
                   ))}
@@ -1419,7 +1419,7 @@ export default function ResourcePlanner() {
                               {fmt(t.low)} → {fmt(t.high)}
                               {!t.settled && (
                                 <span
-                                  className="text-amber-300 ml-1"
+                                  className="text-orange-200 ml-1"
                                   title="Still drifting at the simulation horizon — the drift column is the story"
                                 >
                                   ↗
@@ -1431,7 +1431,7 @@ export default function ResourcePlanner() {
                                 Math.abs(t.daily_net) < 1
                                   ? 'text-secondary/60'
                                   : t.daily_net > 0
-                                    ? 'text-amber-300'
+                                    ? 'text-orange-200'
                                     : 'text-success'
                               }`}
                             >
@@ -1525,11 +1525,11 @@ export default function ResourcePlanner() {
                         return (
                           <tr
                             key={v.village_id}
-                            className={`group border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/15 transition-colors ${
-                              isSelected(resource, v.village_id) ? 'bg-amber-400/5' : ''
+                            className={`group border-t border-gray-800 hover:bg-white/5 focus-within:bg-violet-400/15 transition-colors ${
+                              isSelected(resource, v.village_id) ? 'bg-violet-400/10' : ''
                             }`}
                           >
-                            <td className="text-center px-2 border-l-2 border-l-transparent group-focus-within:border-l-amber-400">
+                            <td className="text-center px-2 border-l-2 border-l-transparent group-focus-within:border-l-violet-400">
                               <input
                                 type="checkbox"
                                 aria-label={`Select ${v.name} for batch edit`}
@@ -1580,7 +1580,7 @@ export default function ResourcePlanner() {
                                   : ship > 0
                                     ? 'text-success'
                                     : ship < 0
-                                      ? 'text-amber-300'
+                                      ? 'text-orange-200'
                                       : 'text-secondary'
                               }`}
                             >
@@ -1732,7 +1732,7 @@ export default function ResourcePlanner() {
 
               {plan.warnings.length > 0 && (
                 <div className="card p-4">
-                  <h3 className="font-semibold mb-2 text-amber-300">
+                  <h3 className="font-semibold mb-2 text-orange-200">
                     Warnings ({plan.warnings.length})
                   </h3>
                   <ul className="text-xs list-disc list-inside space-y-0.5 max-h-64 overflow-y-auto">

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -1,0 +1,569 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useToast } from '../components/Toast'
+import api from '../api'
+
+// Owned state the game will not tell us, kept per village. Trade Office level
+// changes only when the operator builds one, so it is stored rather than fetched.
+const LS_TRADE_OFFICE = 'planner_trade_office'
+const LS_ALLOCATIONS = 'planner_allocations'
+const LS_SNAPSHOT = 'planner_snapshot'
+
+const RESOURCES = ['lumber', 'clay', 'iron', 'crop']
+const RESOURCE_LABEL = { lumber: 'Lumber', clay: 'Clay', iron: 'Iron', crop: 'Crop' }
+const MODES = [
+  { value: 'keep', label: 'Keep own' },
+  { value: 'absolute', label: 'Absolute /h' },
+  { value: 'percentage', label: '% of total' },
+  { value: 'sustain', label: 'Sustain +%' },
+]
+
+function loadJson(key, fallback) {
+  try {
+    return JSON.parse(localStorage.getItem(key)) ?? fallback
+  } catch {
+    return fallback
+  }
+}
+
+function saveJson(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    /* storage full or disabled — the plan still works, it just will not persist */
+  }
+}
+
+const fmt = (n) => (n == null ? '—' : Math.round(n).toLocaleString())
+const signed = (n) => (n == null ? '—' : `${n > 0 ? '+' : ''}${Math.round(n).toLocaleString()}`)
+
+/** Net crop, shown with a word as well as a colour.
+ *  Design Guideline — Accessibility: never rely on colour alone to convey
+ *  information, so "starving" is spelled out rather than implied by red. */
+function CropCell({ village }) {
+  if (village.crop_per_hour == null) {
+    return (
+      <span className="text-amber-300" title="Rate could not be derived — not treated as zero">
+        unknown
+      </span>
+    )
+  }
+  const starving = village.crop_per_hour < 0
+  return (
+    <span className={starving ? 'text-danger' : 'text-success'}>
+      {signed(village.crop_per_hour)}/h{starving ? ' · starving' : ''}
+    </span>
+  )
+}
+
+/** Merchant budget as a bar plus the numbers.
+ *  Design Guideline — Charts: a chart supplements the data, it does not replace
+ *  it, so committed/spare stay readable as text for screen readers. */
+function BudgetBar({ budget }) {
+  const spare = Math.max(budget.spare, 1)
+  const usedPct = Math.min(100, Math.round((budget.committed / spare) * 100))
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        className="h-2 w-28 rounded bg-black/40 overflow-hidden"
+        role="img"
+        aria-label={`${budget.committed} of ${budget.spare} merchants committed`}
+      >
+        <div
+          className={`h-full ${budget.over_budget ? 'bg-red-500' : 'bg-emerald-500'}`}
+          style={{ width: `${usedPct}%` }}
+        />
+      </div>
+      <span className="font-mono text-xs">
+        {budget.committed}/{budget.spare}
+      </span>
+      {budget.over_budget && (
+        <span className="text-danger text-xs">
+          over by {budget.committed - budget.spare}
+          {budget.trade_office_levels_needed != null
+            ? ` · Trade Office +${budget.trade_office_levels_needed} would fit`
+            : ' · no upgrade fixes this'}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export default function ResourcePlanner() {
+  const toast = useToast()
+  const [stage, setStage] = useState('snapshot')
+  const [snapshot, setSnapshot] = useState(() => loadJson(LS_SNAPSHOT, null))
+  const [tradeOffice, setTradeOffice] = useState(() => loadJson(LS_TRADE_OFFICE, {}))
+  const [allocations, setAllocations] = useState(() => loadJson(LS_ALLOCATIONS, {}))
+  const [plan, setPlan] = useState(null)
+  const [fetching, setFetching] = useState(false)
+  const [planning, setPlanning] = useState(false)
+
+  useEffect(() => saveJson(LS_TRADE_OFFICE, tradeOffice), [tradeOffice])
+  useEffect(() => saveJson(LS_ALLOCATIONS, allocations), [allocations])
+
+  // Memoised so it does not become a fresh array on every render, which would
+  // re-run the plan callback and the totals memo for no reason.
+  const villages = useMemo(() => snapshot?.villages ?? [], [snapshot])
+
+  const fetchSnapshot = async () => {
+    setFetching(true)
+    try {
+      const res = await api.get('/distribution/snapshot', { timeout: 0 })
+      setSnapshot(res.data)
+      saveJson(LS_SNAPSHOT, res.data)
+      setPlan(null)
+      const fresh = res.data.villages.filter((v) => tradeOffice[v.village_id] == null)
+      toast.success(
+        `Read ${res.data.villages.length} villages in ${res.data.requests_used} requests` +
+          (fresh.length ? ` · ${fresh.length} need a Trade Office level` : '')
+      )
+    } catch (err) {
+      toast.error(err.response?.data?.detail || 'Could not read account state')
+    } finally {
+      setFetching(false)
+    }
+  }
+
+  const buildPlan = useCallback(async () => {
+    if (!villages.length) {
+      toast.error('Fetch account state first')
+      return
+    }
+    setPlanning(true)
+    try {
+      const res = await api.post('/distribution/plan', {
+        snapshot: villages,
+        config: villages.map((v) => ({
+          village_id: v.village_id,
+          trade_office_level: Number(tradeOffice[v.village_id] ?? 0),
+        })),
+        allocations,
+      })
+      setPlan(res.data)
+      setStage('plan')
+    } catch (err) {
+      toast.error(err.response?.data?.detail || 'Could not build a plan')
+    } finally {
+      setPlanning(false)
+    }
+  }, [villages, tradeOffice, allocations, toast])
+
+  // Live unallocated counter, so slack is visible while typing rather than
+  // discovered later (profile known issue #9).
+  const totals = useMemo(() => {
+    const out = {}
+    for (const resource of RESOURCES) {
+      const field = `${resource}_per_hour`
+      let total = 0
+      let known = true
+      for (const v of villages) {
+        if (v[field] == null) {
+          known = false
+          continue
+        }
+        total += v[field]
+      }
+      out[resource] = { total, known }
+    }
+    return out
+  }, [villages])
+
+  const remainderFor = (resource) => {
+    const per = allocations[resource] ?? {}
+    const found = Object.entries(per).find(([, a]) => a.mode === 'remainder')
+    return found ? Number(found[0]) : null
+  }
+
+  const setAllocation = (resource, villageId, patch) => {
+    setAllocations((prev) => {
+      const per = { ...(prev[resource] ?? {}) }
+      per[villageId] = { mode: 'keep', value: 0, ...(per[villageId] ?? {}), ...patch }
+      return { ...prev, [resource]: per }
+    })
+  }
+
+  const setRemainder = (resource, villageId) => {
+    setAllocations((prev) => {
+      const per = { ...(prev[resource] ?? {}) }
+      // Exactly one remainder per resource, enforced by the widget itself.
+      for (const [vid, a] of Object.entries(per)) {
+        if (a.mode === 'remainder') per[vid] = { mode: 'keep', value: 0 }
+      }
+      per[villageId] = { mode: 'remainder', value: 0 }
+      return { ...prev, [resource]: per }
+    })
+  }
+
+  const explicitTotal = (resource) => {
+    const per = allocations[resource] ?? {}
+    const { total } = totals[resource]
+    let assigned = 0
+    for (const v of villages) {
+      const a = per[v.village_id]
+      if (!a || a.mode === 'remainder') continue
+      if (a.mode === 'absolute') assigned += Number(a.value) || 0
+      else if (a.mode === 'percentage') assigned += (total * (Number(a.value) || 0)) / 100
+      else if (a.mode === 'sustain') {
+        const own = v[`${resource}_per_hour`] ?? 0
+        assigned += own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
+      } else assigned += v[`${resource}_per_hour`] ?? 0
+    }
+    return total - assigned
+  }
+
+  const stages = [
+    { id: 'snapshot', label: 'Snapshot' },
+    { id: 'allocate', label: 'Allocate' },
+    { id: 'plan', label: 'Plan' },
+  ]
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <div className="flex justify-between items-center mb-4 gap-3 flex-wrap">
+        <h2 className="heading-gold text-2xl">Resource Planner</h2>
+        <div className="flex items-center gap-3">
+          <span className="text-secondary text-xs">
+            {villages.length ? `${villages.length} villages` : 'no snapshot yet'}
+          </span>
+          {/* Every fetch is priced in the label — requests are the scarce
+              resource, so the cost is stated before it is spent. */}
+          <button className="btn-primary btn-sm" onClick={fetchSnapshot} disabled={fetching}>
+            {fetching ? 'Reading…' : 'Fetch state (4 requests)'}
+          </button>
+          <button className="btn-secondary btn-sm" onClick={buildPlan} disabled={planning}>
+            {planning ? 'Planning…' : 'Build plan (0 requests)'}
+          </button>
+        </div>
+      </div>
+
+      <nav className="flex gap-1 mb-4 border-b border-gray-700" aria-label="Planner stages">
+        {stages.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => setStage(s.id)}
+            aria-current={stage === s.id ? 'page' : undefined}
+            className={`px-4 py-2 text-sm rounded-t ${
+              stage === s.id
+                ? 'bg-black/40 text-white border-b-2 border-amber-400'
+                : 'text-secondary hover:text-white'
+            }`}
+          >
+            {s.label}
+          </button>
+        ))}
+      </nav>
+
+      {!villages.length && (
+        <div className="card p-6 text-center text-secondary">
+          <p>No account state yet.</p>
+          <p className="text-xs mt-1">
+            Fetching reads production, stocks and granary countdowns for every village in four
+            requests — net crop included, so army villages are not mistaken for healthy ones.
+          </p>
+        </div>
+      )}
+
+      {stage === 'snapshot' && villages.length > 0 && (
+        <div className="card p-4 overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-secondary text-xs uppercase">
+              <tr>
+                <th className="text-left py-2 px-2">Village</th>
+                <th className="text-right px-2">Lumber/h</th>
+                <th className="text-right px-2">Clay/h</th>
+                <th className="text-right px-2">Iron/h</th>
+                <th className="text-left px-2">Net crop</th>
+                <th className="text-right px-2">Merchants</th>
+                <th className="text-right px-2">Trade Office</th>
+              </tr>
+            </thead>
+            <tbody>
+              {villages.map((v) => (
+                <tr key={v.village_id} className="border-t border-gray-800">
+                  <td className="py-1.5 px-2">
+                    {v.name}{' '}
+                    <span className="text-secondary text-xs">
+                      ({v.x}|{v.y})
+                    </span>
+                  </td>
+                  <td className="text-right px-2 font-mono">{fmt(v.lumber_per_hour)}</td>
+                  <td className="text-right px-2 font-mono">{fmt(v.clay_per_hour)}</td>
+                  <td className="text-right px-2 font-mono">{fmt(v.iron_per_hour)}</td>
+                  <td className="px-2 font-mono">
+                    <CropCell village={v} />
+                  </td>
+                  <td className="text-right px-2 font-mono">
+                    {v.merchants_free}/{v.merchants_total}
+                  </td>
+                  <td className="text-right px-2">
+                    {/* Owned, not fetched — editable, and blank means "unknown",
+                        which the planner floors to 0 rather than guessing up. */}
+                    <input
+                      type="number"
+                      min="0"
+                      max="20"
+                      aria-label={`Trade Office level for ${v.name}`}
+                      placeholder="?"
+                      className="input-field w-16 text-right text-xs py-1"
+                      value={tradeOffice[v.village_id] ?? ''}
+                      onChange={(e) =>
+                        setTradeOffice((prev) => ({
+                          ...prev,
+                          [v.village_id]: e.target.value === '' ? undefined : Number(e.target.value),
+                        }))
+                      }
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {snapshot?.warnings?.length > 0 && (
+            <ul className="mt-3 text-xs text-amber-300 list-disc list-inside">
+              {snapshot.warnings.map((w, i) => (
+                <li key={i}>{w}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {stage === 'allocate' && villages.length > 0 && (
+        <div className="space-y-4">
+          {RESOURCES.map((resource) => {
+            const slack = explicitTotal(resource)
+            const remainder = remainderFor(resource)
+            const settled = Math.abs(slack) < 1 || remainder != null
+            return (
+              <div key={resource} className="card p-4">
+                <div className="flex justify-between items-baseline mb-2 flex-wrap gap-2">
+                  <h3 className="font-semibold">{RESOURCE_LABEL[resource]}</h3>
+                  <div className="text-xs">
+                    <span className="text-secondary">
+                      total {fmt(totals[resource].total)}/h
+                      {!totals[resource].known && ' (some villages unknown)'} ·{' '}
+                    </span>
+                    <span className={settled ? 'text-success' : 'text-danger'}>
+                      {fmt(slack)}/h unassigned
+                      {remainder != null
+                        ? ` → village ${remainder}`
+                        : ' · no remainder village set'}
+                    </span>
+                  </div>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-xs">
+                    <thead className="text-secondary uppercase">
+                      <tr>
+                        <th className="text-left py-1 px-2">Village</th>
+                        <th className="text-right px-2">Own/h</th>
+                        <th className="text-left px-2">Mode</th>
+                        <th className="text-right px-2">Value</th>
+                        <th className="text-right px-2">Ship/h</th>
+                        <th className="text-center px-2">Rest</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {villages.map((v) => {
+                        const own = v[`${resource}_per_hour`]
+                        const a = allocations[resource]?.[v.village_id] ?? { mode: 'keep', value: 0 }
+                        let target = own ?? 0
+                        if (a.mode === 'absolute') target = Number(a.value) || 0
+                        else if (a.mode === 'percentage')
+                          target = (totals[resource].total * (Number(a.value) || 0)) / 100
+                        else if (a.mode === 'sustain')
+                          target = own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
+                        const ship = a.mode === 'remainder' ? null : target - (own ?? 0)
+                        return (
+                          <tr key={v.village_id} className="border-t border-gray-800">
+                            <td className="py-1 px-2">{v.name}</td>
+                            <td className="text-right px-2 font-mono text-secondary">
+                              {own == null ? '—' : signed(own)}
+                            </td>
+                            <td className="px-2">
+                              <select
+                                aria-label={`${RESOURCE_LABEL[resource]} mode for ${v.name}`}
+                                className="input-field text-xs py-0.5"
+                                value={a.mode === 'remainder' ? 'keep' : a.mode}
+                                onChange={(e) =>
+                                  setAllocation(resource, v.village_id, { mode: e.target.value })
+                                }
+                              >
+                                {MODES.map((m) => (
+                                  <option key={m.value} value={m.value}>
+                                    {m.label}
+                                  </option>
+                                ))}
+                              </select>
+                            </td>
+                            <td className="text-right px-2">
+                              <input
+                                type="number"
+                                aria-label={`${RESOURCE_LABEL[resource]} value for ${v.name}`}
+                                className="input-field w-24 text-right text-xs py-0.5"
+                                disabled={a.mode === 'keep' || a.mode === 'remainder'}
+                                value={a.value ?? 0}
+                                onChange={(e) =>
+                                  setAllocation(resource, v.village_id, {
+                                    value: Number(e.target.value),
+                                  })
+                                }
+                              />
+                            </td>
+                            {/* Ship is the primary number: the cargo is the GAP,
+                                not the target. Profile known issue #1. */}
+                            <td
+                              className={`text-right px-2 font-mono ${
+                                ship == null
+                                  ? 'text-secondary'
+                                  : ship > 0
+                                    ? 'text-success'
+                                    : ship < 0
+                                      ? 'text-amber-300'
+                                      : 'text-secondary'
+                              }`}
+                            >
+                              {ship == null ? 'rest' : signed(ship)}
+                            </td>
+                            <td className="text-center px-2">
+                              <input
+                                type="radio"
+                                name={`remainder-${resource}`}
+                                aria-label={`Send remaining ${RESOURCE_LABEL[resource]} to ${v.name}`}
+                                checked={remainder === v.village_id}
+                                onChange={() => setRemainder(resource, v.village_id)}
+                              />
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {stage === 'plan' && (
+        <div className="space-y-4">
+          {!plan && (
+            <div className="card p-6 text-center text-secondary">
+              No plan yet — press <strong>Build plan</strong>. It costs no game requests, so
+              re-planning while tuning targets is free.
+            </div>
+          )}
+
+          {plan && (
+            <>
+              <div className="card p-4 flex flex-wrap gap-6 items-center">
+                <div>
+                  <div className="text-secondary text-xs uppercase">Routes</div>
+                  <div className="text-xl font-mono">{plan.rows.length}</div>
+                </div>
+                <div>
+                  <div className="text-secondary text-xs uppercase">Merchants</div>
+                  <div className="text-xl font-mono">{plan.total_merchants}</div>
+                </div>
+                <div>
+                  <div className="text-secondary text-xs uppercase">Status</div>
+                  <div className={plan.feasible ? 'text-success' : 'text-danger'}>
+                    {plan.feasible ? 'Feasible' : 'Not feasible'}
+                  </div>
+                </div>
+              </div>
+
+              <div className="card p-4">
+                <h3 className="font-semibold mb-2">Merchant budget</h3>
+                <div className="space-y-1">
+                  {plan.budgets
+                    .filter((b) => b.committed > 0 || b.over_budget)
+                    .map((b) => (
+                      <div key={b.village_id} className="flex items-center gap-3 text-xs">
+                        <span className="w-28 truncate">
+                          {villages.find((v) => v.village_id === b.village_id)?.name ??
+                            b.village_id}
+                        </span>
+                        <BudgetBar budget={b} />
+                      </div>
+                    ))}
+                </div>
+              </div>
+
+              <div className="card p-4 overflow-x-auto">
+                <h3 className="font-semibold mb-2">Setup sheet</h3>
+                <table className="w-full text-xs">
+                  <thead className="text-secondary uppercase">
+                    <tr>
+                      <th className="text-left py-1 px-2">From</th>
+                      <th className="text-left px-2">To</th>
+                      <th className="text-left px-2">Cargo per send</th>
+                      <th className="text-right px-2">Cycle</th>
+                      <th className="text-right px-2">Create at</th>
+                      <th className="text-right px-2">Arrives</th>
+                      <th className="text-right px-2">Merchants</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {plan.rows.map((row, i) => (
+                      <tr key={i} className="border-t border-gray-800">
+                        <td className="py-1 px-2">
+                          {villages.find((v) => v.village_id === row.origin)?.name ?? row.origin}
+                        </td>
+                        <td className="px-2">
+                          {villages.find((v) => v.village_id === row.destination)?.name ??
+                            row.destination}
+                        </td>
+                        <td className="px-2 font-mono">
+                          {Object.entries(row.cargo)
+                            .map(([r, v]) => `${RESOURCE_LABEL[r]} ${v.toLocaleString()}`)
+                            .join(' · ')}
+                        </td>
+                        <td className="text-right px-2 font-mono">{row.cycle_hours}h</td>
+                        <td className="text-right px-2 font-mono">{row.dispatch}</td>
+                        <td className="text-right px-2 font-mono">{row.arrival}</td>
+                        <td className="text-right px-2 font-mono">{row.merchants}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <p className="text-secondary text-xs mt-2">
+                  A Gold Club route repeats from the moment it is created, so “create at” is the
+                  clock time to press create — not a field you can set afterwards.
+                </p>
+              </div>
+
+              {plan.shortfalls.length > 0 && (
+                <div className="card p-4">
+                  <h3 className="font-semibold mb-2 text-danger">Unroutable demand</h3>
+                  <ul className="text-xs list-disc list-inside space-y-0.5">
+                    {plan.shortfalls.map((s, i) => (
+                      <li key={i}>
+                        {RESOURCE_LABEL[s.resource]} · village {s.village_id} short{' '}
+                        {fmt(s.per_hour)}/h — {s.reason}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {plan.warnings.length > 0 && (
+                <div className="card p-4">
+                  <h3 className="font-semibold mb-2 text-amber-300">
+                    Warnings ({plan.warnings.length})
+                  </h3>
+                  <ul className="text-xs list-disc list-inside space-y-0.5 max-h-64 overflow-y-auto">
+                    {plan.warnings.map((w, i) => (
+                      <li key={i}>{w}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -50,8 +50,57 @@ function loadProfiles(accountKey) {
 // server-side and travels in the snapshot.
 const DEFAULT_MERCHANT_MODEL = { base_capacity: 2200, bonus_per_to_level: 0.2 }
 
+const LS_WINDOWS = 'planner_profile_windows'
+const LS_CROP_CEILING = 'planner_crop_ceiling'
+// Sensible defaults by convention; anything else starts unset until the
+// operator gives it hours.
+const DEFAULT_WINDOWS = { Day: ['07:00', '23:00'], Night: ['23:00', '07:00'] }
+const hhmmToMinutes = (t) => {
+  const [h, m] = String(t).split(':').map(Number)
+  return Number.isFinite(h) && Number.isFinite(m) ? h * 60 + m : null
+}
+
 const RESOURCES = ['lumber', 'clay', 'iron', 'crop']
 const RESOURCE_LABEL = { lumber: 'Lumber', clay: 'Clay', iron: 'Iron', crop: 'Crop' }
+
+// Minimal inline glyphs in the game's resource order, so cargo reads the way
+// the marketplace shows it. Drawn here rather than shipped as assets: no
+// external sprite, and they inherit currentColor for the strokes.
+function ResourceIcon({ resource }) {
+  const common = { width: 13, height: 13, viewBox: '0 0 16 16', 'aria-label': RESOURCE_LABEL[resource], role: 'img', className: 'inline-block align-[-2px]' }
+  if (resource === 'lumber')
+    return (
+      <svg {...common}>
+        <rect x="1" y="6" width="11" height="4" rx="2" fill="#a16207" />
+        <rect x="4" y="10" width="11" height="4" rx="2" fill="#854d0e" />
+        <circle cx="12" cy="8" r="1.6" fill="#fde68a" />
+        <circle cx="15" cy="12" r="1.4" fill="#fde68a" />
+      </svg>
+    )
+  if (resource === 'clay')
+    return (
+      <svg {...common}>
+        <rect x="1" y="4" width="9" height="5" rx="1" fill="#ea580c" />
+        <rect x="6" y="9" width="9" height="5" rx="1" fill="#c2410c" />
+      </svg>
+    )
+  if (resource === 'iron')
+    return (
+      <svg {...common}>
+        <path d="M3 12 L6 5 L10 5 L13 12 Z" fill="#94a3b8" />
+        <path d="M6 5 L8 8 L10 5 Z" fill="#e2e8f0" />
+      </svg>
+    )
+  return (
+    <svg {...common}>
+      <path d="M8 15 V6" stroke="#eab308" strokeWidth="1.4" />
+      <path d="M8 7 C5 6 4 4 4 1 C7 2 8 4 8 7 Z" fill="#facc15" />
+      <path d="M8 7 C11 6 12 4 12 1 C9 2 8 4 8 7 Z" fill="#eab308" />
+      <path d="M8 11 C6 10 5 9 5 7 C7 8 8 9 8 11 Z" fill="#facc15" />
+      <path d="M8 11 C10 10 11 9 11 7 C9 8 8 9 8 11 Z" fill="#eab308" />
+    </svg>
+  )
+}
 const MODES = [
   { value: 'keep', label: 'Keep own' },
   { value: 'absolute', label: 'Absolute /h' },
@@ -254,6 +303,15 @@ export default function ResourcePlanner() {
   // material is how the targets are EDITED; grouped by village is how the
   // operator actually thinks about the outcome.
   const [allocView, setAllocView] = useState('village')
+  // Which hours of the day each profile actually runs, 'HH:MM' pairs. The
+  // profiles are separate plans, but the account lives through all of them
+  // every day -- the windows are what lets the full-day check line them up.
+  const [profileWindows, setProfileWindows] = useState({})
+  // Operator alert level for a village's crop stock (e.g. an NPC trigger),
+  // below capacity. Cached per account like the Trade Office levels.
+  const [cropCeilings, setCropCeilings] = useState({})
+  const [dayCheck, setDayCheck] = useState(null)
+  const [dayChecking, setDayChecking] = useState(false)
   const [snapshot, setSnapshot] = useState(null)
   const [tradeOffice, setTradeOffice] = useState({})
   const [profiles, setProfiles] = useState({ [DEFAULT_PROFILE]: {} })
@@ -323,6 +381,9 @@ export default function ResourcePlanner() {
     setSnapshot(loadJson(`${LS_SNAPSHOT}::${accountKey}`, null))
     setTradeOffice(loadJson(`${LS_TRADE_OFFICE}::${accountKey}`, {}))
     setForeignTargets(loadJson(`${LS_FOREIGN}::${accountKey}`, []))
+    setProfileWindows(loadJson(`${LS_WINDOWS}::${accountKey}`, {}))
+    setCropCeilings(loadJson(`${LS_CROP_CEILING}::${accountKey}`, {}))
+    setDayCheck(null)
     setProfiles(loaded)
     setActiveProfile(loaded[storedActive] ? storedActive : Object.keys(loaded)[0])
     setMerchantModel(loadJson(`${LS_MERCHANT}::${accountKey}`, DEFAULT_MERCHANT_MODEL))
@@ -337,6 +398,13 @@ export default function ResourcePlanner() {
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_FOREIGN), foreignTargets)
   }, [foreignTargets, hydratedKey, accountKey, storageKey])
+  useEffect(() => {
+    if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_WINDOWS), profileWindows)
+  }, [profileWindows, hydratedKey, accountKey, storageKey])
+  useEffect(() => {
+    if (hydratedKey && hydratedKey === accountKey)
+      saveJson(storageKey(LS_CROP_CEILING), cropCeilings)
+  }, [cropCeilings, hydratedKey, accountKey, storageKey])
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey) saveJson(storageKey(LS_PROFILES), profiles)
   }, [profiles, hydratedKey, accountKey, storageKey])
@@ -589,6 +657,55 @@ export default function ResourcePlanner() {
   // editing the set clears it.
   const profileNames = Object.keys(profiles)
 
+  const windowFor = (name) => profileWindows[name] ?? DEFAULT_WINDOWS[name] ?? null
+
+  const runDayCheck = async () => {
+    const requestedFor = accountKey
+    const segments = []
+    const skipped = []
+    for (const name of profileNames) {
+      const w = windowFor(name)
+      const start = w && hhmmToMinutes(w[0])
+      const end = w && hhmmToMinutes(w[1])
+      if (start == null || end == null || start === end) {
+        skipped.push(name)
+        continue
+      }
+      const per = profiles[name] ?? {}
+      const sendAllocations = {}
+      for (const resource of RESOURCES) {
+        const usable = {}
+        for (const [vid, a] of Object.entries(per[resource] ?? {})) {
+          if (a.mode !== 'keep') usable[vid] = a
+        }
+        if (Object.keys(usable).length) sendAllocations[resource] = usable
+      }
+      segments.push({ name, window: [start, end], allocations: sendAllocations })
+    }
+    if (!segments.length) {
+      toast.error('No profile has hours set — give each profile its window first')
+      return
+    }
+    setDayChecking(true)
+    try {
+      const ceilings = {}
+      for (const [vid, value] of Object.entries(cropCeilings)) {
+        if (Number(value) > 0) ceilings[vid] = Number(value)
+      }
+      const res = await api.post('/distribution/day-check', {
+        snapshot: villages,
+        segments,
+        crop_ceilings: ceilings,
+      })
+      if (requestedFor !== currentAccountKey()) return
+      setDayCheck({ ...res.data, skipped })
+    } catch (err) {
+      toast.error(errorDetail(err, 'Full-day check failed'))
+    } finally {
+      setDayChecking(false)
+    }
+  }
+
   const switchProfile = (name) => {
     if (!profiles[name] || name === activeProfile) return
     setActiveProfile(name)
@@ -711,6 +828,37 @@ export default function ResourcePlanner() {
         >
           Delete
         </button>
+        {/* The hours this profile actually runs. Profiles are separate plans,
+            but the account lives through all of them every day; without hours
+            the full-day check cannot line them up. */}
+        <span className="flex items-center gap-1 text-xs text-secondary ml-1">
+          runs
+          <input
+            type="time"
+            aria-label={`${activeProfile} window start`}
+            className="input-field text-xs py-0.5 px-1 w-[74px]"
+            value={(windowFor(activeProfile) ?? ['', ''])[0]}
+            onChange={(e) =>
+              setProfileWindows((prev) => ({
+                ...prev,
+                [activeProfile]: [e.target.value, (windowFor(activeProfile) ?? ['', ''])[1]],
+              }))
+            }
+          />
+          –
+          <input
+            type="time"
+            aria-label={`${activeProfile} window end`}
+            className="input-field text-xs py-0.5 px-1 w-[74px]"
+            value={(windowFor(activeProfile) ?? ['', ''])[1]}
+            onChange={(e) =>
+              setProfileWindows((prev) => ({
+                ...prev,
+                [activeProfile]: [(windowFor(activeProfile) ?? ['', ''])[0], e.target.value],
+              }))
+            }
+          />
+        </span>
         <span className="text-secondary">
           each profile builds its own routes — switching is free (no request)
         </span>
@@ -756,6 +904,12 @@ export default function ResourcePlanner() {
                 <th className="text-left px-2">Net crop</th>
                 <th className="text-right px-2">Merchants</th>
                 <th className="text-right px-2">Trade Office</th>
+                <th
+                  className="text-right px-2"
+                  title="Alert when this village's crop stock would cross this level (e.g. your NPC trigger). Used by the full-day check."
+                >
+                  Crop alert
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -794,6 +948,23 @@ export default function ResourcePlanner() {
                         setTradeOffice((prev) => ({
                           ...prev,
                           [v.village_id]: e.target.value === '' ? undefined : Number(e.target.value),
+                        }))
+                      }
+                    />
+                  </td>
+                  <td className="text-right px-2">
+                    <input
+                      type="number"
+                      min="0"
+                      aria-label={`Crop stock alert level for ${v.name}`}
+                      placeholder="—"
+                      className="input-field w-24 text-right text-xs py-1"
+                      value={cropCeilings[v.village_id] ?? ''}
+                      onChange={(e) =>
+                        setCropCeilings((prev) => ({
+                          ...prev,
+                          [v.village_id]:
+                            e.target.value === '' ? undefined : Number(e.target.value),
                         }))
                       }
                     />
@@ -1030,6 +1201,7 @@ export default function ResourcePlanner() {
             {[
               ['village', 'Result by village'],
               ['edit', 'Edit by resource'],
+              ['fullday', 'Full day (all profiles)'],
             ].map(([key, label]) => (
               <button
                 key={key}
@@ -1061,7 +1233,10 @@ export default function ResourcePlanner() {
                     <th className="text-left py-1.5 px-2">Village</th>
                     {RESOURCES.map((resource) => (
                       <th key={resource} className="text-right px-3">
-                        {RESOURCE_LABEL[resource]}
+                        <span className="inline-flex items-center gap-1">
+                          <ResourceIcon resource={resource} />
+                          {RESOURCE_LABEL[resource]}
+                        </span>
                       </th>
                     ))}
                   </tr>
@@ -1159,6 +1334,128 @@ export default function ResourcePlanner() {
                 marks a village whose crop crosses from starving to surplus — e.g. −2,500/h own
                 +4,000/h shipped → 1,500/h). Bottom line: what ships in (+) or out (−) to make it
                 true. “rest” absorbs whatever the others leave unassigned.
+              </p>
+            </div>
+          )}
+
+          {allocView === 'fullday' && (
+            <div className="card p-4">
+              <div className="flex items-center justify-between flex-wrap gap-2 mb-2">
+                <div>
+                  <h3 className="font-semibold">The whole day, every profile in its hours</h3>
+                  <p className="text-secondary text-xs mt-0.5">
+                    Profiles are planned separately, but the account lives through all of them:
+                    what Day ships decides the stock Night starts from. This simulates the
+                    composite — net rates per window, production always on — and answers
+                    questions like “does 02 cross its crop alert at night?” with an hour on it.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="btn-primary text-xs py-1.5"
+                  disabled={dayChecking}
+                  onClick={runDayCheck}
+                >
+                  {dayChecking ? 'Simulating…' : dayCheck ? 'Re-run (0 requests)' : 'Run (0 requests)'}
+                </button>
+              </div>
+
+              {dayCheck?.skipped?.length > 0 && (
+                <p className="text-amber-300 text-xs mb-2">
+                  Skipped {dayCheck.skipped.join(', ')} — no hours set. Give each profile its
+                  window in the bar above.
+                </p>
+              )}
+
+              {dayCheck?.warnings?.length > 0 && (
+                <ul className="text-xs text-amber-300 list-disc list-inside mb-3 space-y-0.5">
+                  {dayCheck.warnings.map((w, i) => (
+                    <li key={i}>{w}</li>
+                  ))}
+                </ul>
+              )}
+              {dayCheck && dayCheck.warnings.length === 0 && (
+                <p className="text-success text-xs mb-3">
+                  No store crosses its cap, alert level or zero across the full day.
+                </p>
+              )}
+
+              {dayCheck && (
+                <table className="w-full text-xs">
+                  <thead className="text-secondary uppercase">
+                    <tr>
+                      <th className="text-left py-1 px-2">Village</th>
+                      <th className="text-right px-2">
+                        <span className="inline-flex items-center gap-1">
+                          <ResourceIcon resource="crop" />
+                          Crop now
+                        </span>
+                      </th>
+                      <th className="text-right px-2">Day swing (low → high)</th>
+                      <th className="text-right px-2">Drift/day</th>
+                      <th className="text-right px-2" title="Your alert level from the Snapshot tab">
+                        Alert at
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dayCheck.villages
+                      .filter((t) => t.resource === 'crop')
+                      .map((t) => {
+                        const ceiling = Number(cropCeilings[t.village_id]) || null
+                        const nearAlert = ceiling != null && t.high >= ceiling
+                        return (
+                          <tr
+                            key={t.village_id}
+                            className={`border-t border-gray-800 ${nearAlert ? 'bg-red-500/10' : ''}`}
+                          >
+                            <td className="py-1 px-2">{t.village_name}</td>
+                            <td className="text-right px-2 font-mono text-secondary">
+                              {fmt(
+                                villages.find((v) => v.village_id === t.village_id)?.crop_stock ?? 0
+                              )}
+                            </td>
+                            <td className="text-right px-2 font-mono">
+                              {fmt(t.low)} → {fmt(t.high)}
+                              {!t.settled && (
+                                <span
+                                  className="text-amber-300 ml-1"
+                                  title="Still drifting at the simulation horizon — the drift column is the story"
+                                >
+                                  ↗
+                                </span>
+                              )}
+                            </td>
+                            <td
+                              className={`text-right px-2 font-mono ${
+                                Math.abs(t.daily_net) < 1
+                                  ? 'text-secondary/60'
+                                  : t.daily_net > 0
+                                    ? 'text-amber-300'
+                                    : 'text-success'
+                              }`}
+                            >
+                              {signed(t.daily_net)}
+                            </td>
+                            <td className="text-right px-2 font-mono text-secondary">
+                              {ceiling != null ? fmt(ceiling) : '—'}
+                            </td>
+                          </tr>
+                        )
+                      })}
+                  </tbody>
+                </table>
+              )}
+              {!dayCheck && !dayChecking && (
+                <p className="text-secondary text-xs italic">
+                  Not run yet. It costs no game requests — everything comes from the snapshot you
+                  already hold.
+                </p>
+              )}
+              <p className="text-secondary text-[11px] mt-2">
+                Approximation, stated plainly: each profile contributes its plan’s net rates, not
+                discrete batches — route phases don’t survive a profile switch. The per-profile
+                batch-level overflow check still runs when you build each plan.
               </p>
             </div>
           )}
@@ -1387,9 +1684,19 @@ export default function ResourcePlanner() {
                               row.destination)}
                         </td>
                         <td className="px-2 font-mono">
-                          {Object.entries(row.cargo)
-                            .map(([r, v]) => `${RESOURCE_LABEL[r]} ${v.toLocaleString()}`)
-                            .join(' · ')}
+                          {/* Always all four, in the marketplace's order, zeros
+                              included -- the sheet is copied into the game's
+                              trade-route dialog field by field. */}
+                          <span className="inline-flex items-center gap-2 whitespace-nowrap">
+                            {RESOURCES.map((r) => (
+                              <span key={r} className="inline-flex items-center gap-1">
+                                <ResourceIcon resource={r} />
+                                <span className={row.cargo[r] ? '' : 'text-secondary/50'}>
+                                  {(row.cargo[r] ?? 0).toLocaleString()}
+                                </span>
+                              </span>
+                            ))}
+                          </span>
                         </td>
                         <td className="text-right px-2 font-mono">{row.cycle_hours}h</td>
                         <td className="text-right px-2 font-mono">{row.dispatch}</td>

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -126,6 +126,14 @@ export default function ResourcePlanner() {
     [accountKey]
   )
 
+  // The live account key, read from the store at call time — NOT the render
+  // closure. An async response must compare against the account that is
+  // current when it lands, or the guard sees its own stale captured value.
+  const currentAccountKey = useCallback(() => {
+    const s = useGameStore.getState()
+    return s.serverUrl && s.playerName ? `${s.serverUrl}|${s.playerName}` : null
+  }, [])
+
   useEffect(() => {
     if (!accountKey) {
       // Disconnected: the page stays routable, so showing (or planning from)
@@ -163,7 +171,7 @@ export default function ResourcePlanner() {
     setFetching(true)
     try {
       const res = await api.get('/distribution/snapshot', { timeout: 0 })
-      if (requestedFor !== accountKey) return
+      if (requestedFor !== currentAccountKey()) return
       setSnapshot(res.data)
       saveJson(`${LS_SNAPSHOT}::${requestedFor}`, res.data)
       setPlan(null)
@@ -224,7 +232,7 @@ export default function ResourcePlanner() {
         })),
         allocations: sendAllocations,
       })
-      if (requestedFor !== accountKey) return
+      if (requestedFor !== currentAccountKey()) return
       setPlan(res.data)
       setStage('plan')
     } catch (err) {
@@ -232,7 +240,7 @@ export default function ResourcePlanner() {
     } finally {
       setPlanning(false)
     }
-  }, [villages, tradeOffice, allocations, toast, accountKey])
+  }, [villages, tradeOffice, allocations, toast, accountKey, currentAccountKey])
 
   // Live unallocated counter, so slack is visible while typing rather than
   // discovered later (profile known issue #9).

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -166,7 +166,7 @@ const signed = (n) => (n == null ? '—' : `${n > 0 ? '+' : ''}${Math.round(n).t
 function CropCell({ village }) {
   if (village.crop_per_hour == null) {
     return (
-      <span className="text-orange-200" title="Rate could not be derived — not treated as zero">
+      <span className="text-warning" title="Rate could not be derived — not treated as zero">
         unknown
       </span>
     )
@@ -229,7 +229,7 @@ function BudgetBar({ budget }) {
       {open && (
         <div className="mt-1 mb-2 ml-2 pl-3 border-l border-gray-700">
           {budget.explanation && (
-            <p className="text-xs text-orange-200 mb-1">{budget.explanation}</p>
+            <p className="text-xs text-warning mb-1">{budget.explanation}</p>
           )}
           <table className="text-xs w-full max-w-2xl">
             <thead className="text-secondary uppercase">
@@ -920,8 +920,10 @@ export default function ResourcePlanner() {
             {villages.length ? `${villages.length} villages` : 'no snapshot yet'}
           </span>
           {snapshot && (
-            <span className={`text-xs ${snapshotStale ? 'text-orange-200' : 'text-secondary'}`}>
+            <span className={`text-xs ${snapshotStale ? 'text-warning' : 'text-secondary'}`}>
+              {/* "stale" in words, so freshness is not signalled by colour alone. */}
               · {snapshotAgeLabel}
+              {snapshotStale && ' · stale'}
             </span>
           )}
           {/* Every fetch is priced in the label — requests are the scarce
@@ -940,8 +942,8 @@ export default function ResourcePlanner() {
       </div>
 
       {snapshotStale && (
-        <div className="card p-3 mb-4 border border-orange-200/40">
-          <p className="text-orange-200 text-xs">
+        <div className="card p-3 mb-4 border border-warning">
+          <p className="text-warning text-xs">
             This snapshot is {snapshotAgeLabel}
             {snapshotFetchedAt == null && ' (restored from a previous session)'} — production,
             stocks and free merchants may have changed. Fetch fresh state before building, or
@@ -1137,11 +1139,18 @@ export default function ResourcePlanner() {
             </tbody>
           </table>
           {snapshot?.warnings?.length > 0 && (
-            <ul className="mt-3 text-xs text-orange-200 list-disc list-inside">
-              {snapshot.warnings.map((w, i) => (
-                <li key={i}>{w}</li>
-              ))}
-            </ul>
+            <div className="mt-3">
+              {/* Explicit label so "this is a warning" is not carried by colour
+                  alone (and is announced by screen readers). */}
+              <p className="text-xs text-warning font-semibold">
+                ⚠ Warnings ({snapshot.warnings.length})
+              </p>
+              <ul className="text-xs text-warning list-disc list-inside">
+                {snapshot.warnings.map((w, i) => (
+                  <li key={i}>{w}</li>
+                ))}
+              </ul>
+            </div>
           )}
 
           {/* World + merchant model. Capacity is server-calibrated and speed
@@ -1355,7 +1364,7 @@ export default function ResourcePlanner() {
                         <td className="px-2 text-right whitespace-nowrap">
                           {incomplete && (
                             <span
-                              className="text-orange-200 mr-2"
+                              className="text-warning mr-2"
                               title="Needs a name and a crop rate before the planner uses it"
                             >
                               draft
@@ -1396,7 +1405,7 @@ export default function ResourcePlanner() {
                 aria-pressed={allocView === key}
                 className={`text-xs px-3 py-1.5 rounded border transition-colors ${
                   allocView === key
-                    ? 'border-violet-400/60 bg-violet-400/15 text-violet-200'
+                    ? 'border-violet-400/60 bg-violet-400/15 text-info'
                     : 'border-gray-700 text-secondary hover:text-white hover:border-gray-500'
                 }`}
                 onClick={() => setAllocView(key)}
@@ -1480,7 +1489,7 @@ export default function ResourcePlanner() {
                                 `${fmt(after)}/h`
                               )}
                               {isRest && (
-                                <span className="ml-1 text-[10px] uppercase text-violet-300/80 font-sans">
+                                <span className="ml-1 text-[10px] uppercase text-info/80 font-sans">
                                   rest
                                 </span>
                               )}
@@ -1493,7 +1502,7 @@ export default function ResourcePlanner() {
                                   ? 'text-secondary/60'
                                   : ship > 0
                                     ? 'text-success'
-                                    : 'text-orange-200'
+                                    : 'text-warning'
                               }`}
                             >
                               {ship == null ? '—' : Math.abs(ship) < 1 ? '·' : signed(ship)}
@@ -1548,18 +1557,23 @@ export default function ResourcePlanner() {
               </div>
 
               {dayCheck?.skipped?.length > 0 && (
-                <p className="text-orange-200 text-xs mb-2">
+                <p className="text-warning text-xs mb-2">
                   Skipped {dayCheck.skipped.join(', ')} — no hours set. Give each profile its
                   window in the bar above.
                 </p>
               )}
 
               {dayCheck?.warnings?.length > 0 && (
-                <ul className="text-xs text-orange-200 list-disc list-inside mb-3 space-y-0.5">
-                  {dayCheck.warnings.map((w, i) => (
-                    <li key={i}>{w}</li>
-                  ))}
-                </ul>
+                <div className="mb-3">
+                  <p className="text-xs text-warning font-semibold">
+                    ⚠ Warnings ({dayCheck.warnings.length})
+                  </p>
+                  <ul className="text-xs text-warning list-disc list-inside space-y-0.5">
+                    {dayCheck.warnings.map((w, i) => (
+                      <li key={i}>{w}</li>
+                    ))}
+                  </ul>
+                </div>
               )}
               {dayCheck && dayCheck.warnings.length === 0 && (
                 <p className="text-success text-xs mb-3">
@@ -1606,7 +1620,7 @@ export default function ResourcePlanner() {
                               {fmt(t.low)} → {fmt(t.high)}
                               {!t.settled && (
                                 <span
-                                  className="text-orange-200 ml-1"
+                                  className="text-warning ml-1"
                                   title="Still drifting at the simulation horizon — the drift column is the story"
                                 >
                                   ↗
@@ -1622,7 +1636,7 @@ export default function ResourcePlanner() {
                                 // starving.
                                 Math.abs(t.daily_net) < 1
                                   ? 'text-secondary/60'
-                                  : 'text-orange-200'
+                                  : 'text-warning'
                               }`}
                             >
                               {signed(t.daily_net)}
@@ -1678,6 +1692,15 @@ export default function ResourcePlanner() {
                     </div>
                   </div>
                 </div>
+                {/* On a phone this editor is wider than the viewport. The village
+                    column is pinned (see .sticky-col) so every field stays
+                    attributable to the right village while the rest scrolls, and
+                    the hint below tells the operator the extra columns exist —
+                    clipping them silently is how the wrong village gets edited. */}
+                <p className="text-secondary text-xs mb-1 sm:hidden">
+                  Swipe the table sideways for Mode, Value, Ship/h and Rest — the village column
+                  stays pinned.
+                </p>
                 <div className="overflow-x-auto">
                   <table className="w-full text-xs">
                     <thead className="text-secondary uppercase">
@@ -1693,7 +1716,7 @@ export default function ResourcePlanner() {
                             onChange={() => toggleSelectAll(resource)}
                           />
                         </th>
-                        <th className="text-left py-1 px-2">Village</th>
+                        <th className="text-left py-1 px-2 sticky-col">Village</th>
                         <th className="text-right px-2">Own/h</th>
                         <th className="text-left px-2">Mode</th>
                         <th className="text-right px-2">Value</th>
@@ -1719,7 +1742,7 @@ export default function ResourcePlanner() {
                         return (
                           <tr
                             key={v.village_id}
-                            className={`group border-t border-gray-800 hover:bg-white/5 focus-within:bg-violet-400/15 transition-colors ${
+                            className={`group touch-target border-t border-gray-800 hover:bg-white/5 focus-within:bg-violet-400/15 transition-colors ${
                               isSelected(resource, v.village_id) ? 'bg-violet-400/10' : ''
                             }`}
                           >
@@ -1731,7 +1754,7 @@ export default function ResourcePlanner() {
                                 onChange={() => toggleSelected(resource, v.village_id)}
                               />
                             </td>
-                            <td className="py-1 px-2">{v.name}</td>
+                            <td className="py-1 px-2 sticky-col">{v.name}</td>
                             <td className="text-right px-2 font-mono text-secondary">
                               {own == null ? '—' : signed(own)}
                             </td>
@@ -1774,7 +1797,7 @@ export default function ResourcePlanner() {
                                   : ship > 0
                                     ? 'text-success'
                                     : ship < 0
-                                      ? 'text-orange-200'
+                                      ? 'text-warning'
                                       : 'text-secondary'
                               }`}
                             >
@@ -1927,7 +1950,7 @@ export default function ResourcePlanner() {
 
               {plan.warnings.length > 0 && (
                 <div className="card p-4">
-                  <h3 className="font-semibold mb-2 text-orange-200">
+                  <h3 className="font-semibold mb-2 text-warning">
                     Warnings ({plan.warnings.length})
                   </h3>
                   <ul className="text-xs list-disc list-inside space-y-0.5 max-h-64 overflow-y-auto">

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -342,7 +342,11 @@ export default function ResourcePlanner() {
         speed_fields_per_hour:
           Number(merchantModel.speed_fields_per_hour) || snapshot?.speed_fields_per_hour,
         merchant_base_capacity: Number(merchantModel.base_capacity) || undefined,
-        trade_office_bonus_per_level: Number(merchantModel.bonus_per_to_level) || undefined,
+        // A per-level bonus of 0 is valid (a world with no Trade Office scaling),
+        // so preserve it — `|| undefined` would drop it and use the 0.2 default.
+        trade_office_bonus_per_level: Number.isFinite(Number(merchantModel.bonus_per_to_level))
+          ? Number(merchantModel.bonus_per_to_level)
+          : undefined,
       })
       if (requestedFor !== currentAccountKey()) return
       setPlan(res.data)

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -655,9 +655,9 @@ export default function ResourcePlanner() {
               {villages.map((v) => (
                 <tr
                   key={v.village_id}
-                  className="border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/10 transition-colors"
+                  className="group border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/15 transition-colors"
                 >
-                  <td className="py-1.5 px-2">
+                  <td className="py-1.5 px-2 border-l-2 border-l-transparent group-focus-within:border-l-amber-400">
                     {v.name}{' '}
                     <span className="text-secondary text-xs">
                       ({v.x}|{v.y})
@@ -839,11 +839,11 @@ export default function ResourcePlanner() {
                         return (
                           <tr
                             key={v.village_id}
-                            className={`border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/10 transition-colors ${
+                            className={`group border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/15 transition-colors ${
                               isSelected(resource, v.village_id) ? 'bg-amber-400/5' : ''
                             }`}
                           >
-                            <td className="text-center px-2">
+                            <td className="text-center px-2 border-l-2 border-l-transparent group-focus-within:border-l-amber-400">
                               <input
                                 type="checkbox"
                                 aria-label={`Select ${v.name} for batch edit`}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -244,10 +244,12 @@ export default function ResourcePlanner() {
           trade_office_level: Number(tradeOffice[v.village_id] ?? 0),
         })),
         allocations: sendAllocations,
-        // Geometry comes from the snapshot (map span + tribe-derived merchant
-        // speed); the merchant capacity model is the operator's calibration.
-        map_span: snapshot?.map_span,
-        speed_fields_per_hour: snapshot?.speed_fields_per_hour,
+        // Geometry defaults to the snapshot (map span + tribe-derived x1
+        // merchant speed) but the operator can override both for non-Europe 2
+        // worlds (x2/x3 speed, larger maps) — no extra Travian requests.
+        map_span: Number(merchantModel.map_span) || snapshot?.map_span,
+        speed_fields_per_hour:
+          Number(merchantModel.speed_fields_per_hour) || snapshot?.speed_fields_per_hour,
         merchant_base_capacity: Number(merchantModel.base_capacity) || undefined,
         trade_office_bonus_per_level: Number(merchantModel.bonus_per_to_level) || undefined,
       })
@@ -442,17 +444,11 @@ export default function ResourcePlanner() {
             </ul>
           )}
 
-          {/* Merchant model: speed is tribe-derived server-side (shown, not
-              editable); capacity is server-calibrated, so the operator sets it. */}
+          {/* World + merchant model. Capacity is server-calibrated and speed
+              defaults to the tribe's x1 value; both — plus map span — are
+              overridable for non-Europe 2 worlds without spending a request. */}
           <div className="mt-4 flex items-center gap-4 flex-wrap text-xs border-t border-gray-800 pt-3">
-            <span className="text-secondary uppercase">Merchant model</span>
-            <span className="text-secondary">
-              Speed:{' '}
-              <span className="font-mono text-white">
-                {snapshot?.speed_fields_per_hour ?? '—'}
-              </span>{' '}
-              fields/h (from tribe)
-            </span>
+            <span className="text-secondary uppercase">World &amp; merchants</span>
             <label className="flex items-center gap-1">
               <span className="text-secondary">Base capacity</span>
               <input
@@ -477,6 +473,40 @@ export default function ResourcePlanner() {
                 value={merchantModel.bonus_per_to_level}
                 onChange={(e) =>
                   setMerchantModel((m) => ({ ...m, bonus_per_to_level: Number(e.target.value) }))
+                }
+              />
+            </label>
+            <label className="flex items-center gap-1">
+              <span className="text-secondary">Speed f/h</span>
+              <input
+                type="number"
+                min="1"
+                aria-label="Merchant speed fields per hour override"
+                placeholder={String(snapshot?.speed_fields_per_hour ?? '')}
+                className="input-field w-20 text-right py-1"
+                value={merchantModel.speed_fields_per_hour ?? ''}
+                onChange={(e) =>
+                  setMerchantModel((m) => ({
+                    ...m,
+                    speed_fields_per_hour: e.target.value === '' ? undefined : Number(e.target.value),
+                  }))
+                }
+              />
+            </label>
+            <label className="flex items-center gap-1">
+              <span className="text-secondary">Map span</span>
+              <input
+                type="number"
+                min="1"
+                aria-label="Map span override"
+                placeholder={String(snapshot?.map_span ?? '')}
+                className="input-field w-20 text-right py-1"
+                value={merchantModel.map_span ?? ''}
+                onChange={(e) =>
+                  setMerchantModel((m) => ({
+                    ...m,
+                    map_span: e.target.value === '' ? undefined : Number(e.target.value),
+                  }))
                 }
               />
             </label>

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -142,15 +142,16 @@ function BudgetBar({ budget }) {
   )
 }
 
-/** Batch-set one resource's mode/value across every village at once, so a
- *  common allocation (e.g. everyone Keep own, or everyone Absolute 5000) does
- *  not have to be typed row by row. The remainder village keeps its role. */
-function BatchSet({ onApply }) {
+/** Batch-set the mode/value of the CHECKED villages for one resource, so a
+ *  common allocation does not have to be typed row by row. Select rows with
+ *  the checkboxes (or the header select-all); the remainder village keeps its
+ *  role. Disabled until at least one village is checked. */
+function BatchSet({ count, onApply }) {
   const [mode, setMode] = useState('keep')
   const [value, setValue] = useState(0)
   return (
     <div className="flex items-center gap-1 text-xs">
-      <span className="text-secondary">Set all</span>
+      <span className="text-secondary">Set checked</span>
       <select
         aria-label="Batch mode"
         className="input-field text-xs py-0.5"
@@ -171,8 +172,12 @@ function BatchSet({ onApply }) {
         value={value}
         onChange={(e) => setValue(Number(e.target.value))}
       />
-      <button className="btn-secondary btn-xs" onClick={() => onApply(mode, value)}>
-        Apply
+      <button
+        className="btn-secondary btn-xs"
+        disabled={!count}
+        onClick={() => onApply(mode, value)}
+      >
+        Apply to {count} selected
       </button>
     </div>
   )
@@ -392,13 +397,42 @@ export default function ResourcePlanner() {
     })
   }
 
-  // Apply one mode/value to every village for a resource in a single edit.
-  // The remainder village keeps its role (it is set via the Rest radio, not a
-  // mode), so a batch set never silently clears the slack destination.
-  const setAllForResource = (resource, mode, value) => {
+  // Per-resource checkbox selection for batch edits: { [resource]: number[] }.
+  const [selected, setSelected] = useState({})
+  const isSelected = (resource, vid) => (selected[resource] ?? []).includes(vid)
+  const someSelected = (resource) => (selected[resource] ?? []).length > 0
+  const allSelected = (resource) =>
+    villages.length > 0 && (selected[resource] ?? []).length === villages.length
+
+  const toggleSelected = (resource, vid) => {
+    setSelected((prev) => {
+      const cur = new Set(prev[resource] ?? [])
+      if (cur.has(vid)) cur.delete(vid)
+      else cur.add(vid)
+      return { ...prev, [resource]: [...cur] }
+    })
+  }
+
+  const toggleSelectAll = (resource) => {
+    setSelected((prev) => ({
+      ...prev,
+      [resource]: allSelected(resource) ? [] : villages.map((v) => v.village_id),
+    }))
+  }
+
+  // Apply one mode/value to the CHECKED villages for a resource. The remainder
+  // village keeps its role (set via the Rest radio, not a mode), so a batch
+  // edit never silently clears the slack destination.
+  const applyToSelected = (resource, mode, value) => {
+    const ids = new Set(selected[resource] ?? [])
+    if (!ids.size) {
+      toast.error('Check the villages to set first')
+      return
+    }
     setAllocations((prev) => {
       const per = { ...(prev[resource] ?? {}) }
       for (const v of villages) {
+        if (!ids.has(v.village_id)) continue
         if (per[v.village_id]?.mode === 'remainder') continue
         per[v.village_id] = { mode, value: Number(value) || 0 }
       }
@@ -615,7 +649,7 @@ export default function ResourcePlanner() {
               {villages.map((v) => (
                 <tr
                   key={v.village_id}
-                  className="border-t border-gray-800 hover:bg-white/5 transition-colors"
+                  className="border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/10 transition-colors"
                 >
                   <td className="py-1.5 px-2">
                     {v.name}{' '}
@@ -744,7 +778,10 @@ export default function ResourcePlanner() {
                 <div className="flex justify-between items-baseline mb-2 flex-wrap gap-2">
                   <h3 className="font-semibold">{RESOURCE_LABEL[resource]}</h3>
                   <div className="flex items-center gap-3 flex-wrap">
-                    <BatchSet onApply={(mode, value) => setAllForResource(resource, mode, value)} />
+                    <BatchSet
+                      count={(selected[resource] ?? []).length}
+                      onApply={(mode, value) => applyToSelected(resource, mode, value)}
+                    />
                     <div className="text-xs">
                       <span className="text-secondary">
                         total {fmt(totals[resource].total)}/h
@@ -763,6 +800,17 @@ export default function ResourcePlanner() {
                   <table className="w-full text-xs">
                     <thead className="text-secondary uppercase">
                       <tr>
+                        <th className="text-center px-2">
+                          <input
+                            type="checkbox"
+                            aria-label="Select all villages"
+                            checked={allSelected(resource)}
+                            ref={(el) => {
+                              if (el) el.indeterminate = someSelected(resource) && !allSelected(resource)
+                            }}
+                            onChange={() => toggleSelectAll(resource)}
+                          />
+                        </th>
                         <th className="text-left py-1 px-2">Village</th>
                         <th className="text-right px-2">Own/h</th>
                         <th className="text-left px-2">Mode</th>
@@ -785,8 +833,18 @@ export default function ResourcePlanner() {
                         return (
                           <tr
                             key={v.village_id}
-                            className="border-t border-gray-800 hover:bg-white/5 transition-colors"
+                            className={`border-t border-gray-800 hover:bg-white/5 focus-within:bg-amber-400/10 transition-colors ${
+                              isSelected(resource, v.village_id) ? 'bg-amber-400/5' : ''
+                            }`}
                           >
+                            <td className="text-center px-2">
+                              <input
+                                type="checkbox"
+                                aria-label={`Select ${v.name} for batch edit`}
+                                checked={isSelected(resource, v.village_id)}
+                                onChange={() => toggleSelected(resource, v.village_id)}
+                              />
+                            </td>
                             <td className="py-1 px-2">{v.name}</td>
                             <td className="text-right px-2 font-mono text-secondary">
                               {own == null ? '—' : signed(own)}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -142,11 +142,51 @@ function BudgetBar({ budget }) {
   )
 }
 
+/** Batch-set one resource's mode/value across every village at once, so a
+ *  common allocation (e.g. everyone Keep own, or everyone Absolute 5000) does
+ *  not have to be typed row by row. The remainder village keeps its role. */
+function BatchSet({ onApply }) {
+  const [mode, setMode] = useState('keep')
+  const [value, setValue] = useState(0)
+  return (
+    <div className="flex items-center gap-1 text-xs">
+      <span className="text-secondary">Set all</span>
+      <select
+        aria-label="Batch mode"
+        className="input-field text-xs py-0.5"
+        value={mode}
+        onChange={(e) => setMode(e.target.value)}
+      >
+        {MODES.map((m) => (
+          <option key={m.value} value={m.value}>
+            {m.label}
+          </option>
+        ))}
+      </select>
+      <input
+        type="number"
+        aria-label="Batch value"
+        className="input-field w-20 text-right text-xs py-0.5"
+        disabled={mode === 'keep'}
+        value={value}
+        onChange={(e) => setValue(Number(e.target.value))}
+      />
+      <button className="btn-secondary btn-xs" onClick={() => onApply(mode, value)}>
+        Apply
+      </button>
+    </div>
+  )
+}
+
 export default function ResourcePlanner() {
   const toast = useToast()
   const serverUrl = useGameStore((s) => s.serverUrl)
   const playerName = useGameStore((s) => s.playerName)
-  const accountKey = serverUrl && playerName ? `${serverUrl}|${playerName}` : null
+  // Normalize the server URL (strip trailing slashes) so the per-account cache
+  // key is STABLE across reconnects — otherwise a slash difference would look
+  // like a new account and silently drop cached Trade Office levels, profiles,
+  // and the merchant model.
+  const accountKey = serverUrl && playerName ? `${serverUrl.replace(/\/+$/, '')}|${playerName}` : null
   const [stage, setStage] = useState('snapshot')
   const [snapshot, setSnapshot] = useState(null)
   const [tradeOffice, setTradeOffice] = useState({})
@@ -184,7 +224,9 @@ export default function ResourcePlanner() {
   // current when it lands, or the guard sees its own stale captured value.
   const currentAccountKey = useCallback(() => {
     const s = useGameStore.getState()
-    return s.serverUrl && s.playerName ? `${s.serverUrl}|${s.playerName}` : null
+    return s.serverUrl && s.playerName
+      ? `${s.serverUrl.replace(/\/+$/, '')}|${s.playerName}`
+      : null
   }, [])
 
   useEffect(() => {
@@ -342,6 +384,20 @@ export default function ResourcePlanner() {
     setAllocations((prev) => {
       const per = { ...(prev[resource] ?? {}) }
       per[villageId] = { mode: 'keep', value: 0, ...(per[villageId] ?? {}), ...patch }
+      return { ...prev, [resource]: per }
+    })
+  }
+
+  // Apply one mode/value to every village for a resource in a single edit.
+  // The remainder village keeps its role (it is set via the Rest radio, not a
+  // mode), so a batch set never silently clears the slack destination.
+  const setAllForResource = (resource, mode, value) => {
+    setAllocations((prev) => {
+      const per = { ...(prev[resource] ?? {}) }
+      for (const v of villages) {
+        if (per[v.village_id]?.mode === 'remainder') continue
+        per[v.village_id] = { mode, value: Number(value) || 0 }
+      }
       return { ...prev, [resource]: per }
     })
   }
@@ -553,7 +609,10 @@ export default function ResourcePlanner() {
             </thead>
             <tbody>
               {villages.map((v) => (
-                <tr key={v.village_id} className="border-t border-gray-800">
+                <tr
+                  key={v.village_id}
+                  className="border-t border-gray-800 hover:bg-white/5 transition-colors"
+                >
                   <td className="py-1.5 px-2">
                     {v.name}{' '}
                     <span className="text-secondary text-xs">
@@ -680,17 +739,20 @@ export default function ResourcePlanner() {
               <div key={resource} className="card p-4">
                 <div className="flex justify-between items-baseline mb-2 flex-wrap gap-2">
                   <h3 className="font-semibold">{RESOURCE_LABEL[resource]}</h3>
-                  <div className="text-xs">
-                    <span className="text-secondary">
-                      total {fmt(totals[resource].total)}/h
-                      {!totals[resource].known && ' (some villages unknown)'} ·{' '}
-                    </span>
-                    <span className={settled ? 'text-success' : 'text-danger'}>
-                      {fmt(slack)}/h unassigned
-                      {remainder != null
-                        ? ` → village ${remainder}`
-                        : ' · no remainder village set'}
-                    </span>
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <BatchSet onApply={(mode, value) => setAllForResource(resource, mode, value)} />
+                    <div className="text-xs">
+                      <span className="text-secondary">
+                        total {fmt(totals[resource].total)}/h
+                        {!totals[resource].known && ' (some villages unknown)'} ·{' '}
+                      </span>
+                      <span className={settled ? 'text-success' : 'text-danger'}>
+                        {fmt(slack)}/h unassigned
+                        {remainder != null
+                          ? ` → village ${remainder}`
+                          : ' · no remainder village set'}
+                      </span>
+                    </div>
                   </div>
                 </div>
                 <div className="overflow-x-auto">
@@ -717,7 +779,10 @@ export default function ResourcePlanner() {
                           target = own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
                         const ship = a.mode === 'remainder' ? null : target - (own ?? 0)
                         return (
-                          <tr key={v.village_id} className="border-t border-gray-800">
+                          <tr
+                            key={v.village_id}
+                            className="border-t border-gray-800 hover:bg-white/5 transition-colors"
+                          >
                             <td className="py-1 px-2">{v.name}</td>
                             <td className="text-right px-2 font-mono text-secondary">
                               {own == null ? '—' : signed(own)}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -249,6 +249,11 @@ export default function ResourcePlanner() {
   // and the merchant model.
   const accountKey = serverUrl && playerName ? `${serverUrl.replace(/\/+$/, '')}|${playerName}` : null
   const [stage, setStage] = useState('snapshot')
+  // Allocate stage has two views: the per-resource editor, and a read-only
+  // result grid grouped by village showing what each ends up with. Grouping by
+  // material is how the targets are EDITED; grouped by village is how the
+  // operator actually thinks about the outcome.
+  const [allocView, setAllocView] = useState('village')
   const [snapshot, setSnapshot] = useState(null)
   const [tradeOffice, setTradeOffice] = useState({})
   const [profiles, setProfiles] = useState({ [DEFAULT_PROFILE]: {} })
@@ -489,6 +494,19 @@ export default function ResourcePlanner() {
       per[villageId] = { mode: 'keep', value: 0, ...(per[villageId] ?? {}), ...patch }
       return { ...prev, [resource]: per }
     })
+  }
+
+  // What a village ends up retaining per hour after the plan runs -- the same
+  // resolution the backend applies, so the grid never disagrees with the plan.
+  const targetFor = (resource, v) => {
+    const own = v[`${resource}_per_hour`]
+    const a = allocations[resource]?.[v.village_id] ?? { mode: 'keep', value: 0 }
+    if (a.mode === 'remainder') return explicitTotal(resource)
+    if (own == null) return a.mode === 'absolute' ? Number(a.value) || 0 : null
+    if (a.mode === 'absolute') return Number(a.value) || 0
+    if (a.mode === 'percentage') return (totals[resource].total * (Number(a.value) || 0)) / 100
+    if (a.mode === 'sustain') return own < 0 ? (-own * (Number(a.value) || 0)) / 100 : own
+    return own // keep
   }
 
   const isSelected = (resource, vid) => (selected[resource] ?? []).includes(vid)
@@ -1005,7 +1023,123 @@ export default function ResourcePlanner() {
 
       {stage === 'allocate' && villages.length > 0 && (
         <div className="space-y-4">
-          {RESOURCES.map((resource) => {
+          <div className="flex items-center gap-2">
+            {[
+              ['village', 'Result by village'],
+              ['edit', 'Edit by resource'],
+            ].map(([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                aria-pressed={allocView === key}
+                className={`text-xs px-3 py-1.5 rounded border transition-colors ${
+                  allocView === key
+                    ? 'border-amber-400/60 bg-amber-400/15 text-amber-200'
+                    : 'border-gray-700 text-secondary hover:text-white hover:border-gray-500'
+                }`}
+                onClick={() => setAllocView(key)}
+              >
+                {label}
+              </button>
+            ))}
+            {allocView === 'village' && (
+              <span className="text-secondary text-xs ml-2">
+                What each village keeps per hour once the routes run. Edit the targets in the
+                other view.
+              </span>
+            )}
+          </div>
+
+          {allocView === 'village' && (
+            <div className="card p-4 overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead className="text-secondary uppercase">
+                  <tr>
+                    <th className="text-left py-1.5 px-2">Village</th>
+                    {RESOURCES.map((resource) => (
+                      <th key={resource} className="text-right px-3">
+                        {RESOURCE_LABEL[resource]}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {villages.map((v) => (
+                    <tr
+                      key={v.village_id}
+                      className="border-t border-gray-800 hover:bg-white/5 transition-colors"
+                    >
+                      <td className="py-1.5 px-2 whitespace-nowrap">
+                        {v.name}{' '}
+                        <span className="text-secondary text-[11px]">
+                          ({v.x}|{v.y})
+                        </span>
+                      </td>
+                      {RESOURCES.map((resource) => {
+                        const own = v[`${resource}_per_hour`]
+                        const after = targetFor(resource, v)
+                        const ship = after == null || own == null ? null : after - own
+                        const isRest = remainderFor(resource) === v.village_id
+                        return (
+                          <td key={resource} className="text-right px-3 py-1.5 align-top">
+                            <div
+                              className={`font-mono ${
+                                after == null
+                                  ? 'text-secondary'
+                                  : after < 0
+                                    ? 'text-danger'
+                                    : ''
+                              }`}
+                              title={own == null ? 'own production unknown' : `own ${fmt(own)}/h`}
+                            >
+                              {after == null ? '?' : `${fmt(after)}/h`}
+                              {isRest && (
+                                <span className="ml-1 text-[10px] uppercase text-amber-300/80 font-sans">
+                                  rest
+                                </span>
+                              )}
+                            </div>
+                            {/* The delta is the cargo: what must arrive (+) or
+                                leave (−) to make the retention true. */}
+                            <div
+                              className={`text-[11px] font-mono ${
+                                ship == null || Math.abs(ship) < 1
+                                  ? 'text-secondary/60'
+                                  : ship > 0
+                                    ? 'text-success'
+                                    : 'text-amber-300'
+                              }`}
+                            >
+                              {ship == null ? '—' : Math.abs(ship) < 1 ? '·' : signed(ship)}
+                            </div>
+                          </td>
+                        )
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+                <tfoot>
+                  <tr className="border-t border-gray-700 text-secondary">
+                    <td className="py-1.5 px-2 uppercase text-[11px]">Account total</td>
+                    {RESOURCES.map((resource) => (
+                      <td key={resource} className="text-right px-3 font-mono">
+                        {fmt(totals[resource].total)}/h
+                        {!totals[resource].known && ' ?'}
+                      </td>
+                    ))}
+                  </tr>
+                </tfoot>
+              </table>
+              <p className="text-secondary text-[11px] mt-2">
+                Top line: retention after distribution (red = still negative). Bottom line: what
+                ships in (+) or out (−) to make it true. “rest” absorbs whatever the others leave
+                unassigned.
+              </p>
+            </div>
+          )}
+
+          {allocView === 'edit' &&
+            RESOURCES.map((resource) => {
             const slack = explicitTotal(resource)
             const remainder = remainderFor(resource)
             const settled = Math.abs(slack) < 1 || remainder != null
@@ -1147,7 +1281,7 @@ export default function ResourcePlanner() {
                 </div>
               </div>
             )
-          })}
+            })}
         </div>
       )}
 

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -1489,7 +1489,7 @@ export default function ResourcePlanner() {
                                 `${fmt(after)}/h`
                               )}
                               {isRest && (
-                                <span className="ml-1 text-[10px] uppercase text-info/80 font-sans">
+                                <span className="ml-1 text-[10px] uppercase text-info font-sans">
                                   rest
                                 </span>
                               )}

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -156,11 +156,16 @@ export default function ResourcePlanner() {
   const villages = useMemo(() => snapshot?.villages ?? [], [snapshot])
 
   const fetchSnapshot = async () => {
+    // The account can change mid-request (switch/disconnect); a response that
+    // lands afterwards must not overwrite the new account's state with the old
+    // account's villages.
+    const requestedFor = accountKey
     setFetching(true)
     try {
       const res = await api.get('/distribution/snapshot', { timeout: 0 })
+      if (requestedFor !== accountKey) return
       setSnapshot(res.data)
-      saveJson(storageKey(LS_SNAPSHOT), res.data)
+      saveJson(`${LS_SNAPSHOT}::${requestedFor}`, res.data)
       setPlan(null)
       // Villages get lost, chiefed or renamed between fetches; allocations kept
       // for ids no longer in the snapshot would fail every future plan call.
@@ -192,6 +197,9 @@ export default function ResourcePlanner() {
       toast.error('Fetch account state first')
       return
     }
+    // Guard against the account changing mid-request: a plan built from
+    // account A's snapshot must not be presented under account B.
+    const requestedFor = accountKey
     setPlanning(true)
     try {
       // Send only entries the planner can act on: `keep` equals the backend
@@ -216,6 +224,7 @@ export default function ResourcePlanner() {
         })),
         allocations: sendAllocations,
       })
+      if (requestedFor !== accountKey) return
       setPlan(res.data)
       setStage('plan')
     } catch (err) {
@@ -223,7 +232,7 @@ export default function ResourcePlanner() {
     } finally {
       setPlanning(false)
     }
-  }, [villages, tradeOffice, allocations, toast])
+  }, [villages, tradeOffice, allocations, toast, accountKey])
 
   // Live unallocated counter, so slack is visible while typing rather than
   // discovered later (profile known issue #9).

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -340,6 +340,10 @@ export default function ResourcePlanner() {
   // from a stale one (see SNAPSHOT_TTL_MS).
   const [snapshotFetchedAt, setSnapshotFetchedAt] = useState(null)
   const [useStaleSnapshot, setUseStaleSnapshot] = useState(false)
+  // Staleness is derived from the clock, but time passing does not re-render
+  // React — so `nowMs` is bumped by a timer that fires exactly when the current
+  // snapshot crosses the TTL, engaging the gate even if the page just sits open.
+  const [nowMs, setNowMs] = useState(() => Date.now())
   const [tradeOffice, setTradeOffice] = useState({})
   const [profiles, setProfiles] = useState({ [DEFAULT_PROFILE]: {} })
   const [activeProfile, setActiveProfile] = useState(DEFAULT_PROFILE)
@@ -387,6 +391,21 @@ export default function ResourcePlanner() {
       ? `${s.serverUrl.replace(/\/+$/, '')}|${s.playerName}`
       : null
   }, [])
+
+  // Fire a re-render exactly when the current snapshot crosses the freshness TTL,
+  // so the stale banner appears and Build plan gates without waiting for some
+  // unrelated state change. Re-armed whenever the snapshot/receipt time changes;
+  // cleared on unmount.
+  useEffect(() => {
+    if (!snapshot || snapshotFetchedAt == null) return undefined
+    const remaining = snapshotFetchedAt + SNAPSHOT_TTL_MS - Date.now()
+    if (remaining <= 0) {
+      setNowMs(Date.now())
+      return undefined
+    }
+    const timer = setTimeout(() => setNowMs(Date.now()), remaining + 50)
+    return () => clearTimeout(timer)
+  }, [snapshot, snapshotFetchedAt])
 
   useEffect(() => {
     if (!accountKey) {
@@ -523,6 +542,18 @@ export default function ResourcePlanner() {
       toast.error('Fetch account state first')
       return
     }
+    // Re-check freshness from the LIVE clock, not the last render, so a stale
+    // snapshot cannot be planned from by racing a not-yet-updated rendered value
+    // (the button-disable is a UI hint; this is the authoritative guard).
+    if (
+      !useStaleSnapshot &&
+      (snapshotFetchedAt == null || Date.now() - snapshotFetchedAt > SNAPSHOT_TTL_MS)
+    ) {
+      toast.error(
+        'Snapshot is stale — fetch fresh state, or tick “plan from this stale snapshot anyway”.'
+      )
+      return
+    }
     // Guard against the account changing mid-request: a plan built from
     // account A's snapshot must not be presented under account B. The input
     // revision closes the same race for edits within one account.
@@ -582,6 +613,8 @@ export default function ResourcePlanner() {
     accountKey,
     currentAccountKey,
     snapshot,
+    snapshotFetchedAt,
+    useStaleSnapshot,
     merchantModel,
     foreignTargets,
   ])
@@ -863,7 +896,11 @@ export default function ResourcePlanner() {
   // A snapshot carries fast-changing production/stock/merchant state; once it is
   // older than the TTL (or its receipt time is unknown, e.g. an older cache),
   // treat it as stale so it is not silently planned from as if it were live.
-  const snapshotAgeMs = snapshot ? (snapshotFetchedAt ? Date.now() - snapshotFetchedAt : null) : null
+  const snapshotAgeMs = snapshot
+    ? snapshotFetchedAt
+      ? nowMs - snapshotFetchedAt
+      : null
+    : null
   const snapshotStale = !!snapshot && (snapshotFetchedAt == null || snapshotAgeMs > SNAPSHOT_TTL_MS)
   const snapshotAgeLabel =
     snapshotAgeMs == null

--- a/frontend/src/pages/ResourcePlanner.jsx
+++ b/frontend/src/pages/ResourcePlanner.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
 import { useToast } from '../components/Toast'
 import useGameStore from '../stores/gameStore'
 import api from '../api'
@@ -422,6 +422,17 @@ export default function ResourcePlanner() {
   useEffect(() => {
     setDayCheck(null)
   }, [profiles, profileWindows, cropCeilings, snapshot, foreignTargets])
+  // Same rule for the route sheet, with higher stakes: its rows are copied
+  // field by field into the game's trade-route dialog. A sheet computed from
+  // yesterday's allocations, Trade Office levels, merchant model, tributes or
+  // snapshot prescribes routes for a world that no longer exists. The
+  // revision counter also kills in-flight builds: a response that started
+  // before the latest edit must not resurrect a stale sheet.
+  const planInputRev = useRef(0)
+  useEffect(() => {
+    planInputRev.current += 1
+    setPlan(null)
+  }, [allocations, tradeOffice, merchantModel, foreignTargets, villages])
   useEffect(() => {
     if (hydratedKey && hydratedKey === accountKey)
       saveJson(storageKey(LS_CROP_CEILING), cropCeilings)
@@ -482,8 +493,10 @@ export default function ResourcePlanner() {
       return
     }
     // Guard against the account changing mid-request: a plan built from
-    // account A's snapshot must not be presented under account B.
+    // account A's snapshot must not be presented under account B. The input
+    // revision closes the same race for edits within one account.
     const requestedFor = accountKey
+    const requestedRev = planInputRev.current
     setPlanning(true)
     try {
       // Send only entries the planner can act on: `keep` equals the backend
@@ -522,6 +535,7 @@ export default function ResourcePlanner() {
           : undefined,
       })
       if (requestedFor !== currentAccountKey()) return
+      if (requestedRev !== planInputRev.current) return
       setPlan(res.data)
       setStage('plan')
     } catch (err) {

--- a/frontend/src/pages/VideoRewards.jsx
+++ b/frontend/src/pages/VideoRewards.jsx
@@ -51,6 +51,9 @@ function RewardCard({ reward, onClaim, claiming, result }) {
 export default function VideoRewards() {
   const toast = useToast()
   const connected = useGameStore((s) => s.connected)
+  // Claims must carry the UI's village: the backend session default is
+  // forever the login village since switching became client-side only.
+  const activeVillageId = useGameStore((s) => s.activeVillageId)
 
   // Per-reward state
   const [claimingType, setClaimingType] = useState(null)
@@ -70,7 +73,10 @@ export default function VideoRewards() {
     })
 
     try {
-      const res = await api.post('/video/claim', { type })
+      const res = await api.post('/video/claim', {
+        type,
+        village_id: activeVillageId ?? undefined,
+      })
       const message = res.data?.message || res.data?.detail || 'Reward claimed!'
       setResults((prev) => ({ ...prev, [type]: { success: true, message } }))
       toast.success(`${REWARD_TYPES.find((r) => r.key === type)?.label || type}: ${message}`)
@@ -90,7 +96,9 @@ export default function VideoRewards() {
     setClaimAllProgress('Starting claim all...')
 
     try {
-      const res = await api.post('/video/claim-all')
+      const res = await api.post('/video/claim-all', {
+        village_id: activeVillageId ?? undefined,
+      })
       const data = res.data
 
       // Handle different response shapes

--- a/frontend/src/pages/VideoRewards.jsx
+++ b/frontend/src/pages/VideoRewards.jsx
@@ -112,7 +112,8 @@ export default function VideoRewards() {
           if (typeof entries[0] === 'object' && !Array.isArray(entries[0])) {
             // Array of result objects
             entries.forEach((item) => {
-              const type = item.type || item.key
+              // /video/claim-all returns each result under reward_type.
+              const type = item.type || item.key || item.reward_type
               const success = item.success !== false && !item.error
               if (success) successCount++
               else failCount++

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -3,6 +3,12 @@ import api from '../api';
 import useGameStore from './gameStore';
 import useLogStore from './logStore';
 
+// Transient /users/me failures are retried a few times before giving up; a
+// backend restart must neither log the user out nor pin the whole UI behind
+// the loading gate forever.
+const AUTH_RETRY_LIMIT = 3
+let authRetryCount = 0
+
 const useAuthStore = create((set, get) => ({
   token: localStorage.getItem('token'),
   user: null,
@@ -46,21 +52,31 @@ const useAuthStore = create((set, get) => ({
     }
     try {
       const res = await api.get('/users/me');
+      authRetryCount = 0;
       set({ user: res.data, isAuthenticated: true, initialCheckDone: true });
     } catch (e) {
       // Only discard the token when the server says it is bad; a restart,
       // timeout, or 5xx during the initial check must not log the user out.
       if (e.response?.status === 401 || e.response?.status === 403) {
+        authRetryCount = 0;
         localStorage.removeItem('token');
         set({ token: null, user: null, isAuthenticated: false, initialCheckDone: true });
-      } else {
-        // Transient failure: the auth state is UNKNOWN, which is neither
-        // logged-in nor logged-out. Leave the current state untouched —
-        // initialCheckDone stays false on first load, so the router shows
-        // the loading gate instead of bouncing to /login, and an already
-        // verified session keeps its pages — and retry until the backend
-        // answers definitively. The token survives either way.
+      } else if (authRetryCount < AUTH_RETRY_LIMIT) {
+        // Transient failure: auth state is UNKNOWN. Leave it untouched — the
+        // loading gate stays up on first load instead of bouncing to /login,
+        // an already verified session keeps its pages — and retry shortly.
+        authRetryCount += 1;
         setTimeout(() => { get().checkAuth() }, 5000);
+      } else {
+        // Retries exhausted: stop blocking the UI. The token is kept, so a
+        // later login-page load or manual retry can still restore the
+        // session once the backend recovers; a verified session stays put.
+        authRetryCount = 0;
+        if (get().isAuthenticated) {
+          set({ initialCheckDone: true });
+        } else {
+          set({ isAuthenticated: false, initialCheckDone: true });
+        }
       }
     }
   },

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -54,7 +54,12 @@ const useAuthStore = create((set, get) => ({
         localStorage.removeItem('token');
         set({ token: null, user: null, isAuthenticated: false, initialCheckDone: true });
       } else {
-        set({ isAuthenticated: true, initialCheckDone: true });
+        // Transient failure: the token was NOT revalidated, so do not enter
+        // the authenticated UI on faith — but keep the token and retry until
+        // the backend gives a definitive answer, so an outage never costs the
+        // user their session.
+        set({ isAuthenticated: false, initialCheckDone: true });
+        setTimeout(() => { get().checkAuth() }, 5000);
       }
     }
   },

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -15,6 +15,13 @@ const useAuthStore = create((set, get) => ({
   // Don't trust localStorage token alone — wait for checkAuth to verify
   isAuthenticated: false,
   initialCheckDone: false,
+  // Recovery state, so the shell can explain a transient backend outage instead
+  // of showing a bare spinner and then an unexplained login screen: which retry
+  // is in flight, and whether automatic retries were exhausted while the stored
+  // token was still kept (an outage, NOT invalid credentials).
+  authRetryAttempt: 0,
+  authRetryLimit: AUTH_RETRY_LIMIT,
+  authOutage: false,
 
   login: async (username, password) => {
     const res = await api.post('/users/login', { username, password });
@@ -53,37 +60,76 @@ const useAuthStore = create((set, get) => ({
     try {
       const res = await api.get('/users/me');
       authRetryCount = 0;
-      set({ user: res.data, isAuthenticated: true, initialCheckDone: true });
+      set({
+        user: res.data,
+        isAuthenticated: true,
+        initialCheckDone: true,
+        authRetryAttempt: 0,
+        authOutage: false,
+      });
     } catch (e) {
       // Only discard the token when the server says it is bad; a restart,
       // timeout, or 5xx during the initial check must not log the user out.
       if (e.response?.status === 401 || e.response?.status === 403) {
         authRetryCount = 0;
         localStorage.removeItem('token');
-        set({ token: null, user: null, isAuthenticated: false, initialCheckDone: true });
+        set({
+          token: null,
+          user: null,
+          isAuthenticated: false,
+          initialCheckDone: true,
+          authRetryAttempt: 0,
+          // A genuine credential rejection is NOT an outage — route to login.
+          authOutage: false,
+        });
       } else if (authRetryCount < AUTH_RETRY_LIMIT) {
         // Transient failure: auth state is UNKNOWN. Leave it untouched — the
         // loading gate stays up on first load instead of bouncing to /login,
         // an already verified session keeps its pages — and retry shortly.
+        // Publish the attempt so the shell can say what it is doing.
         authRetryCount += 1;
+        set({ authRetryAttempt: authRetryCount, authOutage: false });
         setTimeout(() => { get().checkAuth() }, 5000);
       } else {
-        // Retries exhausted: stop blocking the UI. The token is kept, so a
-        // later login-page load or manual retry can still restore the
-        // session once the backend recovers; a verified session stays put.
+        // Retries exhausted with the token still stored: this is a backend
+        // outage, not bad credentials. Stop blocking the UI, but flag the
+        // outage so the shell offers an explicit Retry instead of silently
+        // presenting the ordinary login screen. A verified session stays put.
         authRetryCount = 0;
+        const stillHasToken = !!localStorage.getItem('token');
         if (get().isAuthenticated) {
-          set({ initialCheckDone: true });
+          set({ initialCheckDone: true, authRetryAttempt: 0, authOutage: false });
         } else {
-          set({ isAuthenticated: false, initialCheckDone: true });
+          set({
+            isAuthenticated: false,
+            initialCheckDone: true,
+            authRetryAttempt: 0,
+            authOutage: stillHasToken,
+          });
         }
       }
     }
   },
 
+  // Operator-triggered retry after automatic attempts were exhausted.
+  retryAuth: async () => {
+    authRetryCount = 0;
+    set({ authOutage: false, authRetryAttempt: 0, initialCheckDone: false });
+    await get().checkAuth();
+  },
+
   logout: () => {
     localStorage.removeItem('token');
-    set({ token: null, user: null, isAuthenticated: false, initialCheckDone: true });
+    // An explicit logout is never an outage — clear the recovery flags so the
+    // normal login screen is shown.
+    set({
+      token: null,
+      user: null,
+      isAuthenticated: false,
+      initialCheckDone: true,
+      authRetryAttempt: 0,
+      authOutage: false,
+    });
     // Clean up other stores to prevent data leaking to next user
     useGameStore.setState({
       connected: false, serverUrl: null, playerName: null, tribeId: null,

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -54,11 +54,12 @@ const useAuthStore = create((set, get) => ({
         localStorage.removeItem('token');
         set({ token: null, user: null, isAuthenticated: false, initialCheckDone: true });
       } else {
-        // Transient failure: the token was NOT revalidated, so do not enter
-        // the authenticated UI on faith — but keep the token and retry until
-        // the backend gives a definitive answer, so an outage never costs the
-        // user their session.
-        set({ isAuthenticated: false, initialCheckDone: true });
+        // Transient failure: the auth state is UNKNOWN, which is neither
+        // logged-in nor logged-out. Leave the current state untouched —
+        // initialCheckDone stays false on first load, so the router shows
+        // the loading gate instead of bouncing to /login, and an already
+        // verified session keeps its pages — and retry until the backend
+        // answers definitively. The token survives either way.
         setTimeout(() => { get().checkAuth() }, 5000);
       }
     }

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -47,9 +47,15 @@ const useAuthStore = create((set, get) => ({
     try {
       const res = await api.get('/users/me');
       set({ user: res.data, isAuthenticated: true, initialCheckDone: true });
-    } catch {
-      localStorage.removeItem('token');
-      set({ token: null, user: null, isAuthenticated: false, initialCheckDone: true });
+    } catch (e) {
+      // Only discard the token when the server says it is bad; a restart,
+      // timeout, or 5xx during the initial check must not log the user out.
+      if (e.response?.status === 401 || e.response?.status === 403) {
+        localStorage.removeItem('token');
+        set({ token: null, user: null, isAuthenticated: false, initialCheckDone: true });
+      } else {
+        set({ isAuthenticated: true, initialCheckDone: true });
+      }
     }
   },
 

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -3,17 +3,26 @@ import api from '../api';
 
 const VILLAGE_KEY = 'activeVillageId'
 
-function getStoredVillageId() {
+// Scoped per (server, player): village ids can overlap across worlds, so one
+// global key could silently inherit another account's selection and route
+// actions to the wrong village after switching accounts in the same tab.
+function villageStorageKey(serverUrl, playerName) {
+  return serverUrl && playerName ? `${VILLAGE_KEY}::${serverUrl}|${playerName}` : null
+}
+
+function getStoredVillageId(key) {
+  if (!key) return null
   try {
-    const v = sessionStorage.getItem(VILLAGE_KEY)
+    const v = sessionStorage.getItem(key)
     return v ? Number(v) : null
   } catch { return null }
 }
 
-function storeVillageId(id) {
+function storeVillageId(key, id) {
+  if (!key) return
   try {
-    if (id != null) sessionStorage.setItem(VILLAGE_KEY, String(id))
-    else sessionStorage.removeItem(VILLAGE_KEY)
+    if (id != null) sessionStorage.setItem(key, String(id))
+    else sessionStorage.removeItem(key)
   } catch { /* empty */ }
 }
 
@@ -32,7 +41,9 @@ const useGameStore = create((set, get) => ({
   playerName: null,
   tribeId: null,
   villages: [],
-  activeVillageId: getStoredVillageId(),
+  // Populated by connect/checkStatus once the account (and so the per-account
+  // storage key) is known.
+  activeVillageId: null,
   resources: null,
   buildings: [],
   buildingsLoading: false,
@@ -46,7 +57,8 @@ const useGameStore = create((set, get) => ({
       password,
     });
     const data = res.data;
-    const storedVid = getStoredVillageId()
+    const vkey = villageStorageKey(data.server_url, data.player_name)
+    const storedVid = getStoredVillageId(vkey)
     const villages = Array.isArray(data.villages) ? data.villages : []
     const villageToUse = (storedVid && villages.some(v => v.id === storedVid))
       ? storedVid
@@ -60,14 +72,15 @@ const useGameStore = create((set, get) => ({
       activeVillageId: villageToUse,
       villages: villages,
     });
-    storeVillageId(villageToUse)
+    storeVillageId(vkey, villageToUse)
     return data;
   },
 
   connectFromSaved: async (serverId) => {
     const res = await api.post(`/travian/servers/${serverId}/connect`);
     const data = res.data;
-    const storedVid = getStoredVillageId()
+    const vkey = villageStorageKey(data.server_url, data.player_name)
+    const storedVid = getStoredVillageId(vkey)
     const villages = Array.isArray(data.villages) ? data.villages : []
     const villageToUse = (storedVid && villages.some(v => v.id === storedVid))
       ? storedVid
@@ -81,13 +94,13 @@ const useGameStore = create((set, get) => ({
       activeVillageId: villageToUse,
       villages: villages,
     });
-    storeVillageId(villageToUse)
+    storeVillageId(vkey, villageToUse)
     return data;
   },
 
   disconnect: async () => {
     try { await api.delete('/travian/disconnect'); } catch (e) { console.warn('Disconnect failed:', e) }
-    storeVillageId(null)
+    storeVillageId(villageStorageKey(get().serverUrl, get().playerName), null)
     set({
       connected: false,
       serverUrl: null,
@@ -106,7 +119,8 @@ const useGameStore = create((set, get) => ({
       const res = await api.get('/travian/status');
       const data = res.data;
       if (data && data.connected) {
-        const storedVid = getStoredVillageId()
+        const vkey = villageStorageKey(data.server_url, data.player_name)
+        const storedVid = getStoredVillageId(vkey)
         const villages = Array.isArray(data.villages) ? data.villages : []
         const villageToUse = (storedVid && villages.some(v => v.id === storedVid))
           ? storedVid
@@ -120,7 +134,7 @@ const useGameStore = create((set, get) => ({
           activeVillageId: villageToUse,
           villages: villages,
         });
-        storeVillageId(villageToUse)
+        storeVillageId(vkey, villageToUse)
       } else {
         set({ connected: false, statusChecked: true });
       }
@@ -132,7 +146,7 @@ const useGameStore = create((set, get) => ({
   switchVillage: async (villageId) => {
     await api.post('/villages/switch', { village_id: villageId });
     set({ activeVillageId: villageId });
-    storeVillageId(villageId)
+    storeVillageId(villageStorageKey(get().serverUrl, get().playerName), villageId)
     await Promise.all([get().fetchResources(), get().fetchBuildings(), get().fetchQueue()]);
   },
 

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -10,6 +10,13 @@ function villageStorageKey(serverUrl, playerName) {
   return serverUrl && playerName ? `${VILLAGE_KEY}::${serverUrl}|${playerName}` : null
 }
 
+// Identity a fetch was issued under: village AND account. A village-only stamp
+// is not enough because ids overlap across worlds, so an in-flight response
+// from world A could pass a bare-vid check and overwrite world B's state.
+function fetchStamp(state) {
+  return `${state.activeVillageId}@${state.serverUrl}|${state.playerName}`
+}
+
 function getStoredVillageId(key) {
   if (!key) return null
   try {
@@ -184,11 +191,13 @@ const useGameStore = create((set, get) => ({
     // Fewer/again-correct Travian requests beats a guess that needs redoing.
     const vid = get().activeVillageId
     if (!vid) return
+    const stamp = fetchStamp(get())
     try {
       const res = await api.get('/buildings/resources', { params: { village_id: vid } });
-      // Drop a response for a village the user has since switched away from:
+      // Drop a response the user has since switched away from — a different
+      // village OR a different account (village ids overlap across worlds):
       // otherwise A's resources land under B's selector.
-      if (get().activeVillageId !== vid) return;
+      if (fetchStamp(get()) !== stamp) return;
       if (res.data && typeof res.data === 'object' && !Array.isArray(res.data)) {
         set({ resources: res.data });
       }
@@ -201,11 +210,13 @@ const useGameStore = create((set, get) => ({
   fetchBuildings: async () => {
     const vid = get().activeVillageId
     if (!vid) return
+    const stamp = fetchStamp(get())
     set({ buildingsLoading: true, buildingsError: null });
     try {
       const res = await api.get('/buildings', { params: { village_id: vid } });
-      // A newer switch owns the store now; its own fetch will settle loading.
-      if (get().activeVillageId !== vid) return;
+      // A newer switch (village or account) owns the store now; its own fetch
+      // will settle loading.
+      if (fetchStamp(get()) !== stamp) return;
       // API returns { village_id, buildings: [...] } or possibly a plain array
       const arr = Array.isArray(res.data) ? res.data
         : Array.isArray(res.data?.buildings) ? res.data.buildings
@@ -222,9 +233,10 @@ const useGameStore = create((set, get) => ({
   fetchQueue: async () => {
     const vid = get().activeVillageId
     if (!vid) return
+    const stamp = fetchStamp(get())
     try {
       const res = await api.get('/buildings/queue', { params: { village_id: vid } });
-      if (get().activeVillageId !== vid) return;
+      if (fetchStamp(get()) !== stamp) return;
       // API returns { village_id, queue: [...] } or possibly a plain array
       const arr = Array.isArray(res.data) ? res.data
         : Array.isArray(res.data?.queue) ? res.data.queue

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -17,6 +17,17 @@ function storeVillageId(id) {
   } catch { /* empty */ }
 }
 
+// When a stored selection wins over the server's default, tell the backend:
+// endpoints that fall back to session.active_village_id (e.g. the reports
+// analyzer WS) would otherwise act on the login village until the user
+// manually re-selects. Best-effort — action routes send explicit ids anyway.
+async function syncBackendVillage(villageId, serverActiveId) {
+  if (villageId == null || villageId === serverActiveId) return
+  try {
+    await api.post('/villages/switch', { village_id: villageId })
+  } catch { /* keep the server default; explicit ids still travel per call */ }
+}
+
 let _checkingStatus = false
 
 const useGameStore = create((set, get) => ({
@@ -55,6 +66,7 @@ const useGameStore = create((set, get) => ({
       villages: villages,
     });
     storeVillageId(villageToUse)
+    await syncBackendVillage(villageToUse, data.active_village_id)
     return data;
   },
 
@@ -76,6 +88,7 @@ const useGameStore = create((set, get) => ({
       villages: villages,
     });
     storeVillageId(villageToUse)
+    await syncBackendVillage(villageToUse, data.active_village_id)
     return data;
   },
 
@@ -115,6 +128,7 @@ const useGameStore = create((set, get) => ({
           villages: villages,
         });
         storeVillageId(villageToUse)
+        await syncBackendVillage(villageToUse, data.active_village_id)
       } else {
         set({ connected: false, statusChecked: true });
       }

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -146,11 +146,12 @@ const useGameStore = create((set, get) => ({
         });
       }
     } catch (e) { console.warn('Store fetch failed:', e)
-      set({
-        connected: false, statusChecked: true, serverUrl: null,
-        playerName: null, tribeId: null, villages: [], activeVillageId: null,
-        resources: null, buildings: [], constructionQueue: [],
-      });
+      // A transport failure is NOT a confirmed logout — a real logout returns
+      // 200 with connected:false (cleared in the else branch above). Leave
+      // account state intact so a brief 5xx/network blip does not reset
+      // account-scoped pages; the next poll (or a 403 from another call)
+      // reconciles. Only mark the first check done so the app can render.
+      set({ statusChecked: true });
     }
   },
 

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -136,10 +136,19 @@ const useGameStore = create((set, get) => ({
         });
         storeVillageId(vkey, villageToUse)
       } else {
-        set({ connected: false, statusChecked: true });
+        // Clear account-scoped state too: pages that key off serverUrl or
+        // playerName (Resource Planner) must not keep showing — or persisting
+        // under — the previous account after the session expired.
+        set({
+          connected: false, statusChecked: true, serverUrl: null,
+          playerName: null, tribeId: null, villages: [], activeVillageId: null,
+        });
       }
     } catch (e) { console.warn('Store fetch failed:', e)
-      set({ connected: false, statusChecked: true });
+      set({
+        connected: false, statusChecked: true, serverUrl: null,
+        playerName: null, tribeId: null, villages: [], activeVillageId: null,
+      });
     }
   },
 

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -149,6 +149,7 @@ const useGameStore = create((set, get) => ({
       set({
         connected: false, statusChecked: true, serverUrl: null,
         playerName: null, tribeId: null, villages: [], activeVillageId: null,
+        resources: null, buildings: [], constructionQueue: [],
       });
     }
   },
@@ -173,10 +174,13 @@ const useGameStore = create((set, get) => ({
   },
 
   fetchResources: async () => {
+    // Never send a village-less read: the backend would resolve it to the
+    // account's default village, which may not be the one the user is on.
+    // Fewer/again-correct Travian requests beats a guess that needs redoing.
+    const vid = get().activeVillageId
+    if (!vid) return
     try {
-      const vid = get().activeVillageId
-      const params = vid ? { village_id: vid } : {}
-      const res = await api.get('/buildings/resources', { params });
+      const res = await api.get('/buildings/resources', { params: { village_id: vid } });
       if (res.data && typeof res.data === 'object' && !Array.isArray(res.data)) {
         set({ resources: res.data });
       }
@@ -187,11 +191,11 @@ const useGameStore = create((set, get) => ({
   },
 
   fetchBuildings: async () => {
+    const vid = get().activeVillageId
+    if (!vid) return
     set({ buildingsLoading: true, buildingsError: null });
     try {
-      const vid = get().activeVillageId
-      const params = vid ? { village_id: vid } : {}
-      const res = await api.get('/buildings', { params });
+      const res = await api.get('/buildings', { params: { village_id: vid } });
       // API returns { village_id, buildings: [...] } or possibly a plain array
       const arr = Array.isArray(res.data) ? res.data
         : Array.isArray(res.data?.buildings) ? res.data.buildings
@@ -206,10 +210,10 @@ const useGameStore = create((set, get) => ({
   },
 
   fetchQueue: async () => {
+    const vid = get().activeVillageId
+    if (!vid) return
     try {
-      const vid = get().activeVillageId
-      const params = vid ? { village_id: vid } : {}
-      const res = await api.get('/buildings/queue', { params });
+      const res = await api.get('/buildings/queue', { params: { village_id: vid } });
       // API returns { village_id, queue: [...] } or possibly a plain array
       const arr = Array.isArray(res.data) ? res.data
         : Array.isArray(res.data?.queue) ? res.data.queue

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -142,6 +142,7 @@ const useGameStore = create((set, get) => ({
         set({
           connected: false, statusChecked: true, serverUrl: null,
           playerName: null, tribeId: null, villages: [], activeVillageId: null,
+          resources: null, buildings: [], constructionQueue: [],
         });
       }
     } catch (e) { console.warn('Store fetch failed:', e)

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -17,16 +17,11 @@ function storeVillageId(id) {
   } catch { /* empty */ }
 }
 
-// When a stored selection wins over the server's default, tell the backend:
-// endpoints that fall back to session.active_village_id (e.g. the reports
-// analyzer WS) would otherwise act on the login village until the user
-// manually re-selects. Best-effort — action routes send explicit ids anyway.
-async function syncBackendVillage(villageId, serverActiveId) {
-  if (villageId == null || villageId === serverActiveId) return
-  try {
-    await api.post('/villages/switch', { village_id: villageId })
-  } catch { /* keep the server default; explicit ids still travel per call */ }
-}
+// NOTE: the tab-local selection is deliberately NOT pushed to the backend
+// here. session.active_village_id is shared across every tab of the user, so
+// a background sync from one tab would silently retarget another tab's
+// default. Every call that acts on a village sends its village_id explicitly;
+// the backend default only changes on an explicit user switch.
 
 let _checkingStatus = false
 
@@ -66,7 +61,6 @@ const useGameStore = create((set, get) => ({
       villages: villages,
     });
     storeVillageId(villageToUse)
-    await syncBackendVillage(villageToUse, data.active_village_id)
     return data;
   },
 
@@ -88,7 +82,6 @@ const useGameStore = create((set, get) => ({
       villages: villages,
     });
     storeVillageId(villageToUse)
-    await syncBackendVillage(villageToUse, data.active_village_id)
     return data;
   },
 
@@ -128,7 +121,6 @@ const useGameStore = create((set, get) => ({
           villages: villages,
         });
         storeVillageId(villageToUse)
-        await syncBackendVillage(villageToUse, data.active_village_id)
       } else {
         set({ connected: false, statusChecked: true });
       }

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -99,7 +99,11 @@ const useGameStore = create((set, get) => ({
   },
 
   disconnect: async () => {
-    try { await api.delete('/travian/disconnect'); } catch (e) { console.warn('Disconnect failed:', e) }
+    // No catch: clearing local state on a failed DELETE would paint the UI
+    // "disconnected" while the backend session stays alive and working (the
+    // server also refuses with a 409 while operations run). The caller
+    // surfaces the failure; state only changes when the backend confirmed.
+    await api.delete('/travian/disconnect')
     storeVillageId(villageStorageKey(get().serverUrl, get().playerName), null)
     set({
       connected: false,

--- a/frontend/src/stores/gameStore.js
+++ b/frontend/src/stores/gameStore.js
@@ -186,6 +186,9 @@ const useGameStore = create((set, get) => ({
     if (!vid) return
     try {
       const res = await api.get('/buildings/resources', { params: { village_id: vid } });
+      // Drop a response for a village the user has since switched away from:
+      // otherwise A's resources land under B's selector.
+      if (get().activeVillageId !== vid) return;
       if (res.data && typeof res.data === 'object' && !Array.isArray(res.data)) {
         set({ resources: res.data });
       }
@@ -201,6 +204,8 @@ const useGameStore = create((set, get) => ({
     set({ buildingsLoading: true, buildingsError: null });
     try {
       const res = await api.get('/buildings', { params: { village_id: vid } });
+      // A newer switch owns the store now; its own fetch will settle loading.
+      if (get().activeVillageId !== vid) return;
       // API returns { village_id, buildings: [...] } or possibly a plain array
       const arr = Array.isArray(res.data) ? res.data
         : Array.isArray(res.data?.buildings) ? res.data.buildings
@@ -219,6 +224,7 @@ const useGameStore = create((set, get) => ({
     if (!vid) return
     try {
       const res = await api.get('/buildings/queue', { params: { village_id: vid } });
+      if (get().activeVillageId !== vid) return;
       // API returns { village_id, queue: [...] } or possibly a plain array
       const arr = Array.isArray(res.data) ? res.data
         : Array.isArray(res.data?.queue) ? res.data.queue

--- a/frontend/src/ws.js
+++ b/frontend/src/ws.js
@@ -54,12 +54,17 @@ export function createWebSocket(path, onMessage, onError, onClose, options = {})
   function connect() {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const host = window.location.host
-    const url = `${protocol}//${host}${path}${path.includes('?') ? '&' : '?'}token=${token}`
+    // The bearer JWT rides in a WebSocket subprotocol, NOT the query string:
+    // uvicorn logs request paths (query included) at INFO, so a `?token=<jwt>`
+    // writes a reusable 24h token into server logs (and proxy logs, browser
+    // history, Referer). Subprotocol values are part of the handshake headers,
+    // which uvicorn does not log. The server reads the token from here.
+    const url = `${protocol}//${host}${path}`
 
     const isReconnect = !isFirstConnect
     if (isReconnect) onReconnecting?.()
     log('info', source, `WS >> connect: ${path}${attempts > 0 ? ` (retry ${attempts})` : ''}`)
-    const ws = new WebSocket(url)
+    const ws = new WebSocket(url, ['travian-jwt', token])
     currentWs = ws
 
     ws.onopen = () => {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -13,9 +13,11 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': 'http://localhost:8000',
+      // Default 8001 matches what travian-web and start.bat actually launch;
+      // override with TRAVIAN_BACKEND_PORT (e.g. 8000 for the stable server).
+      '/api': `http://localhost:${process.env.TRAVIAN_BACKEND_PORT || '8001'}`,
       '/ws': {
-        target: 'ws://localhost:8000',
+        target: `ws://localhost:${process.env.TRAVIAN_BACKEND_PORT || '8001'}`,
         ws: true,
       },
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,11 @@ travian-web = "travian_api.web:main"
 [tool.setuptools.packages.find]
 where = ["src"]
 
+# Ship the built web UI in wheels when it exists (frontend/ builds into
+# src/travian_api/web/static; the files are gitignored, not package-ignored).
+[tool.setuptools.package-data]
+"travian_api.web" = ["static/**/*"]
+
 [tool.setuptools.package-dir]
 "" = "src"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
 [project.scripts]
 travian = "travian_api.cli:app"
 travian-setup = "travian_api._post_install:main"
-travian-web = "travian_api.web.app:main"
+travian-web = "travian_api.web:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/codex-unwedge.ps1
+++ b/scripts/codex-unwedge.ps1
@@ -1,0 +1,42 @@
+# Detects and clears a wedged Codex app-server broker.
+#
+# Failure mode this repairs: app-server-broker.mjs spawns `codex app-server` as a
+# child and forwards every JSON-RPC request to it. If that child dies while the
+# broker survives, the broker keeps listening on its named pipe, so
+# isBrokerEndpointReady() (which only tests connectability) happily reuses it --
+# but AppServerClientBase.request() never rejects once handleExit() has already
+# run, so the forwarded request never settles. Reviews then hang forever with
+# zero output and no error.
+#
+# Safe to run any time: it only kills brokers that have no live app-server.
+
+$ErrorActionPreference = 'Stop'
+
+$brokers = Get-CimInstance Win32_Process |
+    Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -like '*app-server-broker.mjs*' }
+
+if (-not $brokers) {
+    Write-Output 'No broker running. Nothing to clear.'
+} else {
+    foreach ($b in $brokers) {
+        $kids = @(Get-CimInstance Win32_Process -Filter "ParentProcessId=$($b.ProcessId)")
+        if ($kids.Count -gt 0) {
+            Write-Output "Broker $($b.ProcessId) is healthy ($($kids.Count) child process(es)). Left alone."
+        } else {
+            Write-Output "Broker $($b.ProcessId) is WEDGED (no app-server child). Killing."
+            Stop-Process -Id $b.ProcessId -Force
+        }
+    }
+}
+
+# Drop stale broker.json state so the next run spawns a fresh broker + pipe.
+Get-ChildItem "$env:USERPROFILE\.claude\plugins\data\codex-openai-codex\state" `
+    -Recurse -Filter 'broker.json' -ErrorAction SilentlyContinue | ForEach-Object {
+    $pidVal = (Get-Content $_.FullName -Raw | ConvertFrom-Json).pid
+    if (-not (Get-Process -Id $pidVal -ErrorAction SilentlyContinue)) {
+        Write-Output "Removing stale state for dead broker PID $pidVal : $($_.FullName)"
+        Remove-Item $_.FullName -Force
+    }
+}
+
+Write-Output 'Done.'

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,23 @@ _FRONTEND = Path(__file__).parent / "frontend"
 
 class BuildPyWithFrontend(build_py):
     def run(self) -> None:
-        self._build_frontend()
+        built_fresh = self._build_frontend()
         super().run()
+        if not built_fresh:
+            # The build was skipped or failed. Drop any static assets that got
+            # copied into the wheel so we never ship a STALE UI that drifts from
+            # this backend — the packaged app then honestly serves its 503
+            # "UI not built" page. Only the build output is cleared; the source
+            # tree (a developer's own build) is left untouched.
+            staged = Path(self.build_lib) / "travian_api" / "web" / "static"
+            if staged.exists():
+                shutil.rmtree(staged, ignore_errors=True)
 
-    def _build_frontend(self) -> None:
+    def _build_frontend(self) -> bool:
+        """Build the SPA into src/travian_api/web/static. Returns True only on a
+        fresh successful build; False when skipped or failed."""
         if not (_FRONTEND / "package.json").exists():
-            return  # source layout without the frontend (e.g. an sdist)
+            return False  # source layout without the frontend (e.g. an sdist)
         npm = shutil.which("npm")
         if npm is None:
             print(
@@ -37,19 +48,21 @@ class BuildPyWithFrontend(build_py):
                 "(the server will serve its 'UI not built' page).",
                 file=sys.stderr,
             )
-            return
+            return False
         try:
             lock = _FRONTEND / "package-lock.json"
             subprocess.run(
                 [npm, "ci" if lock.exists() else "install"], cwd=_FRONTEND, check=True
             )
             subprocess.run([npm, "run", "build"], cwd=_FRONTEND, check=True)
+            return True
         except Exception as exc:  # noqa: BLE001 - build must not hard-fail packaging
             print(
                 f"warning: frontend build failed ({exc}); packaging without the "
                 f"built web UI.",
                 file=sys.stderr,
             )
+            return False
 
 
 setup(cmdclass={"build_py": BuildPyWithFrontend})

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,55 @@
+"""Imperative build steps; package metadata lives in pyproject.toml.
+
+Builds the React frontend into ``src/travian_api/web/static`` during packaging
+so a non-editable ``pip install .[web]`` serves a real UI instead of the 503
+"UI not built" fallback. Combined with the ``static/**`` package-data entry,
+the built assets land in the wheel.
+
+Degrades gracefully: if Node/npm is unavailable (or the build fails), packaging
+still succeeds and the server falls back to the 503 page — the same behavior as
+before. The one-click start.bat / start.sh path builds the frontend explicitly
+and is unaffected.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.build_py import build_py
+
+_FRONTEND = Path(__file__).parent / "frontend"
+
+
+class BuildPyWithFrontend(build_py):
+    def run(self) -> None:
+        self._build_frontend()
+        super().run()
+
+    def _build_frontend(self) -> None:
+        if not (_FRONTEND / "package.json").exists():
+            return  # source layout without the frontend (e.g. an sdist)
+        npm = shutil.which("npm")
+        if npm is None:
+            print(
+                "warning: npm not found; packaging without the built web UI "
+                "(the server will serve its 'UI not built' page).",
+                file=sys.stderr,
+            )
+            return
+        try:
+            lock = _FRONTEND / "package-lock.json"
+            subprocess.run(
+                [npm, "ci" if lock.exists() else "install"], cwd=_FRONTEND, check=True
+            )
+            subprocess.run([npm, "run", "build"], cwd=_FRONTEND, check=True)
+        except Exception as exc:  # noqa: BLE001 - build must not hard-fail packaging
+            print(
+                f"warning: frontend build failed ({exc}); packaging without the "
+                f"built web UI.",
+                file=sys.stderr,
+            )
+
+
+setup(cmdclass={"build_py": BuildPyWithFrontend})

--- a/src/travian_api/clients/http_client.py
+++ b/src/travian_api/clients/http_client.py
@@ -46,6 +46,25 @@ except ImportError:
     CurlError = Exception  # placeholder for retry_if_exception_type
 
 
+# Shared transient-failure retry for the request methods. Every method whose
+# except-blocks say "let tenacity retry" must actually wear this decorator --
+# post_json/delete_json/post_form once relied on the comment alone and aborted
+# on the first transient failure. NetworkError is deliberately NOT retried:
+# the except blocks convert non-retryable failures (safe_to_retry=False) into
+# NetworkError precisely so this decorator lets them straight through.
+_transient_retry = retry(
+    stop=stop_after_attempt(3),
+    # Random-exponential backoff: avoids the textbook 1s, 2s, 4s, 8s cadence
+    # (a recognizable bot signature) by sampling each wait uniformly between
+    # 0 and 2^attempt — same expected throughput, no power-of-two stripes in
+    # request timing.
+    wait=wait_random_exponential(multiplier=0.8, max=12),
+    retry=retry_if_exception_type(
+        (httpx.RequestError, httpx.TimeoutException) + ((CurlError,) if HAS_CURL_CFFI else ())
+    ),
+)
+
+
 def _jitter_penalty(base_seconds: float) -> float:
     """±15% jitter on a throttle penalty.
 
@@ -819,6 +838,7 @@ class HttpClient:
         self._sync_cookies_from_curl(response)
         return response
 
+    @_transient_retry
     async def post_json(
         self,
         url: str,
@@ -938,6 +958,7 @@ class HttpClient:
                 raise NetworkError(f"Request failed (non-retryable): {e}")
             raise
 
+    @_transient_retry
     async def delete_json(
         self,
         url: str,
@@ -1032,6 +1053,7 @@ class HttpClient:
                 raise NetworkError(f"Request failed (non-retryable): {e}")
             raise
 
+    @_transient_retry
     async def post_form(self, url: str, data: Dict[str, str], *, safe_to_retry: bool = True) -> str:
         """Make a POST request with form data."""
         if not url.startswith("http"):
@@ -1151,17 +1173,7 @@ class HttpClient:
                 raise NetworkError(f"Request failed (non-retryable): {e}")
             raise
 
-    @retry(
-        stop=stop_after_attempt(3),
-        # Random-exponential backoff: avoids the textbook 1s, 2s, 4s, 8s
-        # cadence (a recognizable bot signature) by sampling each wait
-        # uniformly between 0 and 2^attempt — same expected throughput, no
-        # power-of-two stripes in request timing.
-        wait=wait_random_exponential(multiplier=0.8, max=12),
-        retry=retry_if_exception_type(
-            (httpx.RequestError, httpx.TimeoutException) + ((CurlError,) if HAS_CURL_CFFI else ())
-        ),
-    )
+    @_transient_retry
     async def get_html(
         self,
         url: str,

--- a/src/travian_api/config.py
+++ b/src/travian_api/config.py
@@ -15,6 +15,16 @@ class Settings(BaseSettings):
     base_url: str = Field(default="", description="Game server URL (required)")
     x_version: str = Field(default="389", description="Game client version (from gpack)")
 
+    # SSRF allowlist for user-supplied server URLs. A public IP passing the
+    # loopback/private checks is not enough on a shared deployment: a plausible
+    # phishing host (https://travian-login.example) would still receive the
+    # user's Travian credentials. Only hosts under one of these suffixes are
+    # accepted. CSV so it stays a plain env var; add fan/regional TLDs here.
+    allowed_server_hosts: str = Field(
+        default="travian.com",
+        description="Comma-separated host suffixes accepted as Travian servers (SSRF allowlist)",
+    )
+
     # Authentication — username + password + server = full auth identity
     username: str = Field(default="", description="Account email/username")
     password: str = Field(default="", description="Account password")

--- a/src/travian_api/logging_config.py
+++ b/src/travian_api/logging_config.py
@@ -1,6 +1,7 @@
 """Logging configuration for Travian API."""
 
 import logging
+import re
 import sys
 from typing import Optional
 
@@ -18,6 +19,37 @@ class SensitiveDataFilter(logging.Filter):
             msg = str(record.msg)
             if any(p in msg for p in self._REDACT_PATTERNS):
                 record.msg = "[REDACTED - Sensitive data filtered]"
+        return True
+
+
+class QueryStringRedactionFilter(logging.Filter):
+    """Redact secret query params anywhere they surface in a log record.
+
+    uvicorn's access logger renders the request line (path + query) into
+    record.args at INFO, so a `?token=<jwt>` on a WebSocket upgrade would
+    otherwise write a reusable bearer token to the logs. This scrubs the
+    value while leaving the parameter name visible, and runs UNCONDITIONALLY
+    (not only in debug) so production logs are covered. It mutates both
+    record.msg and each string in record.args in place.
+    """
+
+    _SECRET_QUERY = re.compile(r"(?i)([?&](?:token|jwt|access_token|password|secret)=)[^&\s\"']+")
+
+    def _scrub(self, value: str) -> str:
+        return self._SECRET_QUERY.sub(r"\1[REDACTED]", value)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str) and "=" in record.msg:
+            record.msg = self._scrub(record.msg)
+        if record.args:
+            if isinstance(record.args, tuple):
+                record.args = tuple(
+                    self._scrub(a) if isinstance(a, str) else a for a in record.args
+                )
+            elif isinstance(record.args, dict):
+                record.args = {
+                    k: (self._scrub(v) if isinstance(v, str) else v) for k, v in record.args.items()
+                }
         return True
 
 
@@ -63,6 +95,15 @@ def setup_logging(level: Optional[str] = None, *, attach_broadcast: bool = False
     # Configure third-party loggers
     logging.getLogger("httpx").setLevel(logging.WARNING)
     logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+    # Redact secret query params everywhere, always. Attached to our handlers
+    # and directly to uvicorn's access logger, which renders the request line
+    # (path + query) into its own records and would otherwise log bearer
+    # tokens from any legacy `?token=` WebSocket upgrade.
+    query_filter = QueryStringRedactionFilter()
+    for handler in root_logger.handlers:
+        handler.addFilter(query_filter)
+    logging.getLogger("uvicorn.access").addFilter(query_filter)
 
     if settings.debug:
         logging.getLogger("travian_api").setLevel(logging.DEBUG)

--- a/src/travian_api/models/buildings.py
+++ b/src/travian_api/models/buildings.py
@@ -88,6 +88,29 @@ class Resources(BaseModel):
     )
 
 
+class CropBalance(BaseModel):
+    """Net crop for one village, derived from the granary countdown.
+
+    Obtained for the whole account in two requests rather than one page per
+    village -- see docs/20-resource-production.md.
+    """
+
+    village_id: int = Field(..., description="Village id")
+    stock: int = Field(default=0, description="Current crop in the granary")
+    net_per_hour: float | None = Field(
+        default=None,
+        description=(
+            "True net crop per hour, negative while draining. None when it "
+            "could not be derived (a filling village with no known granary "
+            "capacity) -- never silently zero."
+        ),
+    )
+    draining: bool = Field(default=False, description="Granary is emptying; troops will starve")
+    seconds_remaining: int = Field(
+        default=0, description="Countdown to an empty granary, or to a full one when filling"
+    )
+
+
 class QueueItem(BaseModel):
     """Construction queue item."""
 

--- a/src/travian_api/models/buildings.py
+++ b/src/travian_api/models/buildings.py
@@ -64,7 +64,12 @@ class Resources(BaseModel):
     iron: int = Field(default=0, ge=0, description="Current iron amount")
     crop: int = Field(default=0, ge=0, description="Current crop amount")
     free_crop: int = Field(
-        default=0, description="Free crop (production - consumption; negative when starving)"
+        default=0,
+        description=(
+            "Raw production.l5 from Travian. NOT net crop and NOT a starvation "
+            "signal -- it can be positive while the village drains. Use "
+            "crop_per_hour. See docs/20-resource-production.md."
+        ),
     )
     max_lumber: int = Field(default=0, ge=0, description="Maximum lumber storage")
     max_clay: int = Field(default=0, ge=0, description="Maximum clay storage")
@@ -73,7 +78,14 @@ class Resources(BaseModel):
     lumber_per_hour: int = Field(default=0, description="Lumber production per hour")
     clay_per_hour: int = Field(default=0, description="Clay production per hour")
     iron_per_hour: int = Field(default=0, description="Iron production per hour")
-    crop_per_hour: int = Field(default=0, description="Crop production per hour")
+    crop_per_hour: int = Field(
+        default=0,
+        description=(
+            "NET crop per hour (production.l4): production minus population, "
+            "constructions and every troop feeding from this village. Negative "
+            "means the granary is draining and troops will starve."
+        ),
+    )
 
 
 class QueueItem(BaseModel):

--- a/src/travian_api/operation_manager.py
+++ b/src/travian_api/operation_manager.py
@@ -150,6 +150,25 @@ class OperationManager:
         """
         # Sync block: check-and-register is atomic in asyncio because no
         # await happens between the policy check and the register call.
+        #
+        # WS handlers fetch `session` and then await the client's config before
+        # reaching here; a /disconnect in that window can pop and close the
+        # session, and spawning an op against that dead HttpClient makes every
+        # request in it fail. Refuse if the cached session is no longer the
+        # one installed for this user. This runs synchronously, so it cannot
+        # interleave with disconnect: either it registers the op first (and
+        # disconnect's guard then sees it and returns 409), or disconnect has
+        # already popped the session and this check fails cleanly.
+        from travian_api.web.sessions import session_manager
+
+        if session is not None and session_manager.get(user_id) is not session:
+            logger.info(
+                "Refusing to start %s for user %s: session was torn down mid-startup",
+                label,
+                user_id,
+            )
+            return None
+
         if require_unique_label or require_unique_extras:
             existing_labels = set(active_ops.get_active(user_id))
             if require_unique_label and label in existing_labels:

--- a/src/travian_api/parsers/html_parser.py
+++ b/src/travian_api/parsers/html_parser.py
@@ -718,18 +718,40 @@ def _stats_village_rows(html: str, table_id: str) -> List[Any]:
     return rows
 
 
+def _stats_ratio(text: str) -> tuple[int, int]:
+    """Parse a ``free/total`` cell such as ``‭‭19‬/‭20‬‬`` -> ``(19, 20)``.
+
+    Returns ``(0, 0)`` when the cell is not a ratio. Note the *second* number is
+    the village's merchant count; the first is how many are idle right now, so
+    reading the wrong one understates capacity on a busy village.
+    """
+    parts = text.split("/")
+    if len(parts) != 2:
+        return (0, 0)
+    return (_stats_int(parts[0]), _stats_int(parts[1]))
+
+
 def parse_village_stats_resources(html: str) -> Dict[int, Dict[str, int]]:
-    """Parse /village/statistics/resources -> ``{village_id: {lumber, clay, iron, crop}}``."""
+    """Parse /village/statistics/resources per village.
+
+    Returns ``{village_id: {lumber, clay, iron, crop, merchants_free,
+    merchants_total}}``. ``merchants_total`` settles profile open question #2 --
+    the count is read directly rather than derived from Marketplace level, and it
+    genuinely varies (2 and 19 both observed alongside the usual 20).
+    """
     out: Dict[int, Dict[str, int]] = {}
     # Travian spells this table id "ressources" — not a typo on our side.
     for vid, cells in _stats_village_rows(html, "ressources"):
         if len(cells) < 4:
             continue
+        free, total = _stats_ratio(cells[4].get_text()) if len(cells) >= 5 else (0, 0)
         out[vid] = {
             "lumber": _stats_int(cells[0].get_text()),
             "clay": _stats_int(cells[1].get_text()),
             "iron": _stats_int(cells[2].get_text()),
             "crop": _stats_int(cells[3].get_text()),
+            "merchants_free": free,
+            "merchants_total": total,
         }
     return out
 

--- a/src/travian_api/parsers/html_parser.py
+++ b/src/travian_api/parsers/html_parser.py
@@ -762,6 +762,44 @@ def parse_village_stats_capacity(html: str) -> Dict[int, Dict[str, int]]:
     return out
 
 
+def parse_village_stats_warehouse(html: str) -> Dict[int, Dict[str, Any]]:
+    """Parse /village/statistics/resources/warehouse -> fill/empty countdowns.
+
+    This page is the cheapest source of **true net crop** for the whole account:
+    the countdown is the server's own calculation, so deriving a rate from it
+    needs no upkeep model and no per-village fetch. See
+    docs/20-resource-production.md.
+
+    Returns ``{village_id: {crop_percent, crop_seconds, crop_draining,
+    warehouse_seconds}}``. ``crop_draining`` is the direction of the granary
+    countdown -- True counts down to empty (starving), False to full.
+    """
+    out: Dict[int, Dict[str, Any]] = {}
+    for vid, cells in _stats_village_rows(html, "warehouse"):
+        # village | lumber% | clay% | iron% | warehouse timer | crop% | granary timer
+        if len(cells) < 6:
+            continue
+        granary_timer = cells[5].find("span", class_="timer")
+        if granary_timer is None:
+            continue
+        # Raw seconds live in the attributes; the rendered H:MM:SS is a JS
+        # countdown and would have to be re-parsed for nothing.
+        raw_seconds = granary_timer.get("data-value") or granary_timer.get("value") or ""
+        warehouse_timer = cells[3].find("span", class_="timer")
+        warehouse_raw = ""
+        if warehouse_timer is not None:
+            warehouse_raw = warehouse_timer.get("data-value") or warehouse_timer.get("value") or ""
+
+        out[vid] = {
+            "crop_percent": _stats_int(cells[4].get_text().replace("%", "")),
+            "crop_seconds": _stats_int(str(raw_seconds)),
+            # The game marks a draining granary `crit` and prefixes a minus.
+            "crop_draining": "crit" in (granary_timer.get("class") or []),
+            "warehouse_seconds": _stats_int(str(warehouse_raw)),
+        }
+    return out
+
+
 def parse_village_stats_troops(html: str, tribe_id: int = 0) -> Dict[int, Dict[str, int]]:
     """Parse /village/statistics/troops -> ``{village_id: {t1..t10}}`` for every village.
 

--- a/src/travian_api/parsers/html_parser.py
+++ b/src/travian_api/parsers/html_parser.py
@@ -801,7 +801,8 @@ def parse_village_stats_warehouse(html: str) -> Dict[int, Dict[str, Any]]:
         # village | lumber% | clay% | iron% | warehouse timer | crop% | granary timer
         if len(cells) < 6:
             continue
-        granary_timer = cells[5].find("span", class_="timer")
+        granary_cell = cells[5]
+        granary_timer = granary_cell.find("span", class_="timer")
         if granary_timer is None:
             continue
         # Raw seconds live in the attributes; the rendered H:MM:SS is a JS
@@ -815,8 +816,12 @@ def parse_village_stats_warehouse(html: str) -> Dict[int, Dict[str, Any]]:
         out[vid] = {
             "crop_percent": _stats_int(cells[4].get_text().replace("%", "")),
             "crop_seconds": _stats_int(str(raw_seconds)),
-            # The game marks a draining granary `crit` and prefixes a minus.
-            "crop_draining": "crit" in (granary_timer.get("class") or []),
+            # A draining granary prefixes a `crit`-classed minus span, so detect
+            # it anywhere in the cell. The timer span itself is unreliable: the
+            # live page emits it with a DUPLICATE class attribute
+            # (`class="timer crit" class="timer"`) and BeautifulSoup keeps the
+            # second, dropping `crit` — which read every village as filling.
+            "crop_draining": granary_cell.find(class_="crit") is not None,
             "warehouse_seconds": _stats_int(str(warehouse_raw)),
         }
     return out

--- a/src/travian_api/services/auth_service.py
+++ b/src/travian_api/services/auth_service.py
@@ -26,6 +26,29 @@ JWT_COOKIE_NAME = "JWT"
 class AuthService:
     """Service for handling authentication with Travian server."""
 
+    def _safe_login_redirect(self, redirect_url: str) -> str:
+        """Confine the post-login redirect to the server the user connected to.
+
+        The login host controls ``redirectTo``, and get_html follows absolute
+        URLs; a malicious or compromised server could point it at a loopback
+        or private-network service and turn login into an SSRF. The connect
+        guard vetted base_url already, so requiring the redirect to stay on
+        that same https host (relative URLs resolve against it) closes the
+        hole without a second DNS round-trip. Real Travian auth always
+        redirects within its own host.
+        """
+        from urllib.parse import urlsplit
+
+        base_host = urlsplit(self.settings.base_url).hostname
+        parsed = urlsplit(redirect_url)
+        if not parsed.netloc:
+            return redirect_url  # relative: resolved against base_url by get_html
+        if parsed.scheme != "https" or parsed.hostname != base_host:
+            raise AuthError(
+                f"Login redirect points off-server ({redirect_url!r}); refusing to follow it"
+            )
+        return redirect_url
+
     def __init__(self, http_client: HttpClient, settings: Settings):
         self.http_client = http_client
         self.settings = settings
@@ -105,7 +128,7 @@ class AuthService:
             if "redirectTo" not in response or "code" not in response:
                 raise AuthError("Invalid login response - missing redirectTo or code")
 
-            redirect_url = response["redirectTo"]
+            redirect_url = self._safe_login_redirect(response["redirectTo"])
 
             # Step 2: GET redirect URL to exchange code for JWT cookie (don't follow redirects)
             await self.http_client.get_html(redirect_url, follow_redirects=False, skip_reauth=True)

--- a/src/travian_api/services/auth_service.py
+++ b/src/travian_api/services/auth_service.py
@@ -57,11 +57,20 @@ class AuthService:
             try:
                 await self._load_cached_jwt()
                 if self._auth_state and self._is_jwt_valid(self._auth_state.jwt):
-                    # Lightweight server-side check: fetch player data
+                    # Server-side liveness check. The same single request also
+                    # carries the current player/village state, so a resumed
+                    # session never serves the cache file's stale village list.
                     player_data = await self.http_client.post_json(
-                        "/api/v1/graphql", {"query": "{ ownPlayer { name } }"}, skip_reauth=True
+                        "/api/v1/graphql",
+                        {
+                            "query": "{ ownPlayer { name tribeId villages { id name x y isMainVillage } } }"
+                        },
+                        skip_reauth=True,
                     )
-                    if player_data.get("data", {}).get("ownPlayer"):
+                    own_player = player_data.get("data", {}).get("ownPlayer")
+                    if own_player:
+                        self._apply_own_player(own_player)
+                        await self._cache_jwt(self._auth_state)
                         # Resolve dynamic X-Version with cached session too
                         try:
                             await self.http_client.try_resolve_x_version()
@@ -126,30 +135,7 @@ class AuthService:
                 )
                 own_player = player_data.get("data", {}).get("ownPlayer", {})
                 if own_player:
-                    self._auth_state.player_name = own_player.get("name", "Unknown")
-                    self._auth_state.tribe_id = own_player.get("tribeId", 0)
-                    villages_data = own_player.get("villages", [])
-                    if villages_data:
-                        self._auth_state.villages = [
-                            Village(
-                                id=v["id"],
-                                name=v.get("name", ""),
-                                x=v.get("x", 0),
-                                y=v.get("y", 0),
-                                is_main_village=v.get("isMainVillage", False),
-                            )
-                            for v in villages_data
-                            if v.get("id")
-                        ]
-                        # Set village_id to main village if not already set from JWT
-                        if not self._auth_state.village_id:
-                            main = next(
-                                (v for v in self._auth_state.villages if v.is_main_village), None
-                            )
-                            if main:
-                                self._auth_state.village_id = main.id
-                            elif self._auth_state.villages:
-                                self._auth_state.village_id = self._auth_state.villages[0].id
+                    self._apply_own_player(own_player)
             except Exception:
                 pass  # GraphQL enrichment is best-effort
 
@@ -242,6 +228,31 @@ class AuthService:
     async def _handle_reauth(self) -> None:
         """Handle re-authentication callback from HTTP client."""
         await self.login()
+
+    def _apply_own_player(self, own_player: dict) -> None:
+        """Refresh player identity and villages on the current auth state.
+
+        Also repairs ``village_id`` when it no longer exists on the account —
+        a cached or JWT-derived id can point at a chiefed/lost village.
+        """
+        self._auth_state.player_name = own_player.get("name", "Unknown")
+        self._auth_state.tribe_id = own_player.get("tribeId", 0)
+        villages_data = own_player.get("villages", [])
+        if villages_data:
+            self._auth_state.villages = [
+                Village(
+                    id=v["id"],
+                    name=v.get("name", ""),
+                    x=v.get("x", 0),
+                    y=v.get("y", 0),
+                    is_main_village=v.get("isMainVillage", False),
+                )
+                for v in villages_data
+                if v.get("id")
+            ]
+            if self._auth_state.village_id not in {v.id for v in self._auth_state.villages}:
+                main = next((v for v in self._auth_state.villages if v.is_main_village), None)
+                self._auth_state.village_id = main.id if main else self._auth_state.villages[0].id
 
     def _decode_jwt_payload(self, jwt: str) -> dict:
         """

--- a/src/travian_api/services/building_service.py
+++ b/src/travian_api/services/building_service.py
@@ -208,18 +208,39 @@ class BuildingService:
 
         balances: Dict[int, CropBalance] = {}
         for vid, timer in timers.items():
-            stock = stocks.get(vid, {}).get("crop", 0)
+            # Defaulting a missing stock to 0 would make a draining village
+            # derive to exactly 0/h, which reads as healthy. That silent zero is
+            # the failure this module exists to avoid -- leave the rate unknown.
+            stock = stocks.get(vid, {}).get("crop")
+            if stock is None:
+                logger.warning(
+                    "Village %s has a granary countdown but no stock in the "
+                    "resources table; net crop left underived",
+                    vid,
+                )
             balances[vid] = CropBalance(
                 village_id=vid,
-                stock=stock,
-                net_per_hour=derive_net_crop_per_hour(
-                    stock=stock,
-                    seconds_remaining=timer["crop_seconds"],
-                    draining=timer["crop_draining"],
-                    granary_capacity=capacities.get(vid),
+                stock=stock or 0,
+                net_per_hour=(
+                    None
+                    if stock is None
+                    else derive_net_crop_per_hour(
+                        stock=stock,
+                        seconds_remaining=timer["crop_seconds"],
+                        draining=timer["crop_draining"],
+                        granary_capacity=capacities.get(vid),
+                    )
                 ),
                 draining=timer["crop_draining"],
                 seconds_remaining=timer["crop_seconds"],
+            )
+
+        missing_timer = set(stocks) - set(timers)
+        if missing_timer:
+            logger.warning(
+                "Villages present in the resources table but absent from the "
+                "warehouse table, so they have no crop balance: %s",
+                sorted(missing_timer),
             )
         return balances
 

--- a/src/travian_api/services/building_service.py
+++ b/src/travian_api/services/building_service.py
@@ -170,7 +170,7 @@ class BuildingService:
         self,
         granary_capacity: Optional[Dict[int, int]] = None,
         stocks: Optional[Dict[int, Dict[str, int]]] = None,
-    ) -> Tuple[Dict[int, CropBalance], int]:
+    ) -> Tuple[Dict[int, CropBalance], Dict[int, Dict[str, int]], int]:
         """True net crop for EVERY village in two requests.
 
         Reads absolute stocks and the granary countdown from the account-wide
@@ -193,10 +193,17 @@ class BuildingService:
                 paid for once.
 
         Returns:
-            Tuple of (village_id -> CropBalance, game requests spent). The count
-            is returned so callers can price the fetch honestly instead of
-            assuming the worst case. ``net_per_hour`` is None where it could not
-            be derived; it is never silently zero.
+            Tuple of ``(village_id -> CropBalance, village_id -> {warehouse,
+            granary} capacity, game requests spent)``. The count is returned so
+            callers can price the fetch honestly instead of assuming the worst
+            case. ``net_per_hour`` is None where it could not be derived; it is
+            never silently zero.
+
+            The capacity map is whatever this read already had to fetch, handed
+            back rather than discarded -- storage-safety checks need exactly the
+            same page, and re-fetching it would spend a request twice for data
+            already in hand. It is empty when every granary was draining, since
+            the derivation needed no capacity at all.
 
         Raises:
             TravianError: If a request fails
@@ -223,17 +230,22 @@ class BuildingService:
                     logger.warning("CROPDIAG dump failed: %s", exc)
 
             capacities = dict(granary_capacity or {})
+            # Both capacities off the same page. The granary figure drives the
+            # crop derivation below; the warehouse figure is carried out to the
+            # caller untouched, because storage-safety checks need it and it
+            # arrives free alongside the one we already came for.
+            storage: Dict[int, Dict[str, int]] = {}
             needs_capacity = [
                 vid
                 for vid, timer in timers.items()
                 if not timer["crop_draining"] and vid not in capacities
             ]
             if needs_capacity:
-                fetched = parse_village_stats_capacity(
+                storage = parse_village_stats_capacity(
                     await self.http_client.get_html("/village/statistics/resources/capacity")
                 )
                 requests_spent += 1
-                for vid, caps in fetched.items():
+                for vid, caps in storage.items():
                     capacities.setdefault(vid, caps["granary"])
         except Exception as e:
             raise TravianError(f"Failed to read crop balance: {e}") from e
@@ -287,7 +299,7 @@ class BuildingService:
                 "warehouse table, so they have no crop balance: %s",
                 sorted(missing_timer),
             )
-        return balances, requests_spent
+        return balances, storage, requests_spent
 
     async def get_building_detail(
         self, slot_id: int, village_id: Optional[int] = None

--- a/src/travian_api/services/building_service.py
+++ b/src/travian_api/services/building_service.py
@@ -178,10 +178,12 @@ class BuildingService:
         dorf1 per village. On a 22-village account that is 2 requests instead
         of 22.
 
-        Capacity is only needed for villages whose granary is *filling*, and it
-        changes only when a granary is upgraded -- so pass a cached mapping to
-        stay at two requests. Without one, a third request is made, and only if
-        some village is actually filling.
+        The account-wide capacity page is fetched whenever there are villages,
+        because its warehouse/granary figures are the only source for storage
+        overflow safety -- fetching it only for a *filling* granary would leave
+        an all-draining account with no overflow checks at all. A cached granary
+        mapping still seeds crop derivation, but the page is read regardless so
+        the returned storage map is always complete (three requests, not two).
 
         Args:
             granary_capacity: village id -> granary capacity. Fetched when
@@ -199,11 +201,9 @@ class BuildingService:
             case. ``net_per_hour`` is None where it could not be derived; it is
             never silently zero.
 
-            The capacity map is whatever this read already had to fetch, handed
-            back rather than discarded -- storage-safety checks need exactly the
-            same page, and re-fetching it would spend a request twice for data
-            already in hand. It is empty when every granary was draining, since
-            the derivation needed no capacity at all.
+            The capacity map is the full warehouse+granary read for every
+            village, so storage-safety checks always have it. It is empty only
+            when there are no villages at all.
 
         Raises:
             TravianError: If a request fails
@@ -230,17 +230,14 @@ class BuildingService:
                     logger.warning("CROPDIAG dump failed: %s", exc)
 
             capacities = dict(granary_capacity or {})
-            # Both capacities off the same page. The granary figure drives the
-            # crop derivation below; the warehouse figure is carried out to the
-            # caller untouched, because storage-safety checks need it and it
-            # arrives free alongside the one we already came for.
+            # Fetch the capacity page whenever the account has any village, not
+            # only when a *filling* granary needs its cap to derive net crop.
+            # This page's warehouse + granary figures are the planner's ONLY
+            # source for storage-overflow safety, so gating it on crop direction
+            # silently disabled every lumber/clay/iron overflow check on an
+            # all-draining account. One request buys a complete safety snapshot.
             storage: Dict[int, Dict[str, int]] = {}
-            needs_capacity = [
-                vid
-                for vid, timer in timers.items()
-                if not timer["crop_draining"] and vid not in capacities
-            ]
-            if needs_capacity:
+            if timers:
                 storage = parse_village_stats_capacity(
                     await self.http_client.get_html("/village/statistics/resources/capacity")
                 )

--- a/src/travian_api/services/building_service.py
+++ b/src/travian_api/services/building_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..clients.http_client import HttpClient
 from ..concurrency import KeyedLock
@@ -161,7 +161,7 @@ class BuildingService:
         self,
         granary_capacity: Optional[Dict[int, int]] = None,
         stocks: Optional[Dict[int, Dict[str, int]]] = None,
-    ) -> Dict[int, CropBalance]:
+    ) -> Tuple[Dict[int, CropBalance], int]:
         """True net crop for EVERY village in two requests.
 
         Reads absolute stocks and the granary countdown from the account-wide
@@ -184,20 +184,25 @@ class BuildingService:
                 paid for once.
 
         Returns:
-            Dict of village_id -> CropBalance. ``net_per_hour`` is None where it
-            could not be derived; it is never silently zero.
+            Tuple of (village_id -> CropBalance, game requests spent). The count
+            is returned so callers can price the fetch honestly instead of
+            assuming the worst case. ``net_per_hour`` is None where it could not
+            be derived; it is never silently zero.
 
         Raises:
             TravianError: If a request fails
         """
+        requests_spent = 0
         try:
             if stocks is None:
                 stocks = parse_village_stats_resources(
                     await self.http_client.get_html("/village/statistics/resources")
                 )
+                requests_spent += 1
             timers = parse_village_stats_warehouse(
                 await self.http_client.get_html("/village/statistics/resources/warehouse")
             )
+            requests_spent += 1
 
             capacities = dict(granary_capacity or {})
             needs_capacity = [
@@ -209,6 +214,7 @@ class BuildingService:
                 fetched = parse_village_stats_capacity(
                     await self.http_client.get_html("/village/statistics/resources/capacity")
                 )
+                requests_spent += 1
                 for vid, caps in fetched.items():
                     capacities.setdefault(vid, caps["granary"])
         except Exception as e:
@@ -250,7 +256,7 @@ class BuildingService:
                 "warehouse table, so they have no crop balance: %s",
                 sorted(missing_timer),
             )
-        return balances
+        return balances, requests_spent
 
     async def get_building_detail(
         self, slot_id: int, village_id: Optional[int] = None

--- a/src/travian_api/services/building_service.py
+++ b/src/travian_api/services/building_service.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from ..clients.http_client import HttpClient
@@ -31,6 +34,12 @@ from ..parsers.html_parser import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _crop_diag_dir() -> Path:
+    """Where TRAVIAN_DIST_DIAG writes the raw statistics HTML for debugging the
+    net-crop derivation. Off unless that env var is set."""
+    return Path(tempfile.gettempdir()) / "travian_crop_diag"
 
 
 def derive_net_crop_per_hour(
@@ -193,16 +202,25 @@ class BuildingService:
             TravianError: If a request fails
         """
         requests_spent = 0
+        _diag = bool(os.environ.get("TRAVIAN_DIST_DIAG"))
         try:
             if stocks is None:
                 stocks = parse_village_stats_resources(
                     await self.http_client.get_html("/village/statistics/resources")
                 )
                 requests_spent += 1
-            timers = parse_village_stats_warehouse(
-                await self.http_client.get_html("/village/statistics/resources/warehouse")
+            warehouse_html = await self.http_client.get_html(
+                "/village/statistics/resources/warehouse"
             )
+            timers = parse_village_stats_warehouse(warehouse_html)
             requests_spent += 1
+            if _diag:
+                try:
+                    out = _crop_diag_dir()
+                    out.mkdir(parents=True, exist_ok=True)
+                    (out / "warehouse.html").write_text(warehouse_html, encoding="utf-8")
+                except Exception as exc:  # diagnostics must never break the read
+                    logger.warning("CROPDIAG dump failed: %s", exc)
 
             capacities = dict(granary_capacity or {})
             needs_capacity = [
@@ -232,19 +250,32 @@ class BuildingService:
                     "resources table; net crop left underived",
                     vid,
                 )
+            net = (
+                None
+                if stock is None
+                else derive_net_crop_per_hour(
+                    stock=stock,
+                    seconds_remaining=timer["crop_seconds"],
+                    draining=timer["crop_draining"],
+                    granary_capacity=capacities.get(vid),
+                )
+            )
+            if _diag:
+                logger.warning(
+                    "CROPDIAG vid=%s stock=%s draining=%s crop_seconds=%s "
+                    "crop_percent=%s capacity=%s -> net=%s",
+                    vid,
+                    stock,
+                    timer["crop_draining"],
+                    timer["crop_seconds"],
+                    timer.get("crop_percent"),
+                    capacities.get(vid),
+                    net,
+                )
             balances[vid] = CropBalance(
                 village_id=vid,
                 stock=stock or 0,
-                net_per_hour=(
-                    None
-                    if stock is None
-                    else derive_net_crop_per_hour(
-                        stock=stock,
-                        seconds_remaining=timer["crop_seconds"],
-                        draining=timer["crop_draining"],
-                        granary_capacity=capacities.get(vid),
-                    )
-                ),
+                net_per_hour=net,
                 draining=timer["crop_draining"],
                 seconds_remaining=timer["crop_seconds"],
             )

--- a/src/travian_api/services/building_service.py
+++ b/src/travian_api/services/building_service.py
@@ -10,7 +10,14 @@ from ..concurrency import KeyedLock
 from ..constants import BUILDING_NAMES
 from ..debug_dump import debug_dumper
 from ..exceptions import TravianError
-from ..models.buildings import Building, BuildingDetail, QueueItem, Resources, UpgradeResult
+from ..models.buildings import (
+    Building,
+    BuildingDetail,
+    CropBalance,
+    QueueItem,
+    Resources,
+    UpgradeResult,
+)
 from ..parsers.html_parser import (
     parse_build_page,
     parse_construction_queue,
@@ -18,9 +25,46 @@ from ..parsers.html_parser import (
     parse_dorf2,
     parse_empty_slot_buildings,
     parse_resources,
+    parse_village_stats_capacity,
+    parse_village_stats_resources,
+    parse_village_stats_warehouse,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def derive_net_crop_per_hour(
+    stock: int,
+    seconds_remaining: int,
+    draining: bool,
+    granary_capacity: Optional[int] = None,
+) -> Optional[float]:
+    """Net crop per hour implied by a granary countdown.
+
+    The countdown is the server's own arithmetic, so inverting it sidesteps the
+    upkeep model entirely -- no troop table, no population figure, and no
+    confusion about which village feeds troops standing somewhere else::
+
+        draining:  net = -stock / hours
+        filling:   net = (capacity - stock) / hours
+
+    Returns None rather than 0 when the rate cannot be derived, because a
+    village reported as "0 net crop" is indistinguishable from a healthy one and
+    that is precisely the silent-zero failure this codebase keeps hitting.
+
+    Note:
+        The draining branch is verified against a live village to 0.5%. The
+        filling branch is **not yet validated** -- see R2 in
+        docs/25-resource-distribution-planner.md.
+    """
+    if seconds_remaining <= 0:
+        return None
+    hours = seconds_remaining / 3600.0
+    if draining:
+        return -stock / hours
+    if granary_capacity is None:
+        return None
+    return (granary_capacity - stock) / hours
 
 
 class BuildingService:
@@ -112,6 +156,72 @@ class BuildingService:
         """
         buildings, _ = await self.get_village_snapshot(village_id)
         return buildings
+
+    async def get_all_villages_net_crop(
+        self, granary_capacity: Optional[Dict[int, int]] = None
+    ) -> Dict[int, CropBalance]:
+        """True net crop for EVERY village in two requests.
+
+        Reads absolute stocks and the granary countdown from the account-wide
+        statistics tables and inverts the countdown, rather than fetching one
+        dorf1 per village. On a 22-village account that is 2 requests instead
+        of 22.
+
+        Capacity is only needed for villages whose granary is *filling*, and it
+        changes only when a granary is upgraded -- so pass a cached mapping to
+        stay at two requests. Without one, a third request is made, and only if
+        some village is actually filling.
+
+        Args:
+            granary_capacity: village id -> granary capacity. Fetched when
+                omitted and needed.
+
+        Returns:
+            Dict of village_id -> CropBalance. ``net_per_hour`` is None where it
+            could not be derived; it is never silently zero.
+
+        Raises:
+            TravianError: If a request fails
+        """
+        try:
+            stocks = parse_village_stats_resources(
+                await self.http_client.get_html("/village/statistics/resources")
+            )
+            timers = parse_village_stats_warehouse(
+                await self.http_client.get_html("/village/statistics/resources/warehouse")
+            )
+
+            capacities = dict(granary_capacity or {})
+            needs_capacity = [
+                vid
+                for vid, timer in timers.items()
+                if not timer["crop_draining"] and vid not in capacities
+            ]
+            if needs_capacity:
+                fetched = parse_village_stats_capacity(
+                    await self.http_client.get_html("/village/statistics/resources/capacity")
+                )
+                for vid, caps in fetched.items():
+                    capacities.setdefault(vid, caps["granary"])
+        except Exception as e:
+            raise TravianError(f"Failed to read crop balance: {e}") from e
+
+        balances: Dict[int, CropBalance] = {}
+        for vid, timer in timers.items():
+            stock = stocks.get(vid, {}).get("crop", 0)
+            balances[vid] = CropBalance(
+                village_id=vid,
+                stock=stock,
+                net_per_hour=derive_net_crop_per_hour(
+                    stock=stock,
+                    seconds_remaining=timer["crop_seconds"],
+                    draining=timer["crop_draining"],
+                    granary_capacity=capacities.get(vid),
+                ),
+                draining=timer["crop_draining"],
+                seconds_remaining=timer["crop_seconds"],
+            )
+        return balances
 
     async def get_building_detail(
         self, slot_id: int, village_id: Optional[int] = None

--- a/src/travian_api/services/building_service.py
+++ b/src/travian_api/services/building_service.py
@@ -158,7 +158,9 @@ class BuildingService:
         return buildings
 
     async def get_all_villages_net_crop(
-        self, granary_capacity: Optional[Dict[int, int]] = None
+        self,
+        granary_capacity: Optional[Dict[int, int]] = None,
+        stocks: Optional[Dict[int, Dict[str, int]]] = None,
     ) -> Dict[int, CropBalance]:
         """True net crop for EVERY village in two requests.
 
@@ -175,6 +177,11 @@ class BuildingService:
         Args:
             granary_capacity: village id -> granary capacity. Fetched when
                 omitted and needed.
+            stocks: already-parsed output of ``parse_village_stats_resources``.
+                Pass it when the caller has fetched that page for something else
+                -- merchant counts live on it too -- so the page is not fetched
+                twice. That duplicate fetch is a waste this codebase has already
+                paid for once.
 
         Returns:
             Dict of village_id -> CropBalance. ``net_per_hour`` is None where it
@@ -184,9 +191,10 @@ class BuildingService:
             TravianError: If a request fails
         """
         try:
-            stocks = parse_village_stats_resources(
-                await self.http_client.get_html("/village/statistics/resources")
-            )
+            if stocks is None:
+                stocks = parse_village_stats_resources(
+                    await self.http_client.get_html("/village/statistics/resources")
+                )
             timers = parse_village_stats_warehouse(
                 await self.http_client.get_html("/village/statistics/resources/warehouse")
             )

--- a/src/travian_api/services/defense_cache.py
+++ b/src/travian_api/services/defense_cache.py
@@ -3,8 +3,13 @@
 L1: cachetools.TTLCache for hot reads (5-minute TTL, max 500 entries)
 L2: diskcache.Cache on disk (survives restarts, adaptive TTL per target)
 
-Cache key: "defense:{x}:{y}"
+Cache key: "defense:{scope}:{x}:{y}" where scope is "{server_url}|{player_name}"
 Cache value: dict with defense data + metadata for adaptive TTL
+
+The scope is not optional. Defense data is read out of the ACCOUNT'S OWN raid
+reports, so the same coordinates mean different data per account -- and per
+world they are simply different villages. An unscoped key let one user read
+another's report and raid on it.
 """
 
 from __future__ import annotations
@@ -46,12 +51,12 @@ class TieredDefenseCache:
         return self._l2
 
     @staticmethod
-    def _key(x: int, y: int) -> str:
-        return f"defense:{x}:{y}"
+    def _key(scope: str, x: int, y: int) -> str:
+        return f"defense:{scope}:{x}:{y}"
 
-    def get(self, x: int, y: int, last_raid_time: int) -> dict[str, Any] | None:
+    def get(self, scope: str, x: int, y: int, last_raid_time: int) -> dict[str, Any] | None:
         """Get cached defense data. Returns None if missing, expired, or stale."""
-        key = self._key(x, y)
+        key = self._key(scope, x, y)
 
         # L1 check
         entry = self._l1.get(key)
@@ -86,9 +91,11 @@ class TieredDefenseCache:
         self._stats["l2_hits"] += 1
         return entry
 
-    def put(self, x: int, y: int, last_raid_time: int, defense_data: dict[str, Any]) -> None:
+    def put(
+        self, scope: str, x: int, y: int, last_raid_time: int, defense_data: dict[str, Any]
+    ) -> None:
         """Store defense data in both L1 and L2."""
-        key = self._key(x, y)
+        key = self._key(scope, x, y)
 
         # Compute adaptive TTL from change history
         prev = None
@@ -136,19 +143,19 @@ class TieredDefenseCache:
             return _DEFAULT_TTL
         return _VOLATILE_TTL
 
-    def get_inflight(self, x: int, y: int) -> asyncio.Future | None:
+    def get_inflight(self, scope: str, x: int, y: int) -> asyncio.Future | None:
         """Check if a fetch is already in-flight for this coordinate."""
-        return self._inflight.get(self._key(x, y))
+        return self._inflight.get(self._key(scope, x, y))
 
-    def set_inflight(self, x: int, y: int) -> asyncio.Future:
+    def set_inflight(self, scope: str, x: int, y: int) -> asyncio.Future:
         """Register an in-flight fetch. Returns the Future to resolve."""
-        key = self._key(x, y)
+        key = self._key(scope, x, y)
         fut: asyncio.Future = asyncio.get_event_loop().create_future()
         self._inflight[key] = fut
         return fut
 
-    def clear_inflight(self, x: int, y: int) -> None:
-        self._inflight.pop(self._key(x, y), None)
+    def clear_inflight(self, scope: str, x: int, y: int) -> None:
+        self._inflight.pop(self._key(scope, x, y), None)
 
     def get_stats(self) -> dict[str, Any]:
         """Return cache statistics for observability."""
@@ -193,5 +200,6 @@ class TieredDefenseCache:
         self._stats = {"l1_hits": 0, "l2_hits": 0, "misses": 0}
 
 
-# Module-level singleton (shared across all users — keys include coordinates, not user_id)
+# Module-level singleton. Shared across all users, which is exactly why every
+# key carries the caller's scope (server + player) alongside the coordinates.
 defense_cache = TieredDefenseCache()

--- a/src/travian_api/services/distribution/__init__.py
+++ b/src/travian_api/services/distribution/__init__.py
@@ -11,10 +11,15 @@ Module map (built in dependency order):
 
     geometry.py    toroidal distance and travel time            [done]
     merchants.py   capacity model + route cost + cycle choice    [done]
-    allocation.py  allocation modes -> per-village ship gaps     [next]
-    optimizer.py   hub assignment and route selection
-    schedule.py    the 24-hour beat
-    planner.py     orchestration: snapshot -> Plan
+    allocation.py  allocation modes -> per-village ship gaps     [done]
+    optimizer.py   flows -> routes, budgets, infeasibilities     [first pass]
+    schedule.py    the 24-hour beat                              [next]
+    planner.py     orchestration: fetched snapshot -> Plan
+
+Nothing in this package hardcodes an account. Village count grows as the account
+expands -- 22 today, 23 landing -- and every production figure differs between
+runs, so state is always passed in and correctness is pinned by properties that
+hold for *any* number of villages rather than by a fixture of one snapshot.
 
 Two review findings are structural rather than incidental, so they are encoded
 here rather than left to callers:

--- a/src/travian_api/services/distribution/__init__.py
+++ b/src/travian_api/services/distribution/__init__.py
@@ -1,0 +1,27 @@
+"""Resource distribution planner.
+
+Design and review: ``docs/25-resource-distribution-planner.md``.
+
+Everything in this package is a **pure function of a snapshot**. No module here
+performs I/O or touches the game; fetching lives in the existing services and is
+passed in. That keeps the whole planner testable without a session and without
+spending requests, which is the scarce resource this tool exists to conserve.
+
+Module map (built in dependency order):
+
+    geometry.py    toroidal distance and travel time            [done]
+    merchants.py   capacity model + route cost + cycle choice    [done]
+    allocation.py  allocation modes -> per-village ship gaps     [next]
+    optimizer.py   hub assignment and route selection
+    schedule.py    the 24-hour beat
+    planner.py     orchestration: snapshot -> Plan
+
+Two review findings are structural rather than incidental, so they are encoded
+here rather than left to callers:
+
+* **R1** — the merchant capacity constants are disputed. ``merchants`` keeps
+  them in one injectable :class:`~.merchants.MerchantModel` and can derive them
+  from observation instead of trusting a default.
+* **R5** — a schedule can only be expressed as a repeating daily beat if every
+  cycle divides 24 hours, so that is the default cycle set.
+"""

--- a/src/travian_api/services/distribution/__init__.py
+++ b/src/travian_api/services/distribution/__init__.py
@@ -12,9 +12,22 @@ Module map (built in dependency order):
     geometry.py    toroidal distance and travel time            [done]
     merchants.py   capacity model + route cost + cycle choice    [done]
     allocation.py  allocation modes -> per-village ship gaps     [done]
+    rounding.py    sum-preserving integer cargo                  [done]
     optimizer.py   flows -> routes, budgets, infeasibilities     [first pass]
-    schedule.py    the 24-hour beat                              [next]
-    planner.py     orchestration: fetched snapshot -> Plan
+    schedule.py    the 24-hour beat                              [done]
+    planner.py     orchestration: snapshot -> setup sheet        [done]
+
+Not yet built, and deliberately not faked:
+
+* **Hub consolidation** (profile 8.5) and escalation steps 2-3 of 8.4 -- reroute
+  via a nearer hub, split cargo across paths. The optimizer sweeps cycles and
+  recommends a Trade Office upgrade, then declares infeasibility rather than
+  quietly trimming a route to fit.
+* **Crop relay through a sub-hub** (profile 3.5). Netting in ``allocation``
+  leaves each village either a sender or a receiver of a resource, never both,
+  so a relay cannot be expressed. It needs multi-leg flows, not a scheduling
+  change.
+* **NPC, storage safety, apply and monitoring** (profile sections 6-9).
 
 Nothing in this package hardcodes an account. Village count grows as the account
 expands -- 22 today, 23 landing -- and every production figure differs between

--- a/src/travian_api/services/distribution/allocation.py
+++ b/src/travian_api/services/distribution/allocation.py
@@ -1,0 +1,226 @@
+"""Allocation modes resolved into per-village shipping rates.
+
+The one thing this module exists to get right is **ship, not target**. Known
+issue #1 in ``docs/25-resource-distribution-planner.md`` is shipping a village's
+*target* when the correct cargo is the *gap* between its target and what it
+already produces -- an error made twice by hand. So :class:`VillageAllocation`
+computes ``ship_per_hour`` itself and there is no way to obtain a target without
+the ship figure sitting beside it.
+
+Rates only. Turning a rate into an integer cargo per send, with sum-preserving
+rounding, belongs to the route stage -- rounding here would compound across
+cycle lengths.
+
+Sign convention: ``ship_per_hour`` is **positive into** the village. A negative
+value means the village sends that much away. Crop production may itself be
+negative for army villages, which is the case that makes sustain mode necessary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+# Rates are floats; treat anything under this as zero rather than warning about
+# a rounding artifact of the percentage arithmetic.
+EPSILON = 1e-6
+
+
+class Resource(StrEnum):
+    LUMBER = "lumber"
+    CLAY = "clay"
+    IRON = "iron"
+    CROP = "crop"
+
+
+class AllocationMode(StrEnum):
+    PERCENTAGE = "percentage"
+    """Share of total account production of this resource, 0-100."""
+
+    ABSOLUTE = "absolute"
+    """Fixed retention rate per hour."""
+
+    SUSTAIN = "sustain"
+    """Cover a negative production deficit plus ``value`` percent headroom."""
+
+    REMAINDER = "remainder"
+    """Absorb everything unallocated. Exactly one village per resource."""
+
+    KEEP = "keep"
+    """Neither send nor receive. The default for unlisted villages."""
+
+
+class AllocationError(ValueError):
+    """The allocation set cannot be resolved as written."""
+
+
+@dataclass(frozen=True)
+class Allocation:
+    """One village's instruction for one resource."""
+
+    mode: AllocationMode
+    value: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.mode is AllocationMode.PERCENTAGE and not 0 <= self.value <= 100:
+            raise AllocationError(f"percentage must be 0-100, got {self.value}")
+        if self.mode is AllocationMode.SUSTAIN and self.value < 0:
+            raise AllocationError(f"sustain headroom cannot be negative, got {self.value}")
+
+
+@dataclass(frozen=True)
+class VillageAllocation:
+    """What one village keeps, and what must move to make that true."""
+
+    village_id: int
+    mode: AllocationMode
+    own_per_hour: float
+    target_per_hour: float
+
+    @property
+    def ship_per_hour(self) -> float:
+        """Rate that must arrive (positive) or leave (negative). The cargo.
+
+        Never ship ``target_per_hour``; a village already produces
+        ``own_per_hour`` of its own target.
+        """
+        return self.target_per_hour - self.own_per_hour
+
+    @property
+    def is_receiver(self) -> bool:
+        return self.ship_per_hour > EPSILON
+
+    @property
+    def is_sender(self) -> bool:
+        return self.ship_per_hour < -EPSILON
+
+
+@dataclass(frozen=True)
+class ResourcePlan:
+    """Resolved allocation for one resource across the account."""
+
+    resource: Resource
+    total_production: float
+    villages: tuple[VillageAllocation, ...]
+    remainder_village_id: int | None
+    unallocated: float
+    warnings: tuple[str, ...]
+
+    @property
+    def is_conserved(self) -> bool:
+        """True when shipping nets to zero -- nothing created or destroyed."""
+        return abs(sum(v.ship_per_hour for v in self.villages)) <= EPSILON
+
+    @property
+    def receivers(self) -> tuple[VillageAllocation, ...]:
+        return tuple(v for v in self.villages if v.is_receiver)
+
+    @property
+    def senders(self) -> tuple[VillageAllocation, ...]:
+        return tuple(v for v in self.villages if v.is_sender)
+
+
+def _explicit_target(allocation: Allocation, own: float, total: float) -> float:
+    """Retention rate this allocation asks for, before the remainder is settled."""
+    if allocation.mode is AllocationMode.PERCENTAGE:
+        return total * allocation.value / 100.0
+    if allocation.mode is AllocationMode.ABSOLUTE:
+        return allocation.value
+    if allocation.mode is AllocationMode.SUSTAIN:
+        # Ship the whole deficit plus headroom, so the village ends up positive
+        # by exactly the headroom. A village that is not in deficit needs
+        # nothing: sustain is a floor, not a top-up.
+        if own >= 0:
+            return own
+        return -own * allocation.value / 100.0
+    return own  # KEEP
+
+
+def resolve_resource(
+    resource: Resource,
+    productions: Mapping[int, float],
+    allocations: Mapping[int, Allocation],
+) -> ResourcePlan:
+    """Resolve one resource's allocations into per-village shipping rates.
+
+    Args:
+        resource: which resource this plan covers.
+        productions: village id -> own net production per hour. May be negative
+            for crop.
+        allocations: village id -> allocation. Villages absent from this mapping
+            default to :attr:`AllocationMode.KEEP` and neither send nor receive.
+
+    Returns:
+        A :class:`ResourcePlan`. Problems that leave the plan usable but wrong
+        (unassigned slack, over-allocation) are reported in ``warnings`` rather
+        than raised, so the UI can show them in place; problems that make the
+        plan meaningless raise.
+
+    Raises:
+        AllocationError: more than one remainder village, or an allocation for a
+            village with no production figure.
+    """
+    unknown = set(allocations) - set(productions)
+    if unknown:
+        raise AllocationError(
+            f"allocations reference villages with no production: {sorted(unknown)}"
+        )
+
+    remainder_ids = [vid for vid, a in allocations.items() if a.mode is AllocationMode.REMAINDER]
+    if len(remainder_ids) > 1:
+        raise AllocationError(
+            f"{resource.value}: exactly one remainder village is allowed, got "
+            f"{sorted(remainder_ids)}. Slack has to land somewhere specific."
+        )
+    remainder_id = remainder_ids[0] if remainder_ids else None
+
+    total = sum(productions.values())
+    warnings: list[str] = []
+
+    targets: dict[int, float] = {}
+    for vid, own in productions.items():
+        allocation = allocations.get(vid, Allocation(AllocationMode.KEEP))
+        if allocation.mode is AllocationMode.REMAINDER:
+            continue  # settled below, once everything else is known
+        if allocation.mode is AllocationMode.SUSTAIN and own >= 0:
+            warnings.append(
+                f"village {vid} is set to sustain but its {resource.value} "
+                f"production is not negative ({own:.0f}/h); nothing to sustain"
+            )
+        targets[vid] = _explicit_target(allocation, own, total)
+
+    unallocated = total - sum(targets.values())
+
+    if remainder_id is not None:
+        targets[remainder_id] = unallocated
+        if unallocated < -EPSILON:
+            warnings.append(
+                f"{resource.value}: allocations exceed production by "
+                f"{-unallocated:.0f}/h, so the remainder village {remainder_id} "
+                f"would have to send more than it has"
+            )
+    elif abs(unallocated) > EPSILON:
+        warnings.append(
+            f"{resource.value}: {unallocated:.0f}/h is unallocated and no "
+            f"remainder village is set, so it will pile up wherever it is produced"
+        )
+
+    villages = tuple(
+        VillageAllocation(
+            village_id=vid,
+            mode=allocations.get(vid, Allocation(AllocationMode.KEEP)).mode,
+            own_per_hour=own,
+            target_per_hour=targets[vid],
+        )
+        for vid, own in sorted(productions.items())
+    )
+
+    return ResourcePlan(
+        resource=resource,
+        total_production=total,
+        villages=villages,
+        remainder_village_id=remainder_id,
+        unallocated=unallocated,
+        warnings=tuple(warnings),
+    )

--- a/src/travian_api/services/distribution/allocation.py
+++ b/src/travian_api/services/distribution/allocation.py
@@ -58,6 +58,18 @@ class AllocationError(ValueError):
     """The allocation set cannot be resolved as written."""
 
 
+def village_label(village_id: int, names: Mapping[int, str] | None = None) -> str:
+    """How a village is named to the operator.
+
+    Every message a human reads goes through here. A village id is an internal
+    handle -- nobody running the account knows which village 53629 is, and a
+    warning they cannot act on is barely better than no warning. Falls back to
+    the id only when there is genuinely no name to use, and says so.
+    """
+    name = (names or {}).get(village_id)
+    return name if name else f"village {village_id}"
+
+
 @dataclass(frozen=True)
 class Allocation:
     """One village's instruction for one resource."""
@@ -145,6 +157,7 @@ def resolve_resource(
     resource: Resource,
     productions: Mapping[int, float],
     allocations: Mapping[int, Allocation],
+    names: Mapping[int, str] | None = None,
 ) -> ResourcePlan:
     """Resolve one resource's allocations into per-village shipping rates.
 
@@ -169,14 +182,16 @@ def resolve_resource(
     unknown = set(allocations) - set(productions)
     if unknown:
         raise AllocationError(
-            f"allocations reference villages with no production: {sorted(unknown)}"
+            "allocations reference villages with no production: "
+            + ", ".join(village_label(vid, names) for vid in sorted(unknown))
         )
 
     remainder_ids = [vid for vid, a in allocations.items() if a.mode is AllocationMode.REMAINDER]
     if len(remainder_ids) > 1:
         raise AllocationError(
             f"{resource.value}: exactly one remainder village is allowed, got "
-            f"{sorted(remainder_ids)}. Slack has to land somewhere specific."
+            + ", ".join(village_label(vid, names) for vid in sorted(remainder_ids))
+            + ". Slack has to land somewhere specific."
         )
     remainder_id = remainder_ids[0] if remainder_ids else None
 
@@ -201,7 +216,7 @@ def resolve_resource(
             continue  # settled below, once everything else is known
         if allocation.mode is AllocationMode.SUSTAIN and own >= 0:
             warnings.append(
-                f"village {vid} is set to sustain but its {resource.value} "
+                f"{village_label(vid, names)} is set to sustain but its {resource.value} "
                 f"production is not negative ({own:.0f}/h); nothing to sustain"
             )
         targets[vid] = _explicit_target(allocation, own, total)
@@ -213,7 +228,8 @@ def resolve_resource(
         if unallocated < -EPSILON:
             warnings.append(
                 f"{resource.value}: allocations exceed production by "
-                f"{-unallocated:.0f}/h, so the remainder village {remainder_id} "
+                f"{-unallocated:.0f}/h, so the remainder village "
+                f"{village_label(remainder_id, names)} "
                 f"would have to send more than it has"
             )
     elif abs(unallocated) > EPSILON:

--- a/src/travian_api/services/distribution/allocation.py
+++ b/src/travian_api/services/distribution/allocation.py
@@ -23,8 +23,11 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 # Rates are floats; treat anything under this as zero rather than warning about
-# a rounding artifact of the percentage arithmetic.
+# a rounding artifact of the percentage arithmetic. Conservation scales this by
+# the account total, because summing twenty five-figure rates accumulates more
+# float error than a fixed absolute tolerance allows for.
 EPSILON = 1e-6
+CONSERVATION_RELATIVE_TOLERANCE = 1e-9
 
 
 class Resource(StrEnum):
@@ -110,7 +113,8 @@ class ResourcePlan:
     @property
     def is_conserved(self) -> bool:
         """True when shipping nets to zero -- nothing created or destroyed."""
-        return abs(sum(v.ship_per_hour for v in self.villages)) <= EPSILON
+        tolerance = max(EPSILON, abs(self.total_production) * CONSERVATION_RELATIVE_TOLERANCE)
+        return abs(sum(v.ship_per_hour for v in self.villages)) <= tolerance
 
     @property
     def receivers(self) -> tuple[VillageAllocation, ...]:
@@ -177,6 +181,16 @@ def resolve_resource(
 
     total = sum(productions.values())
     warnings: list[str] = []
+
+    # A percentage of a negative total is meaningless: 30% of an account that is
+    # net -4,000 crop/h is a target of -1,200, which reads as an instruction to
+    # ship crop away from a village that is already starving.
+    if total < 0 and any(a.mode is AllocationMode.PERCENTAGE for a in allocations.values()):
+        warnings.append(
+            f"{resource.value}: account production is negative ({total:.0f}/h), so "
+            f"percentage targets resolve to negative amounts. Use absolute or "
+            f"sustain targets until the account is net positive."
+        )
 
     targets: dict[int, float] = {}
     for vid, own in productions.items():

--- a/src/travian_api/services/distribution/allocation.py
+++ b/src/travian_api/services/distribution/allocation.py
@@ -162,8 +162,9 @@ def resolve_resource(
         plan meaningless raise.
 
     Raises:
-        AllocationError: more than one remainder village, or an allocation for a
-            village with no production figure.
+        AllocationError: more than one remainder village, an allocation for a
+            village with no production figure, or a percentage allocation
+            against a negative account total.
     """
     unknown = set(allocations) - set(productions)
     if unknown:
@@ -184,9 +185,10 @@ def resolve_resource(
 
     # A percentage of a negative total is meaningless: 30% of an account that is
     # net -4,000 crop/h is a target of -1,200, which reads as an instruction to
-    # ship crop away from a village that is already starving.
+    # ship crop away from a village that is already starving. The resolved
+    # routes would be wrong, not merely noisy, so this raises rather than warns.
     if total < 0 and any(a.mode is AllocationMode.PERCENTAGE for a in allocations.values()):
-        warnings.append(
+        raise AllocationError(
             f"{resource.value}: account production is negative ({total:.0f}/h), so "
             f"percentage targets resolve to negative amounts. Use absolute or "
             f"sustain targets until the account is net positive."

--- a/src/travian_api/services/distribution/allocation.py
+++ b/src/travian_api/services/distribution/allocation.py
@@ -224,6 +224,12 @@ def resolve_resource(
     unallocated = total - sum(targets.values())
 
     if remainder_id is not None:
+        # The remainder holds whatever is left. When over-allocated this goes
+        # negative, which the day-check needs verbatim to model the sender
+        # draining its stock. The PLAN must not treat that negative target as
+        # sustainable surplus, though: the optimizer caps each sender's shippable
+        # surplus at its own production, so the shortfall surfaces there and the
+        # plan is reported infeasible rather than emitting an impossible rate.
         targets[remainder_id] = unallocated
         if unallocated < -EPSILON:
             warnings.append(

--- a/src/travian_api/services/distribution/geometry.py
+++ b/src/travian_api/services/distribution/geometry.py
@@ -1,0 +1,60 @@
+"""Toroidal map geometry: distances and travel times between villages.
+
+Pure functions. The Travian map wraps at its edges, so the shortest path between
+two villages may cross the boundary rather than run through the middle -- a
+village at x=-190 and one at x=190 are neighbours on a 401-wide map, not 380
+fields apart.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+Coord = tuple[int, int]
+
+
+@dataclass(frozen=True)
+class MapGeometry:
+    """Distance and travel-time model for one server.
+
+    Args:
+        span: full map width in fields. Travian coordinates run -N..+N, so a
+            map whose corners are +/-200 has ``span = 401``.
+        speed_fields_per_hour: merchant speed. **Tribe-specific** (Teuton 12,
+            Roman 16, Gaul 24 at 1x) -- it belongs with the tribe, not in
+            global config, see review R9.
+    """
+
+    span: int
+    speed_fields_per_hour: float
+
+    def __post_init__(self) -> None:
+        if self.span <= 0:
+            raise ValueError(f"span must be positive, got {self.span}")
+        if self.speed_fields_per_hour <= 0:
+            raise ValueError(f"speed must be positive, got {self.speed_fields_per_hour}")
+
+    def _axis_delta(self, a: int, b: int) -> int:
+        """Shortest separation on one wrapped axis."""
+        raw = abs(a - b)
+        return min(raw, self.span - raw)
+
+    def distance(self, origin: Coord, target: Coord) -> float:
+        """Euclidean distance in fields, taking the wrap into account."""
+        return math.hypot(
+            self._axis_delta(origin[0], target[0]),
+            self._axis_delta(origin[1], target[1]),
+        )
+
+    def one_way_minutes(self, origin: Coord, target: Coord) -> float:
+        """Travel time one way, in minutes."""
+        return self.distance(origin, target) / self.speed_fields_per_hour * 60.0
+
+    def round_trip_minutes(self, origin: Coord, target: Coord) -> float:
+        """Travel time there and back, in minutes.
+
+        This is what sizes a merchant pool: a merchant is unavailable for the
+        whole round trip, not just the delivery.
+        """
+        return 2.0 * self.one_way_minutes(origin, target)

--- a/src/travian_api/services/distribution/merchants.py
+++ b/src/travian_api/services/distribution/merchants.py
@@ -1,0 +1,251 @@
+"""Merchant capacity and the cost of running a trade route.
+
+Two review findings from ``docs/25-resource-distribution-planner.md`` shape this
+module:
+
+**R1 — the capacity constants are disputed.** The profiling doc used
+``base 2200`` with ``+20%`` per Trade Office level; published Teuton values are
+``base 1000`` and ``+10%`` (``+20%`` is the Roman rate). Both errors overstate
+capacity, which under-provisions merchants -- the unsafe direction. Rather than
+pick a side, capacity lives in one injectable :class:`MerchantModel` that can be
+*derived from observation* via :func:`calibrate`. Nothing else in the planner is
+allowed to hardcode a capacity.
+
+**R5 — cycles should divide 24 hours.** Otherwise the schedule has no repeating
+daily period and cannot be written down as a beat. :data:`DAILY_BEAT_CYCLES` is
+the default; :data:`ALL_CYCLES` remains available so the optimizer can quantify
+what the restriction costs instead of hiding it.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+# Cycle lengths that divide a day, so the schedule repeats every 24h (R5).
+DAILY_BEAT_CYCLES: tuple[int, ...] = (1, 2, 3, 4, 6, 8, 12, 24)
+
+# Every cycle Gold Club accepts. Use to measure what DAILY_BEAT_CYCLES costs.
+ALL_CYCLES: tuple[int, ...] = tuple(range(1, 25))
+
+
+@dataclass(frozen=True)
+class MerchantModel:
+    """How much one merchant carries, and how fast it travels.
+
+    ``capacity = base_capacity * (1 + bonus_per_trade_office_level * level)``
+
+    Warning:
+        The stock constants below are **published values, unverified for any
+        particular server**. Trade artifacts multiply merchant capacity and can
+        be captured or lost, and server speed scales it. Prefer
+        :func:`calibrate` on real observations over trusting a default.
+    """
+
+    base_capacity: int
+    bonus_per_trade_office_level: float
+    speed_fields_per_hour: float
+
+    def __post_init__(self) -> None:
+        if self.base_capacity <= 0:
+            raise ValueError(f"base_capacity must be positive, got {self.base_capacity}")
+        if self.bonus_per_trade_office_level < 0:
+            raise ValueError("bonus_per_trade_office_level cannot be negative")
+
+    def capacity(self, trade_office_level: int = 0) -> int:
+        """Carrying capacity of one merchant, rounded **down**.
+
+        Flooring is deliberate. Understating capacity over-provisions merchants,
+        which wastes some; overstating it under-provisions, which silently
+        breaches the village's merchant budget. Only the first is recoverable.
+        """
+        if trade_office_level < 0:
+            raise ValueError(f"trade office level cannot be negative, got {trade_office_level}")
+        scaled = self.base_capacity * (1 + self.bonus_per_trade_office_level * trade_office_level)
+        return math.floor(scaled)
+
+
+# Published stock values at 1x. UNVERIFIED for this account -- see R1.
+STOCK_TEUTON = MerchantModel(
+    base_capacity=1000, bonus_per_trade_office_level=0.10, speed_fields_per_hour=12.0
+)
+STOCK_ROMAN = MerchantModel(
+    base_capacity=500, bonus_per_trade_office_level=0.20, speed_fields_per_hour=16.0
+)
+STOCK_GAUL = MerchantModel(
+    base_capacity=750, bonus_per_trade_office_level=0.10, speed_fields_per_hour=24.0
+)
+
+
+@dataclass(frozen=True)
+class CapacityObservation:
+    """A merchant capacity read straight off a village's marketplace page."""
+
+    trade_office_level: int
+    capacity: int
+
+
+class CalibrationError(ValueError):
+    """Observations cannot be explained by one base-and-bonus model."""
+
+
+def calibrate(
+    observations: Sequence[CapacityObservation],
+    speed_fields_per_hour: float,
+    *,
+    tolerance: float = 1.0,
+) -> MerchantModel:
+    """Derive :class:`MerchantModel` from marketplace readings. Resolves R1.
+
+    Two observations at *different* Trade Office levels determine both unknowns
+    in ``capacity = base * (1 + k * level)``:
+
+        k    = (c_a - c_b) / (c_b * a - c_a * b)
+        base = c_a / (1 + k * a)
+
+    Any further observations are checked against the solution rather than
+    averaged into it. A mismatch is raised, not smoothed away: it means capacity
+    is not a single account-wide function of Trade Office level -- most likely a
+    Trade artifact affecting some villages and not others -- and silently fitting
+    a line through that would reintroduce exactly the error R1 describes.
+
+    Args:
+        observations: at least two readings spanning two Trade Office levels.
+        speed_fields_per_hour: merchant speed for the tribe.
+        tolerance: allowed absolute deviation, in resources, before raising.
+
+    Raises:
+        CalibrationError: fewer than two distinct levels, or inconsistent data.
+    """
+    if len(observations) < 2:
+        raise CalibrationError("need at least two observations to solve for base and bonus")
+
+    levels = {o.trade_office_level for o in observations}
+    if len(levels) < 2:
+        raise CalibrationError(
+            f"observations must span two different Trade Office levels, all are {levels.pop()}"
+        )
+
+    low = min(observations, key=lambda o: o.trade_office_level)
+    high = max(observations, key=lambda o: o.trade_office_level)
+
+    a, c_a = low.trade_office_level, low.capacity
+    b, c_b = high.trade_office_level, high.capacity
+
+    denominator = c_b * a - c_a * b
+    if denominator == 0:
+        raise CalibrationError("degenerate observations: cannot solve for the bonus")
+
+    bonus = (c_a - c_b) / denominator
+    base = c_a / (1 + bonus * a)
+
+    if base <= 0 or bonus < 0:
+        raise CalibrationError(
+            f"observations imply an impossible model (base={base:.1f}, bonus={bonus:.4f})"
+        )
+
+    model = MerchantModel(
+        base_capacity=round(base),
+        bonus_per_trade_office_level=bonus,
+        speed_fields_per_hour=speed_fields_per_hour,
+    )
+
+    for observation in observations:
+        predicted = model.capacity(observation.trade_office_level)
+        if abs(predicted - observation.capacity) > tolerance:
+            raise CalibrationError(
+                f"observation TO={observation.trade_office_level} capacity="
+                f"{observation.capacity} does not fit the model derived from the "
+                f"others (predicted {predicted}). Capacity may vary per village "
+                f"-- a Trade artifact would do this."
+            )
+    return model
+
+
+@dataclass(frozen=True)
+class RouteCost:
+    """What one trade route costs in merchants, at a given cycle length."""
+
+    cycle_hours: int
+    batch: int
+    merchants_per_send: int
+    sets_in_flight: int
+
+    @property
+    def merchants_committed(self) -> int:
+        """Merchants this route occupies permanently at the sender."""
+        return self.merchants_per_send * self.sets_in_flight
+
+
+def route_cost(
+    hourly_cargo: float,
+    cycle_hours: int,
+    round_trip_minutes: float,
+    merchant_capacity: int,
+) -> RouteCost:
+    """Merchants committed by one route at one cycle length.
+
+    A merchant is busy for the whole round trip, so if the trip outlasts the
+    cycle several sets are in flight at once and each needs its own merchants::
+
+        batch  = hourly_cargo * cycle_hours
+        send   = ceil(batch / merchant_capacity)
+        sets   = ceil(round_trip_minutes / (cycle_hours * 60))
+        total  = send * sets
+
+    Both ceilings mean ``total`` is **not monotonic** in ``cycle_hours``: a
+    longer cycle needs more merchants per send but fewer sets, and which wins
+    flips back and forth. Never reason about a direction -- use
+    :func:`cheapest_cycle`.
+    """
+    if cycle_hours <= 0:
+        raise ValueError(f"cycle_hours must be positive, got {cycle_hours}")
+    if merchant_capacity <= 0:
+        raise ValueError(f"merchant_capacity must be positive, got {merchant_capacity}")
+    if hourly_cargo < 0:
+        raise ValueError(f"hourly_cargo cannot be negative, got {hourly_cargo}")
+
+    batch = math.ceil(hourly_cargo * cycle_hours)
+    return RouteCost(
+        cycle_hours=cycle_hours,
+        batch=batch,
+        merchants_per_send=math.ceil(batch / merchant_capacity),
+        sets_in_flight=math.ceil(round_trip_minutes / (cycle_hours * 60)),
+    )
+
+
+def cycle_sweep(
+    hourly_cargo: float,
+    round_trip_minutes: float,
+    merchant_capacity: int,
+    cycles: Sequence[int] = DAILY_BEAT_CYCLES,
+) -> list[RouteCost]:
+    """Cost at every candidate cycle, in the order given.
+
+    The UI shows this curve rather than only the winner: the operator planned
+    these routes by hand and will not trust a cycle choice they cannot see the
+    reasoning for.
+    """
+    return [
+        route_cost(hourly_cargo, cycle, round_trip_minutes, merchant_capacity) for cycle in cycles
+    ]
+
+
+def cheapest_cycle(
+    hourly_cargo: float,
+    round_trip_minutes: float,
+    merchant_capacity: int,
+    cycles: Sequence[int] = DAILY_BEAT_CYCLES,
+) -> RouteCost:
+    """Cycle length committing the fewest merchants; shortest cycle wins ties.
+
+    Tie-breaking on the shorter cycle is deliberate: for equal merchant cost it
+    delivers sooner, which is objective 2 (latency) in the optimizer.
+    """
+    if not cycles:
+        raise ValueError("cycles must not be empty")
+    return min(
+        cycle_sweep(hourly_cargo, round_trip_minutes, merchant_capacity, cycles),
+        key=lambda cost: (cost.merchants_committed, cost.cycle_hours),
+    )

--- a/src/travian_api/services/distribution/merchants.py
+++ b/src/travian_api/services/distribution/merchants.py
@@ -28,6 +28,10 @@ import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+# Slack subtracted before any ceil of a cargo batch, so float dust just above
+# an integer does not round a boundary-exact batch up to a phantom unit.
+CEIL_DUST_TOLERANCE = 1e-6
+
 # Cycle lengths that divide a day, so the schedule repeats every 24h (R5).
 DAILY_BEAT_CYCLES: tuple[int, ...] = (1, 2, 3, 4, 6, 8, 12, 24)
 
@@ -240,7 +244,14 @@ def route_cost(
     if hourly_cargo < 0:
         raise ValueError(f"hourly_cargo cannot be negative, got {hourly_cargo}")
 
-    batch = math.ceil(hourly_cargo * cycle_hours)
+    # ceil with a dust tolerance. Breakpoint transfers deliberately land flow
+    # rates exactly on capacity boundaries, and the arithmetic that produces
+    # them (k * capacity / cycle - rate) leaves ~1e-12 of float dust ABOVE the
+    # integer. A bare ceil amplifies that dust into a whole extra unit of
+    # cargo -- and worse, a whole extra merchant per send. Genuine fractional
+    # batches are never this close to an integer (the smallest real fraction is
+    # capacity/cycle granularity, orders of magnitude above the tolerance).
+    batch = math.ceil(hourly_cargo * cycle_hours - CEIL_DUST_TOLERANCE)
     return RouteCost(
         cycle_hours=cycle_hours,
         batch=batch,

--- a/src/travian_api/services/distribution/merchants.py
+++ b/src/travian_api/services/distribution/merchants.py
@@ -3,13 +3,18 @@
 Two review findings from ``docs/25-resource-distribution-planner.md`` shape this
 module:
 
-**R1 — the capacity constants are disputed.** The profiling doc used
-``base 2200`` with ``+20%`` per Trade Office level; published Teuton values are
-``base 1000`` and ``+10%`` (``+20%`` is the Roman rate). Both errors overstate
-capacity, which under-provisions merchants -- the unsafe direction. Rather than
-pick a side, capacity lives in one injectable :class:`MerchantModel` that can be
-*derived from observation* via :func:`calibrate`. Nothing else in the planner is
-allowed to hardcode a capacity.
+**R1 — RESOLVED, and the review was wrong.** The review argued the profile's
+``base 2200`` / ``+20%`` per Trade Office level had to be mistaken, because
+published Teuton values are ``base 1000`` / ``+10%``. A live reading settled it:
+a TO 13 village carries **7,920** per merchant, which is exactly
+``2200 * (1 + 0.2 * 13)``. Stock Teuton would have given 2,300. The profile was
+right and this server is not stock.
+
+The seam stays regardless. Capacity lives in one injectable
+:class:`MerchantModel` and can be *derived from observation* via
+:func:`calibrate`, because the measured model is still only pinned by a single
+data point -- any ``base * (1 + 13k) = 7920`` fits it, and a Trade artifact can
+change it mid-server. Nothing else in the planner may hardcode a capacity.
 
 **R5 — cycles should divide 24 hours.** Otherwise the schedule has no repeating
 daily period and cannot be written down as a beat. :data:`DAILY_BEAT_CYCLES` is
@@ -40,20 +45,22 @@ MIN_CALIBRATION_SEPARATION = 3
 
 @dataclass(frozen=True)
 class MerchantModel:
-    """How much one merchant carries, and how fast it travels.
+    """How much one merchant carries.
 
     ``capacity = base_capacity * (1 + bonus_per_trade_office_level * level)``
 
+    Merchant *speed* deliberately lives on :class:`~.geometry.MapGeometry`
+    instead, which is the only thing that needs it. Holding it in both places
+    would let the two disagree.
+
     Warning:
-        The stock constants below are **published values, unverified for any
-        particular server**. Trade artifacts multiply merchant capacity and can
-        be captured or lost, and server speed scales it. Prefer
-        :func:`calibrate` on real observations over trusting a default.
+        Do not assume a published constant applies. Europe 2 does not follow
+        stock Teuton values, Trade artifacts multiply capacity and can be
+        captured or lost, and server speed scales it. Prefer :func:`calibrate`.
     """
 
     base_capacity: int
     bonus_per_trade_office_level: float
-    speed_fields_per_hour: float
 
     def __post_init__(self) -> None:
         if self.base_capacity <= 0:
@@ -74,16 +81,17 @@ class MerchantModel:
         return math.floor(scaled)
 
 
-# Published stock values at 1x. UNVERIFIED for this account -- see R1.
-STOCK_TEUTON = MerchantModel(
-    base_capacity=1000, bonus_per_trade_office_level=0.10, speed_fields_per_hour=12.0
-)
-STOCK_ROMAN = MerchantModel(
-    base_capacity=500, bonus_per_trade_office_level=0.20, speed_fields_per_hour=16.0
-)
-STOCK_GAUL = MerchantModel(
-    base_capacity=750, bonus_per_trade_office_level=0.10, speed_fields_per_hour=24.0
-)
+# Measured on Europe 2 (Teuton): a TO 13 village carries 7,920, and
+# 2200 * (1 + 0.2 * 13) == 7920 exactly. Still only one data point -- other
+# (base, bonus) pairs also satisfy it -- so re-derive with calibrate() when a
+# village at a different Trade Office level is to hand.
+EUROPE2_TEUTON = MerchantModel(base_capacity=2200, bonus_per_trade_office_level=0.20)
+
+# Published stock values at 1x, for reference. Europe 2 does NOT follow these:
+# stock Teuton predicts 2,300 at TO 13 where the game reports 7,920.
+STOCK_TEUTON = MerchantModel(base_capacity=1000, bonus_per_trade_office_level=0.10)
+STOCK_ROMAN = MerchantModel(base_capacity=500, bonus_per_trade_office_level=0.20)
+STOCK_GAUL = MerchantModel(base_capacity=750, bonus_per_trade_office_level=0.10)
 
 
 @dataclass(frozen=True)
@@ -100,7 +108,6 @@ class CalibrationError(ValueError):
 
 def calibrate(
     observations: Sequence[CapacityObservation],
-    speed_fields_per_hour: float,
     *,
     tolerance: float = 1.0,
 ) -> MerchantModel:
@@ -127,7 +134,6 @@ def calibrate(
 
     Args:
         observations: at least two readings spanning two Trade Office levels.
-        speed_fields_per_hour: merchant speed for the tribe.
         tolerance: allowed absolute deviation, in resources, before raising.
 
     Raises:
@@ -177,11 +183,7 @@ def calibrate(
             f"observations imply an impossible model (base={base:.1f}, bonus={bonus:.4f})"
         )
 
-    model = MerchantModel(
-        base_capacity=round(base),
-        bonus_per_trade_office_level=bonus,
-        speed_fields_per_hour=speed_fields_per_hour,
-    )
+    model = MerchantModel(base_capacity=round(base), bonus_per_trade_office_level=bonus)
 
     for observation in observations:
         predicted = model.capacity(observation.trade_office_level)
@@ -274,6 +276,16 @@ def cheapest_cycle(
 
     Tie-breaking on the shorter cycle is deliberate: for equal merchant cost it
     delivers sooner, which is objective 2 (latency) in the optimizer.
+
+    Note:
+        There is deliberately no budget parameter. Because this already returns
+        the minimum-merchant cycle, that cycle is also the most affordable one:
+        if it does not fit a village's spare merchants, no cycle does. Filtering
+        by a budget could therefore never change the answer. Feasibility is the
+        caller's decision -- compare :attr:`RouteCost.merchants_committed`
+        against the budget and escalate per the optimizer's ladder. Known issue
+        #6 is that comparison being skipped, and no signature here can make it
+        for you.
     """
     if not cycles:
         raise ValueError("cycles must not be empty")

--- a/src/travian_api/services/distribution/merchants.py
+++ b/src/travian_api/services/distribution/merchants.py
@@ -87,11 +87,11 @@ class MerchantModel:
 # village at a different Trade Office level is to hand.
 EUROPE2_TEUTON = MerchantModel(base_capacity=2200, bonus_per_trade_office_level=0.20)
 
-# Published stock values at 1x, for reference. Europe 2 does NOT follow these:
-# stock Teuton predicts 2,300 at TO 13 where the game reports 7,920.
+# Published stock Teuton values at 1x, kept only as the counter-example: they
+# predict 2,300 at TO 13 where the game reports 7,920, which is how we know this
+# server is not stock. Roman and Gaul figures are deliberately absent -- the tool
+# is single-account, and an unused constant is one more thing to get wrong.
 STOCK_TEUTON = MerchantModel(base_capacity=1000, bonus_per_trade_office_level=0.10)
-STOCK_ROMAN = MerchantModel(base_capacity=500, bonus_per_trade_office_level=0.20)
-STOCK_GAUL = MerchantModel(base_capacity=750, bonus_per_trade_office_level=0.10)
 
 
 @dataclass(frozen=True)

--- a/src/travian_api/services/distribution/merchants.py
+++ b/src/travian_api/services/distribution/merchants.py
@@ -29,6 +29,14 @@ DAILY_BEAT_CYCLES: tuple[int, ...] = (1, 2, 3, 4, 6, 8, 12, 24)
 # Every cycle Gold Club accepts. Use to measure what DAILY_BEAT_CYCLES costs.
 ALL_CYCLES: tuple[int, ...] = tuple(range(1, 25))
 
+# Minimum gap between the two Trade Office levels used to calibrate. The game
+# reports a floored capacity, so with adjacent levels that rounding is a large
+# share of the difference between the readings and the solve is ill-conditioned.
+# Measured over 570 synthetic models, adjacent levels mis-predict capacity at
+# TO 20 by up to 19 and *overstate* it in 8% of cases -- the unsafe direction.
+# A gap of 3 cuts that to 6; a Trade-Office-free sample removes it entirely.
+MIN_CALIBRATION_SEPARATION = 3
+
 
 @dataclass(frozen=True)
 class MerchantModel:
@@ -104,6 +112,13 @@ def calibrate(
         k    = (c_a - c_b) / (c_b * a - c_a * b)
         base = c_a / (1 + k * a)
 
+    **Include a village with no Trade Office if you can.** Its capacity *is* the
+    base, so no inversion is needed and the residual error becomes one-sided in
+    the safe direction -- verified over 600 synthetic models, where that path
+    never once overstated capacity. Without such a sample the levels must be at
+    least :data:`MIN_CALIBRATION_SEPARATION` apart, because the game reports a
+    floored capacity and close readings make the solve ill-conditioned.
+
     Any further observations are checked against the solution rather than
     averaged into it. A mismatch is raised, not smoothed away: it means capacity
     is not a single account-wide function of Trade Office level -- most likely a
@@ -116,7 +131,8 @@ def calibrate(
         tolerance: allowed absolute deviation, in resources, before raising.
 
     Raises:
-        CalibrationError: fewer than two distinct levels, or inconsistent data.
+        CalibrationError: fewer than two distinct levels, levels too close to
+            solve reliably, or observations that no single model explains.
     """
     if len(observations) < 2:
         raise CalibrationError("need at least two observations to solve for base and bonus")
@@ -133,12 +149,28 @@ def calibrate(
     a, c_a = low.trade_office_level, low.capacity
     b, c_b = high.trade_office_level, high.capacity
 
-    denominator = c_b * a - c_a * b
-    if denominator == 0:
-        raise CalibrationError("degenerate observations: cannot solve for the bonus")
+    if a == 0:
+        # A Trade-Office-free village reports the base directly, so there is no
+        # inversion and no ill-conditioning.
+        base = float(c_a)
+        bonus = (c_b / base - 1) / b
+    else:
+        if b - a < MIN_CALIBRATION_SEPARATION:
+            raise CalibrationError(
+                f"Trade Office levels {a} and {b} are only {b - a} apart, which "
+                f"cannot be solved reliably: the game floors the capacity it "
+                f"reports, so with close levels that rounding dominates the "
+                f"difference between the readings and the fit can overstate "
+                f"capacity -- the direction that breaches merchant budgets. Use "
+                f"levels at least {MIN_CALIBRATION_SEPARATION} apart, or read a "
+                f"village with no Trade Office (its capacity is the base)."
+            )
+        denominator = c_b * a - c_a * b
+        if denominator == 0:
+            raise CalibrationError("degenerate observations: cannot solve for the bonus")
 
-    bonus = (c_a - c_b) / denominator
-    base = c_a / (1 + bonus * a)
+        bonus = (c_a - c_b) / denominator
+        base = c_a / (1 + bonus * a)
 
     if base <= 0 or bonus < 0:
         raise CalibrationError(

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -18,7 +18,7 @@ resource:
 Both are asserted as invariants in the tests rather than defended with runtime
 checks, because the property comes from the data model, not from vigilance here.
 
-Two stages, per profile section 14 (``cluster -> assign -> improve``):
+Three stages, per profile section 14 (``cluster -> assign -> improve``):
 
 1. **Greedy seed** -- :func:`_flows_for_resource` matches each receiver to its
    nearest senders, largest demand first. Deterministic and explainable, but
@@ -253,10 +253,16 @@ def _flows_for_resource(
 FlowKey = tuple[int, int]
 Assignment = dict[Resource, dict[FlowKey, float]]
 
-# Backstop against a pathological non-converging sweep. Each accepted swap
-# strictly lowers the integer objective, so convergence is guaranteed well
-# inside this on any real account; the cap only bounds the worst case.
-MAX_IMPROVE_PASSES = 200
+# Ceiling on improvement passes. Termination does not depend on it -- each
+# accepted swap strictly lowers an integer objective -- so this exists only to
+# bound worst-case runtime, and hitting it is reported rather than hidden
+# (a truncated search overstates over_budget_excess, which becomes user-facing
+# Trade Office advice). Sized from measurement, not guessed: 200 truncated from
+# ~45 villages upward, which is an ordinary account, and at 100 villages that
+# cost 86 merchants of phantom excess. 1000 converges every account size
+# measured up to 120 villages; a 22-village account finishes in ~11 passes and
+# never approaches it. Tunable via PlannerConfig.max_improve_passes.
+MAX_IMPROVE_PASSES = 1000
 
 
 def _merge_pair_cargo(assignment: Assignment) -> dict[FlowKey, dict[Resource, float]]:
@@ -323,6 +329,7 @@ def _spend_idle_merchants_on_latency(
     cycles: Sequence[int],
     budgets: Mapping[int, int],
     latency_target: float,
+    min_send_fill: float = MIN_SEND_FILL,
 ) -> list[Route]:
     """Shorten over-target routes by spending each village's idle merchants.
 
@@ -366,7 +373,7 @@ def _spend_idle_merchants_on_latency(
                     if new_latency >= route.latency_hours:
                         continue
                     # Don't buy speed with half-empty merchants (axis 2).
-                    if cost.batch < MIN_SEND_FILL * cost.merchants_per_send * capacity:
+                    if cost.batch < min_send_fill * cost.merchants_per_send * capacity:
                         continue
                     compliant = int(new_latency <= latency_target)
                     per_merchant = (route.latency_hours - new_latency) / delta
@@ -404,7 +411,8 @@ def _improve_flows(
     merchant_model: MerchantModel,
     cycles: Sequence[int],
     budgets: Mapping[int, int],
-) -> Assignment:
+    max_passes: int = MAX_IMPROVE_PASSES,
+) -> tuple[Assignment, bool]:
     """Lower merchant commitment by reassigning flow, seeded by the greedy plan.
 
     The greedy seed matches each receiver to its nearest senders, which is
@@ -425,14 +433,40 @@ def _improve_flows(
     route_count)`` — feasibility first, then merchants (§8.3 objective 1), then
     route count (objective 4). A swap is applied only when it strictly lowers
     that tuple, so the result is deterministic and never worse than the seed.
+
+    Returns:
+        ``(flows, converged)``. ``converged`` is False when ``max_passes`` ran
+        out with improvements still available — the caller must surface that,
+        because a truncated search overstates ``over_budget_excess`` (the *first*
+        objective key), and that number drives both the over-budget report and
+        the Trade Office upgrade advice built from it.
     """
     # Working state, kept in sync: per-resource flows, merged pair cargo, the
     # merchant cost of each pair, and the running per-origin commitment.
     flows: Assignment = {resource: dict(legs) for resource, legs in assignment.items()}
+
+    # Distance and capacity are fixed for the whole search but were being
+    # recomputed inside the innermost loop, millions of times on a large account.
+    capacities = {vid: merchant_model.capacity(v.trade_office_level) for vid, v in villages.items()}
+    one_way_cache: dict[FlowKey, float] = {}
+
+    def merchants_for(origin: int, destination: int, cargo: Mapping[Resource, float]) -> int:
+        hourly_total = sum(cargo.values())
+        if hourly_total <= EPSILON:
+            return 0
+        one_way = one_way_cache.get((origin, destination))
+        if one_way is None:
+            one_way = geometry.one_way_minutes(
+                villages[origin].coords, villages[destination].coords
+            )
+            one_way_cache[(origin, destination)] = one_way
+        return cheapest_cycle(
+            hourly_total, 2.0 * one_way, capacities[origin], cycles
+        ).merchants_committed
+
     pair = _merge_pair_cargo(flows)
     pair_merch: dict[FlowKey, int] = {
-        key: _pair_merchants(key[0], key[1], cargo, villages, geometry, merchant_model, cycles)
-        for key, cargo in pair.items()
+        key: merchants_for(key[0], key[1], cargo) for key, cargo in pair.items()
     }
     committed: dict[int, int] = {}
     for (origin, _destination), merchants in pair_merch.items():
@@ -441,18 +475,38 @@ def _improve_flows(
     def excess(origin: int, count: int) -> int:
         return max(0, count - budgets.get(origin, 0))
 
-    for _pass in range(MAX_IMPROVE_PASSES):
+    # Pairs proven non-improving and not invalidated by a swap since. Purely a
+    # memo -- it never changes which swap is chosen, only how much work is
+    # repeated to find it.
+    settled: set[tuple[Resource, FlowKey, FlowKey]] = set()
+
+    converged = False
+    for _pass in range(max_passes):
         applied = False
         for resource in sorted(flows, key=lambda r: r.value):
             legs = flows[resource]
             edges = sorted(key for key, amount in legs.items() if amount > EPSILON)
             for i, (o1, d1) in enumerate(edges):
                 for o2, d2 in edges[i + 1 :]:
-                    if o1 == o2 or d1 == d2:
+                    # Skip pairs already proven non-improving that no swap since
+                    # has touched. This is the whole speedup: it preserves the
+                    # first-improving-in-sorted-order trajectory exactly (and so
+                    # the resulting plan), while avoiding the re-evaluation of
+                    # every untouched pair after each swap.
+                    if (resource, (o1, d1), (o2, d2)) in settled:
                         continue
-                    t = min(legs[(o1, d1)], legs[(o2, d2)])
+                    # o1 == d2 (or o2 == d1) would create a self-loop, whose
+                    # zero travel time makes it cost zero merchants -- the most
+                    # attractive move there is, silently deleting real delivery.
+                    # Unreachable while a village is either sender or receiver of
+                    # a resource but never both, but this must not depend on an
+                    # invariant owned by another module to stay correct.
+                    if o1 in (o2, d2) or d1 in (d2, o2):
+                        continue
+                    t = min(legs.get((o1, d1), 0.0), legs.get((o2, d2), 0.0))
                     if t <= EPSILON:
                         continue
+                    candidate = (resource, (o1, d1), (o2, d2))
 
                     # Cargo of the four pairs the swap touches, after the move.
                     moved = [((o1, d1), -t), ((o2, d2), -t), ((o1, d2), t), ((o2, d1), t)]
@@ -466,9 +520,7 @@ def _improve_flows(
                             cargo.pop(resource, None)
                         new_cargo[key] = cargo
                     new_merch = {
-                        key: _pair_merchants(
-                            key[0], key[1], cargo, villages, geometry, merchant_model, cycles
-                        )
+                        key: merchants_for(key[0], key[1], cargo)
                         for key, cargo in new_cargo.items()
                     }
 
@@ -496,6 +548,7 @@ def _improve_flows(
                     # The whole objective only shifts by these deltas, so the
                     # full tuple improves exactly when the delta tuple is < 0.
                     if (over_delta, total_delta, rc_delta) >= (0, 0, 0):
+                        settled.add(candidate)
                         continue
 
                     for key, cargo in new_cargo.items():
@@ -515,6 +568,19 @@ def _improve_flows(
                     for key in ((o1, d1), (o2, d2)):
                         if legs[key] <= EPSILON:
                             del legs[key]
+
+                    # This swap moved cargo on four pairs and changed the
+                    # commitment of two origins, so any cached verdict involving
+                    # those villages is stale. Everything else is untouched and
+                    # stays settled -- that is what makes the rescan cheap.
+                    touched = {o1, o2, d1, d2}
+                    settled.difference_update(
+                        [
+                            entry
+                            for entry in settled
+                            if touched & {entry[1][0], entry[1][1], entry[2][0], entry[2][1]}
+                        ]
+                    )
                     applied = True
                     break
                 if applied:
@@ -522,8 +588,9 @@ def _improve_flows(
             if applied:
                 break
         if not applied:
+            converged = True
             break
-    return flows
+    return flows, converged
 
 
 def build_plan(
@@ -535,6 +602,8 @@ def build_plan(
     merchant_reserve: int = DEFAULT_MERCHANT_RESERVE,
     cycles: Sequence[int] = DAILY_BEAT_CYCLES,
     max_latency_hours: float | None = 2.0,
+    min_send_fill: float = MIN_SEND_FILL,
+    max_improve_passes: int = MAX_IMPROVE_PASSES,
 ) -> Plan:
     """Build a route set from fetched state. Works for any village count.
 
@@ -577,7 +646,18 @@ def build_plan(
     # Reassign the greedy seed to cut merchants and relieve over-budget villages
     # wherever a cheaper routing exists; never worse than the seed (§8.3, §14).
     budgets = {vid: villages[vid].spare_merchants(merchant_reserve) for vid in villages}
-    assignment = _improve_flows(assignment, villages, geometry, merchant_model, cycles, budgets)
+    assignment, converged = _improve_flows(
+        assignment, villages, geometry, merchant_model, cycles, budgets, max_improve_passes
+    )
+    if not converged:
+        # Never let a truncated search masquerade as a converged one: it inflates
+        # over_budget_excess, so villages get reported over budget -- and handed
+        # Trade Office upgrade advice -- that a finished search would not flag.
+        warnings.append(
+            f"route search stopped after {max_improve_passes} improvement passes with "
+            f"better assignments still available; the over-budget figures below may "
+            f"overstate the real shortfall. Raise max_improve_passes to finish the search."
+        )
     pair_cargo = _merge_pair_cargo(assignment)
 
     routes: list[Route] = [
@@ -599,7 +679,7 @@ def build_plan(
     # leaving the plan purely merchant-minimal.
     if max_latency_hours is not None:
         routes = _spend_idle_merchants_on_latency(
-            routes, villages, merchant_model, cycles, budgets, max_latency_hours
+            routes, villages, merchant_model, cycles, budgets, max_latency_hours, min_send_fill
         )
 
     committed: dict[int, int] = {vid: 0 for vid in villages}

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
-from .allocation import EPSILON, Resource, ResourcePlan
+from .allocation import EPSILON, Resource, ResourcePlan, village_label
 from .geometry import MapGeometry
 from .merchants import DAILY_BEAT_CYCLES, MerchantModel, cheapest_cycle, cycle_sweep
 
@@ -819,6 +819,8 @@ def build_plan(
         in the plan, never silently dropped or quietly trimmed to fit.
     """
     warnings: list[str] = []
+    # Every message below names villages the way the operator does.
+    names = {vid: village.name for vid, village in villages.items() if village.name}
     assignment: Assignment = {}
     shortfalls: list[Shortfall] = []
 
@@ -827,8 +829,9 @@ def build_plan(
         missing = {v.village_id for v in plan.villages} - set(villages)
         if missing:
             warnings.append(
-                f"{resource.value}: no fetched state for village(s) "
-                f"{sorted(missing)}; excluded from routing"
+                f"{resource.value}: no fetched state for "
+                + ", ".join(village_label(vid, names) for vid in sorted(missing))
+                + "; excluded from routing"
             )
         flows, resource_shortfalls = _flows_for_resource(plan, villages, geometry)
         shortfalls.extend(resource_shortfalls)
@@ -885,7 +888,8 @@ def build_plan(
         committed[route.origin] += route.merchants_committed
         if max_latency_hours is not None and route.latency_hours > max_latency_hours:
             warnings.append(
-                f"route {route.origin} -> {route.destination} has "
+                f"route {village_label(route.origin, names)} -> "
+                f"{village_label(route.destination, names)} has "
                 f"{route.latency_hours:.1f}h latency against a {max_latency_hours:.0f}h "
                 f"target; geometry or the merchant budget may forbid better"
             )

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -28,6 +28,14 @@ Two stages, per profile section 14 (``cluster -> assign -> improve``):
    objective ``(over_budget_excess, total_merchants, route_count)``. It never
    returns a plan worse than the seed, and cross-resource bundling falls out of
    costing the *merged* pair cargo.
+3. **Latency pass** -- :func:`_spend_idle_merchants_on_latency` then hands each
+   village's *idle* merchants (those the budget allows but the merchant-minimal
+   plan left unused) to the routes furthest over the latency target, shortening
+   their cycles while keeping merchants full (:data:`MIN_SEND_FILL`). It spends
+   strictly within budget, so feasibility never regresses, and runs only when a
+   target is set. Its reach is bounded by geometry: on a spread-out account the
+   one-way trip dwarfs the cycle wait, so cycle choice can only do so much --
+   assignment and a crop sub-hub are what shorten the trip itself.
 
 What it still does *not* do is claim global optimality (the problem is NP-hard,
 section 14) or relay crop through a sub-hub (single-leg flows only). A village
@@ -41,9 +49,16 @@ from dataclasses import dataclass, field
 
 from .allocation import EPSILON, Resource, ResourcePlan
 from .geometry import MapGeometry
-from .merchants import DAILY_BEAT_CYCLES, MerchantModel, cheapest_cycle
+from .merchants import DAILY_BEAT_CYCLES, MerchantModel, cheapest_cycle, cycle_sweep
 
 DEFAULT_MERCHANT_RESERVE = 2
+
+# Floor on how full a merchant must stay when idle merchants are spent to cut
+# latency. Shortening a cycle shrinks each batch, so without a floor the latency
+# pass runs half-empty merchants just to go faster — trading merchant fill (its
+# own optimisation axis) for speed. 0.6 keeps sends reasonably full while still
+# letting routes speed up where the trip, not the load, is the cost.
+MIN_SEND_FILL = 0.6
 
 
 @dataclass(frozen=True)
@@ -301,6 +316,87 @@ def _route_for_pair(
     )
 
 
+def _spend_idle_merchants_on_latency(
+    routes: Sequence[Route],
+    villages: Mapping[int, VillageState],
+    merchant_model: MerchantModel,
+    cycles: Sequence[int],
+    budgets: Mapping[int, int],
+    latency_target: float,
+) -> list[Route]:
+    """Shorten over-target routes by spending each village's idle merchants.
+
+    Merchant minimisation drives routes to long cycles (a 24h cycle can save one
+    merchant over a 3h one), so the cheapest plan is also the slowest — measured
+    at a median 5.6h against a 2h target. Yet villages carry idle merchants the
+    budget already allows. This pass hands those idle merchants to the routes
+    that most need speed: for each village it repeatedly picks the affordable
+    shorter cycle giving the best latency cut per merchant, spending strictly
+    within ``budget - already_committed`` so a village can never be pushed over
+    its cap. Compliant routes (<= target) are left alone rather than
+    over-shortened, and a route whose one-way trip alone exceeds the target is
+    still sped up as far as the spare budget reaches.
+
+    Runs only when a latency target is set; with ``None`` the plan stays purely
+    merchant-minimal.
+    """
+    result = list(routes)
+    by_origin: dict[int, list[int]] = {}
+    for index, route in enumerate(result):
+        by_origin.setdefault(route.origin, []).append(index)
+
+    for origin in sorted(by_origin):
+        capacity = merchant_model.capacity(villages[origin].trade_office_level)
+        indices = by_origin[origin]
+        spare = budgets.get(origin, 0) - sum(result[i].merchants_committed for i in indices)
+        while spare > 0:
+            best: tuple[tuple[int, float, int, int], int, int, int, int] | None = None
+            for i in indices:
+                route = result[i]
+                if route.latency_hours <= latency_target:
+                    continue  # already fast enough; do not waste merchants on it
+                one_way = route.one_way_minutes
+                for cost in cycle_sweep(route.hourly_total, 2.0 * one_way, capacity, cycles):
+                    if cost.cycle_hours >= route.cycle_hours:
+                        continue  # only a shorter cycle lowers latency
+                    delta = cost.merchants_committed - route.merchants_committed
+                    if delta <= 0 or delta > spare:
+                        continue
+                    new_latency = cost.cycle_hours + one_way / 60.0
+                    if new_latency >= route.latency_hours:
+                        continue
+                    # Don't buy speed with half-empty merchants (axis 2).
+                    if cost.batch < MIN_SEND_FILL * cost.merchants_per_send * capacity:
+                        continue
+                    compliant = int(new_latency <= latency_target)
+                    per_merchant = (route.latency_hours - new_latency) / delta
+                    key = (compliant, per_merchant, -delta, -cost.cycle_hours)
+                    if best is None or key > best[0]:
+                        best = (
+                            key,
+                            i,
+                            cost.cycle_hours,
+                            cost.merchants_per_send,
+                            cost.sets_in_flight,
+                        )
+                        best_delta = delta
+            if best is None:
+                break
+            _, i, cycle_hours, merchants_per_send, sets_in_flight = best
+            route = result[i]
+            result[i] = Route(
+                origin=route.origin,
+                destination=route.destination,
+                cargo_per_hour=route.cargo_per_hour,
+                cycle_hours=cycle_hours,
+                merchants_per_send=merchants_per_send,
+                sets_in_flight=sets_in_flight,
+                one_way_minutes=route.one_way_minutes,
+            )
+            spare -= best_delta
+    return result
+
+
 def _improve_flows(
     assignment: Assignment,
     villages: Mapping[int, VillageState],
@@ -484,25 +580,36 @@ def build_plan(
     assignment = _improve_flows(assignment, villages, geometry, merchant_model, cycles, budgets)
     pair_cargo = _merge_pair_cargo(assignment)
 
-    routes: list[Route] = []
-    committed: dict[int, int] = {vid: 0 for vid in villages}
-
-    for origin, destination in sorted(pair_cargo):
-        cargo = pair_cargo[(origin, destination)]
-        if sum(cargo.values()) <= EPSILON:
-            continue
-
-        route = _route_for_pair(
-            origin, destination, cargo, villages, geometry, merchant_model, cycles
+    routes: list[Route] = [
+        _route_for_pair(
+            origin,
+            destination,
+            pair_cargo[(origin, destination)],
+            villages,
+            geometry,
+            merchant_model,
+            cycles,
         )
-        routes.append(route)
-        committed[origin] += route.merchants_committed
+        for origin, destination in sorted(pair_cargo)
+        if sum(pair_cargo[(origin, destination)].values()) > EPSILON
+    ]
 
+    # Spend each village's idle merchants (within budget) to shorten the routes
+    # furthest over the latency target; skipped entirely when no target is set,
+    # leaving the plan purely merchant-minimal.
+    if max_latency_hours is not None:
+        routes = _spend_idle_merchants_on_latency(
+            routes, villages, merchant_model, cycles, budgets, max_latency_hours
+        )
+
+    committed: dict[int, int] = {vid: 0 for vid in villages}
+    for route in routes:
+        committed[route.origin] += route.merchants_committed
         if max_latency_hours is not None and route.latency_hours > max_latency_hours:
             warnings.append(
-                f"route {origin} -> {destination} has {route.latency_hours:.1f}h "
-                f"latency against a {max_latency_hours:.0f}h target; geometry may "
-                f"forbid better"
+                f"route {route.origin} -> {route.destination} has "
+                f"{route.latency_hours:.1f}h latency against a {max_latency_hours:.0f}h "
+                f"target; geometry or the merchant budget may forbid better"
             )
 
     routes_by_origin: dict[int, list[Route]] = {}

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -14,6 +14,8 @@ resource:
   same resource, so ``A -> B`` and ``B -> A`` for iron cannot both exist.
 * **waterfall for W/C/I** -- for the same reason a village that nets as a
   receiver of lumber cannot also send lumber, so ``A -> B -> C`` cannot form.
+  Crop is deliberately exempt: relay through a sub-hub is permitted there, and
+  restricting the relay move to crop is what keeps this true for the rest.
 
 Both are asserted as invariants in the tests rather than defended with runtime
 checks, because the property comes from the data model, not from vigilance here.
@@ -37,9 +39,18 @@ Three stages, per profile section 14 (``cluster -> assign -> improve``):
    one-way trip dwarfs the cycle wait, so cycle choice can only do so much --
    assignment and a crop sub-hub are what shorten the trip itself.
 
+4. **Crop relay** -- :func:`_improve_flows` may also reroute a crop flow through
+   an intermediate village that forwards it (profile section 3.5 permits this for
+   crop, never for materials). Relay cannot lower total merchants -- cost is
+   essentially ``cargo x round_trip / capacity``, linear in both, so the long haul
+   costs the same consolidated as split and the collection legs are pure addition
+   -- but it *moves* commitment off a village that cannot staff its own haul, and
+   occasionally sheds a merchant to integer rounding. Because excess is the first
+   objective key, it is adopted exactly when it pays and never merely to shuffle.
+
 What it still does *not* do is claim global optimality (the problem is NP-hard,
-section 14) or relay crop through a sub-hub (single-leg flows only). A village
-over its merchant budget is reported, never hidden.
+section 14) or relay materials. A village over its merchant budget is reported,
+never hidden.
 """
 
 from __future__ import annotations
@@ -264,6 +275,12 @@ Assignment = dict[Resource, dict[FlowKey, float]]
 # never approaches it. Tunable via PlannerConfig.max_improve_passes.
 MAX_IMPROVE_PASSES = 1000
 
+# Levels of crop relay permitted. 1 allows village -> sub-hub -> destination;
+# 0 disables relay entirely. Chains beyond one level would make the beat's
+# collect-then-ship ordering much harder to reason about, so deeper relay is
+# a deliberate future decision rather than an accident of the search.
+MAX_RELAY_HOPS = 1
+
 
 def _merge_pair_cargo(assignment: Assignment) -> dict[FlowKey, dict[Resource, float]]:
     """Collapse the per-resource flows into one mixed cargo per village pair.
@@ -412,6 +429,7 @@ def _improve_flows(
     cycles: Sequence[int],
     budgets: Mapping[int, int],
     max_passes: int = MAX_IMPROVE_PASSES,
+    max_relay_hops: int = MAX_RELAY_HOPS,
 ) -> tuple[Assignment, bool]:
     """Lower merchant commitment by reassigning flow, seeded by the greedy plan.
 
@@ -479,6 +497,119 @@ def _improve_flows(
     # memo -- it never changes which swap is chosen, only how much work is
     # repeated to find it.
     settled: set[tuple[Resource, FlowKey, FlowKey]] = set()
+
+    # Villages currently forwarding relayed crop. Relaying a flow whose origin is
+    # already a hub would build a chain (o -> h1 -> h2 -> d); one level keeps the
+    # collect-then-ship ordering in the beat analysable.
+    relay_hubs: set[int] = set()
+
+    def _apply_changes(changes: Sequence[tuple[FlowKey, Resource, float]]) -> bool:
+        """Evaluate a set of pair-cargo deltas and apply them if they improve.
+
+        Shared by the relay move. Returns True when the objective strictly fell.
+        """
+        touched_keys = {key for key, _r, _d in changes}
+        new_cargo: dict[FlowKey, dict[Resource, float]] = {
+            key: dict(pair.get(key, {})) for key in touched_keys
+        }
+        for key, resource, delta in changes:
+            updated = new_cargo[key].get(resource, 0.0) + delta
+            if updated > EPSILON:
+                new_cargo[key][resource] = updated
+            else:
+                new_cargo[key].pop(resource, None)
+        new_merch = {key: merchants_for(key[0], key[1], cargo) for key, cargo in new_cargo.items()}
+
+        per_origin: dict[int, int] = {}
+        for key in touched_keys:
+            per_origin[key[0]] = per_origin.get(key[0], 0) + (
+                new_merch[key] - pair_merch.get(key, 0)
+            )
+        over_delta = sum(
+            excess(origin, committed.get(origin, 0) + delta)
+            - excess(origin, committed.get(origin, 0))
+            for origin, delta in per_origin.items()
+        )
+        total_delta = sum(new_merch.values()) - sum(pair_merch.get(key, 0) for key in touched_keys)
+        rc_delta = sum(1 for key in touched_keys if new_merch[key] > 0) - sum(
+            1 for key in touched_keys if pair_merch.get(key, 0) > 0
+        )
+        if (over_delta, total_delta, rc_delta) >= (0, 0, 0):
+            return False
+
+        for key in touched_keys:
+            if new_cargo[key]:
+                pair[key] = new_cargo[key]
+            else:
+                pair.pop(key, None)
+            if new_merch[key] > 0:
+                pair_merch[key] = new_merch[key]
+            else:
+                pair_merch.pop(key, None)
+        for origin, delta in per_origin.items():
+            committed[origin] = committed.get(origin, 0) + delta
+        for key, resource, delta in changes:
+            legs = flows[resource]
+            legs[key] = legs.get(key, 0.0) + delta
+            if legs[key] <= EPSILON:
+                legs.pop(key, None)
+        touched_villages = {v for key in touched_keys for v in key}
+        settled.difference_update(
+            [
+                entry
+                for entry in settled
+                if touched_villages & {entry[1][0], entry[1][1], entry[2][0], entry[2][1]}
+            ]
+        )
+        return True
+
+    def _relay_scan() -> bool:
+        """Reroute a crop flow through an intermediate village that forwards it.
+
+        Relay can never lower TOTAL merchants: cost is essentially
+        ``cargo x round_trip / capacity``, linear in both, so the long haul costs
+        the same consolidated as split and the collection legs are pure addition
+        (measured across every cluster geometry: best case break-even). What it
+        does is *move* commitment off a village that cannot staff its own haul
+        onto one with spare capacity. Since ``over_budget_excess`` is the first
+        objective key and merchants only the second, the accept test below adopts
+        relay exactly when it buys feasibility and never merely to shuffle load.
+
+        Crop only, per profile section 3.5: materials must not chain A->B->C, and
+        restricting relay to crop keeps that no-waterfall rule true by
+        construction rather than by a runtime check.
+        """
+        if max_relay_hops < 1:
+            return False
+        legs = flows.get(Resource.CROP)
+        if not legs:
+            return False
+        # Only villages already carrying crop may act as hubs. A village with no
+        # crop allocation is typically one that has just been founded, and
+        # conscripting it as infrastructure would both surprise the operator and
+        # break the idempotent re-plan that route diffing depends on (known issue
+        # #10): merely adding a village would reshuffle routes that have nothing
+        # to do with it. Computed once per scan, not per edge.
+        hubs = sorted({v for key in legs for v in key})
+        for origin, destination in sorted(key for key, amount in legs.items() if amount > EPSILON):
+            if origin in relay_hubs:
+                continue  # would build a second relay level
+            amount = legs.get((origin, destination), 0.0)
+            if amount <= EPSILON:
+                continue
+            for hub in hubs:
+                if hub in (origin, destination):
+                    continue
+                if _apply_changes(
+                    [
+                        ((origin, destination), Resource.CROP, -amount),
+                        ((origin, hub), Resource.CROP, amount),
+                        ((hub, destination), Resource.CROP, amount),
+                    ]
+                ):
+                    relay_hubs.add(hub)
+                    return True
+        return False
 
     converged = False
     for _pass in range(max_passes):
@@ -588,6 +719,11 @@ def _improve_flows(
             if applied:
                 break
         if not applied:
+            # Swaps are exhausted. Relay is tried only now, so a plan with no
+            # over-budget village -- where relay can never improve anything --
+            # comes out identical to one produced without this move at all.
+            applied = _relay_scan()
+        if not applied:
             converged = True
             break
     return flows, converged
@@ -604,6 +740,7 @@ def build_plan(
     max_latency_hours: float | None = 2.0,
     min_send_fill: float = MIN_SEND_FILL,
     max_improve_passes: int = MAX_IMPROVE_PASSES,
+    max_relay_hops: int = MAX_RELAY_HOPS,
 ) -> Plan:
     """Build a route set from fetched state. Works for any village count.
 
@@ -647,7 +784,14 @@ def build_plan(
     # wherever a cheaper routing exists; never worse than the seed (§8.3, §14).
     budgets = {vid: villages[vid].spare_merchants(merchant_reserve) for vid in villages}
     assignment, converged = _improve_flows(
-        assignment, villages, geometry, merchant_model, cycles, budgets, max_improve_passes
+        assignment,
+        villages,
+        geometry,
+        merchant_model,
+        cycles,
+        budgets,
+        max_improve_passes,
+        max_relay_hops,
     )
     if not converged:
         # Never let a truncated search masquerade as a converged one: it inflates

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -503,6 +503,31 @@ def _improve_flows(
     # collect-then-ship ordering in the beat analysable.
     relay_hubs: set[int] = set()
 
+    def _crop_shape_ok(edges: set[FlowKey]) -> bool:
+        """Would this crop graph still be a set of single hops?
+
+        Asked of a PROSPECTIVE edge set, before anything is committed. It cannot
+        be asked afterwards and undone: :func:`_apply_changes` only applies moves
+        that improve the objective, so a revert -- which by definition worsens it
+        -- is silently refused and the bad shape stays.
+
+        Guarding the relay move alone is also not enough. Once a hub exists an
+        ordinary 2x2 swap can rewire its legs into a longer chain, and swaps know
+        nothing about relay, so both movers consult this.
+        """
+        senders = {origin for origin, _ in edges}
+        receivers = {destination for _, destination in edges}
+        hubs = senders & receivers
+        for origin, destination in edges:
+            if (destination, origin) in edges:
+                return False  # a two-way pair: ship-after-collect is unsatisfiable
+            if origin in hubs and destination in hubs:
+                return False  # hub feeding a hub: a chain, not a single hop
+        return True
+
+    def _crop_edges() -> set[FlowKey]:
+        return {key for key, amount in flows.get(Resource.CROP, {}).items() if amount > EPSILON}
+
     def _apply_changes(changes: Sequence[tuple[FlowKey, Resource, float]]) -> bool:
         """Evaluate a set of pair-cargo deltas and apply them if they improve.
 
@@ -592,13 +617,29 @@ def _improve_flows(
         # to do with it. Computed once per scan, not per edge.
         hubs = sorted({v for key in legs for v in key})
         for origin, destination in sorted(key for key, amount in legs.items() if amount > EPSILON):
-            if origin in relay_hubs:
-                continue  # would build a second relay level
+            # Both ends must be outside the relay graph, not just the origin.
+            # Guarding only the origin let a leg that *ends* at an existing hub
+            # extend the chain, producing depth-3 waterfalls like 2 -> 6 -> 1 -> 3
+            # that the beat's collect-then-ship ordering was never designed for.
+            if origin in relay_hubs or destination in relay_hubs:
+                continue
             amount = legs.get((origin, destination), 0.0)
             if amount <= EPSILON:
                 continue
             for hub in hubs:
                 if hub in (origin, destination):
+                    continue
+                # Never create a two-way crop pair. A 2-cycle is not a relay: it
+                # makes "ship after you collect" unsatisfiable at both ends
+                # simultaneously, so no schedule can honour it.
+                if (hub, origin) in legs or (destination, hub) in legs:
+                    continue
+                # Relay moves the whole flow, so (origin, destination) goes away.
+                prospective = (_crop_edges() - {(origin, destination)}) | {
+                    (origin, hub),
+                    (hub, destination),
+                }
+                if not _crop_shape_ok(prospective):
                     continue
                 if _apply_changes(
                     [
@@ -681,6 +722,19 @@ def _improve_flows(
                     if (over_delta, total_delta, rc_delta) >= (0, 0, 0):
                         settled.add(candidate)
                         continue
+
+                    if resource is Resource.CROP and relay_hubs:
+                        # Swaps are blind to relay: rewiring a hub's legs can
+                        # lengthen the chain or close a loop, either of which the
+                        # beat cannot then schedule. Checked on the prospective
+                        # edge set, never applied-then-undone.
+                        prospective = _crop_edges() | {(o1, d2), (o2, d1)}
+                        for key in ((o1, d1), (o2, d2)):
+                            if legs.get(key, 0.0) - t <= EPSILON:
+                                prospective.discard(key)
+                        if not _crop_shape_ok(prospective):
+                            settled.add(candidate)
+                            continue
 
                     for key, cargo in new_cargo.items():
                         if cargo:

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -740,7 +740,17 @@ def _improve_flows(
         # break the idempotent re-plan that route diffing depends on (known issue
         # #10): merely adding a village would reshuffle routes that have nothing
         # to do with it. Computed once per scan, not per edge.
-        hubs = sorted({v for key in legs for v in key})
+        # A hub relays crop through itself, so it must be a real village that can
+        # actually staff the extra leg. Foreign sinks (merchant_count == 0) and
+        # anything absent from the account are excluded: including a sink let the
+        # search adopt an impossible sink->sink leg (zero distance between two
+        # co-located tributes costs zero merchants), emitting a route whose origin
+        # is a negative foreign id.
+        hubs = sorted(
+            v
+            for v in {v for key in legs for v in key}
+            if v in villages and villages[v].merchant_count > 0
+        )
         for origin, destination in sorted(key for key, amount in legs.items() if amount > EPSILON):
             # Both ends must be outside the relay graph, not just the origin.
             # Guarding only the origin let a leg that *ends* at an existing hub
@@ -980,6 +990,18 @@ def build_plan(
             f"overstate the real shortfall. Raise max_improve_passes to finish the search."
         )
     pair_cargo = _merge_pair_cargo(assignment)
+
+    # A route can only originate at a real village that can staff merchants. This
+    # is guaranteed by construction (senders come from surplus, relay hubs are
+    # filtered to merchant-capable villages), but assert it before emitting the
+    # plan: a route whose origin is a foreign sink is impossible to execute, and
+    # silently shipping it is worse than failing loudly.
+    for origin, _destination in pair_cargo:
+        if origin not in villages or villages[origin].merchant_count <= 0:
+            raise AssertionError(
+                f"route origin {origin} is not a merchant-capable village; "
+                "the optimizer built an impossible route"
+            )
 
     routes: list[Route] = [
         _route_for_pair(

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -440,6 +440,65 @@ def _spend_idle_merchants_on_latency(
     return result
 
 
+# How many transfer sizes the refinement sweep tries per swap. Boundaries are
+# deduped and taken largest-first; the cap bounds refinement cost without
+# silently dropping the full transfer, which is always included.
+MAX_BREAKPOINT_CANDIDATES = 12
+
+
+def breakpoint_candidates(
+    grows: Sequence[tuple[float, int]],
+    shrinks: Sequence[tuple[float, int]],
+    t_full: float,
+    cycles: Sequence[int],
+) -> list[float]:
+    """Transfer sizes worth trying besides all-of-min.
+
+    Vehicle cost is a staircase, so the best transfer is often a breakpoint
+    BELOW ``min(both)``: the size that lands some pair's batch exactly on a
+    multiple of its origin's capacity, wasting nothing. All-of-min restricts the
+    search to transportation-polytope vertices; these interior points are where
+    the ceiling-waste savings live.
+
+    Boundaries come from all FOUR touched pairs, not only the growing two. The
+    first version generated candidates only where a growing pair's batch hit a
+    boundary, and Codex review produced the counterexample: with the saving on a
+    SHRINKING leg (200/h over a 1,800-minute round trip dropping to the
+    166.67/h boundary at a 6h cycle), the only improving transfer is one this
+    function never emitted, and the search declared convergence with an
+    improvement still on the table. Both directions now contribute, across every
+    cycle, one boundary each (the nearest below the pair's post-transfer load).
+
+    Args:
+        grows: ``(current_rate, origin_capacity)`` for the two pairs gaining t.
+        shrinks: same, for the two pairs losing t.
+        t_full: the all-of-min transfer; always included.
+        cycles: candidate cycle lengths.
+
+    Returns:
+        Distinct sizes in (0, t_full], largest first, capped at
+        :data:`MAX_BREAKPOINT_CANDIDATES`.
+    """
+    candidates = {t_full}
+    for rate, capacity in grows:
+        for cycle in cycles:
+            step = capacity / cycle  # rate that fills one vehicle exactly
+            k = int((rate + t_full) // step)
+            if k >= 1:
+                t = k * step - rate
+                if EPSILON < t < t_full - EPSILON:
+                    candidates.add(t)
+    for rate, capacity in shrinks:
+        for cycle in cycles:
+            step = capacity / cycle
+            k = int((rate - EPSILON) // step)
+            if k >= 1:
+                t = rate - k * step
+                if EPSILON < t < t_full - EPSILON:
+                    candidates.add(t)
+    return sorted(candidates, reverse=True)[:MAX_BREAKPOINT_CANDIDATES]
+
+
 def _improve_flows(
     assignment: Assignment,
     villages: Mapping[int, VillageState],
@@ -754,32 +813,13 @@ def _improve_flows(
         return _crop_shape_ok(prospective)
 
     def _breakpoint_ts(resource, o1, d1, o2, d2, t_full):
-        """Transfer sizes worth trying besides all-of-min.
-
-        Vehicle cost is a staircase, so the best transfer is often a breakpoint
-        BELOW min(both): the size that lands a growing pair's batch exactly on a
-        multiple of its origin's capacity, wasting nothing. All-of-min restricts
-        the search to transportation-polytope vertices; these interior points
-        are where the ceiling-waste savings live.
-        """
-        candidates = {t_full}
-        for origin, dest in ((o1, d2), (o2, d1)):
-            capacity = capacities[origin]
-            old_rate = sum(pair.get((origin, dest), {}).values())
-            round_trip = 2.0 * _one_way((origin, dest))
-            cycle = cheapest_cycle(old_rate + t_full, round_trip, capacity, cycles).cycle_hours
-            step = capacity / cycle  # rate that fills one vehicle exactly
-            k = int((old_rate + t_full) // step)
-            while k >= 1:
-                t = k * step - old_rate
-                if t <= EPSILON:
-                    break
-                if t < t_full - EPSILON:
-                    candidates.add(t)
-                k -= 1
-                if len(candidates) >= 8:
-                    break
-        return sorted(candidates, reverse=True)
+        grows = [
+            (sum(pair.get(key, {}).values()), capacities[key[0]]) for key in ((o1, d2), (o2, d1))
+        ]
+        shrinks = [
+            (sum(pair.get(key, {}).values()), capacities[key[0]]) for key in ((o1, d1), (o2, d2))
+        ]
+        return breakpoint_candidates(grows, shrinks, t_full, cycles)
 
     def _best_swap(refinement: bool):
         """One full sweep; return the single best improving swap, or None.

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -71,6 +71,13 @@ DEFAULT_MERCHANT_RESERVE = 2
 # letting routes speed up where the trip, not the load, is the cost.
 MIN_SEND_FILL = 0.6
 
+# How much a route into a foreign tribute counts for, against the route-count
+# term. A tribute split across several villages is several routes to create and
+# watch for one obligation, so consolidating one is worth more than shedding an
+# ordinary route. Sinks are identified structurally -- they can receive but have
+# no merchants to send with -- rather than by any flag.
+SINK_ROUTE_WEIGHT = 4
+
 
 @dataclass(frozen=True)
 class VillageState:
@@ -374,11 +381,15 @@ def _spend_idle_merchants_on_latency(
         indices = by_origin[origin]
         spare = budgets.get(origin, 0) - sum(result[i].merchants_committed for i in indices)
         while spare > 0:
-            best: tuple[tuple[int, float, int, int], int, int, int, int] | None = None
+            best: tuple[tuple[int, int, float, int, int], int, int, int, int] | None = None
             for i in indices:
                 route = result[i]
-                if route.latency_hours <= latency_target:
-                    continue  # already fast enough; do not waste merchants on it
+                # Every route is a candidate, not only the ones over target.
+                # A 1h cycle really is better than a 3h one, so once the routes
+                # that breach the target have been dealt with, leftover idle
+                # merchants keep buying speed on the rest. Routes that already
+                # comply are simply ranked last, via `urgency` below.
+                urgency = int(route.latency_hours > latency_target)
                 one_way = route.one_way_minutes
                 for cost in cycle_sweep(route.hourly_total, 2.0 * one_way, capacity, cycles):
                     if cost.cycle_hours >= route.cycle_hours:
@@ -394,7 +405,9 @@ def _spend_idle_merchants_on_latency(
                         continue
                     compliant = int(new_latency <= latency_target)
                     per_merchant = (route.latency_hours - new_latency) / delta
-                    key = (compliant, per_merchant, -delta, -cost.cycle_hours)
+                    # Fix what breaches the target first, then buy the biggest
+                    # remaining latency cut per merchant spent.
+                    key = (urgency, compliant, per_merchant, -delta, -cost.cycle_hours)
                     if best is None or key > best[0]:
                         best = (
                             key,
@@ -493,6 +506,14 @@ def _improve_flows(
     def excess(origin: int, count: int) -> int:
         return max(0, count - budgets.get(origin, 0))
 
+    # A village with no merchants cannot ship, so it is a pure sink: a foreign
+    # tribute. Splitting one across suppliers is harder to run than an ordinary
+    # split, so each route into it weighs more in the route-count term.
+    sinks = {vid for vid, village in villages.items() if village.merchant_count == 0}
+
+    def route_weight(key: FlowKey) -> int:
+        return SINK_ROUTE_WEIGHT if key[1] in sinks else 1
+
     # Pairs proven non-improving and not invalidated by a swap since. Purely a
     # memo -- it never changes which swap is chosen, only how much work is
     # repeated to find it.
@@ -556,8 +577,8 @@ def _improve_flows(
             for origin, delta in per_origin.items()
         )
         total_delta = sum(new_merch.values()) - sum(pair_merch.get(key, 0) for key in touched_keys)
-        rc_delta = sum(1 for key in touched_keys if new_merch[key] > 0) - sum(
-            1 for key in touched_keys if pair_merch.get(key, 0) > 0
+        rc_delta = sum(route_weight(key) for key in touched_keys if new_merch[key] > 0) - sum(
+            route_weight(key) for key in touched_keys if pair_merch.get(key, 0) > 0
         )
         if (over_delta, total_delta, rc_delta) >= (0, 0, 0):
             return False
@@ -713,9 +734,9 @@ def _improve_flows(
                     total_delta = sum(new_merch.values()) - sum(
                         pair_merch.get(key, 0) for key, _ in moved
                     )
-                    rc_delta = sum(1 for key, _ in moved if new_merch[key] > 0) - sum(
-                        1 for key, _ in moved if pair_merch.get(key, 0) > 0
-                    )
+                    rc_delta = sum(
+                        route_weight(key) for key, _ in moved if new_merch[key] > 0
+                    ) - sum(route_weight(key) for key, _ in moved if pair_merch.get(key, 0) > 0)
 
                     # The whole objective only shifts by these deltas, so the
                     # full tuple improves exactly when the delta tuple is < 0.

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -549,10 +549,18 @@ def _improve_flows(
     def _crop_edges() -> set[FlowKey]:
         return {key for key, amount in flows.get(Resource.CROP, {}).items() if amount > EPSILON}
 
-    def _apply_changes(changes: Sequence[tuple[FlowKey, Resource, float]]) -> bool:
-        """Evaluate a set of pair-cargo deltas and apply them if they improve.
+    def _score_changes(changes: Sequence[tuple[FlowKey, Resource, float]]):
+        """Cost a set of pair-cargo deltas WITHOUT applying them.
 
-        Shared by the relay move. Returns True when the objective strictly fell.
+        Split out from applying so a mover can compare candidates before
+        committing to one. Relay used to take the first hub that merely
+        improved, and since hubs are iterated in village-id order that made the
+        choice arbitrary: on a real account it routed a 96-field haul through
+        the lowest-numbered village while four nearer ones sat unused.
+
+        Returns ``(delta, state)`` where delta is the lexicographic objective
+        change -- lower is better, negative means an improvement -- and state is
+        what :func:`_commit_changes` needs to apply it.
         """
         touched_keys = {key for key, _r, _d in changes}
         new_cargo: dict[FlowKey, dict[Resource, float]] = {
@@ -580,9 +588,15 @@ def _improve_flows(
         rc_delta = sum(route_weight(key) for key in touched_keys if new_merch[key] > 0) - sum(
             route_weight(key) for key in touched_keys if pair_merch.get(key, 0) > 0
         )
-        if (over_delta, total_delta, rc_delta) >= (0, 0, 0):
-            return False
+        return (over_delta, total_delta, rc_delta), (
+            touched_keys,
+            new_cargo,
+            new_merch,
+            per_origin,
+        )
 
+    def _commit_changes(changes, state) -> None:
+        touched_keys, new_cargo, new_merch, per_origin = state
         for key in touched_keys:
             if new_cargo[key]:
                 pair[key] = new_cargo[key]
@@ -607,7 +621,6 @@ def _improve_flows(
                 if touched_villages & {entry[1][0], entry[1][1], entry[2][0], entry[2][1]}
             ]
         )
-        return True
 
     def _relay_scan() -> bool:
         """Reroute a crop flow through an intermediate village that forwards it.
@@ -647,6 +660,11 @@ def _improve_flows(
             amount = legs.get((origin, destination), 0.0)
             if amount <= EPSILON:
                 continue
+            # Score every candidate hub and take the best one. Accepting the
+            # first that merely improves picks by village id, which is arbitrary
+            # and measurably bad: it sent a 96-field haul through the
+            # lowest-numbered village when four nearer ones would have done.
+            best = None
             for hub in hubs:
                 if hub in (origin, destination):
                     continue
@@ -662,15 +680,25 @@ def _improve_flows(
                 }
                 if not _crop_shape_ok(prospective):
                     continue
-                if _apply_changes(
-                    [
-                        ((origin, destination), Resource.CROP, -amount),
-                        ((origin, hub), Resource.CROP, amount),
-                        ((hub, destination), Resource.CROP, amount),
-                    ]
-                ):
-                    relay_hubs.add(hub)
-                    return True
+                changes = [
+                    ((origin, destination), Resource.CROP, -amount),
+                    ((origin, hub), Resource.CROP, amount),
+                    ((hub, destination), Resource.CROP, amount),
+                ]
+                delta, state = _score_changes(changes)
+                if delta >= (0, 0, 0):
+                    continue
+                # Tie-break on the collection leg: when two hubs cost the same,
+                # the nearer one is the better place to send cargo, and it keeps
+                # the choice stable rather than falling back on village id.
+                key = (delta, one_way_cache.get((origin, hub), 0.0), hub)
+                if best is None or key < best[0]:
+                    best = (key, hub, changes, state)
+            if best is not None:
+                _, hub, changes, state = best
+                _commit_changes(changes, state)
+                relay_hubs.add(hub)
+                return True
         return False
 
     converged = False

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -102,17 +102,49 @@ class Shortfall:
     reason: str
 
 
+MAX_TRADE_OFFICE_LEVEL = 20
+
+
 @dataclass(frozen=True)
 class OverBudget:
-    """A village asked to staff more merchants than it has."""
+    """A village asked to staff more merchants than it has.
+
+    ``trade_office_levels_needed`` is escalation step 4 of profile section 8.4:
+    the smallest Trade Office upgrade that would make this village's own routes
+    fit, or None when even the maximum level cannot. It is a recommendation
+    about the *current* route set -- upgrading changes merchant capacity, so the
+    plan should be re-run afterwards rather than assumed.
+    """
 
     village_id: int
     committed: int
     available: int
+    trade_office_levels_needed: int | None = None
 
     @property
     def excess(self) -> int:
         return self.committed - self.available
+
+
+def _trade_office_levels_needed(
+    village: VillageState,
+    routes_from: Sequence[Route],
+    merchant_model: MerchantModel,
+    budget: int,
+    cycles: Sequence[int],
+) -> int | None:
+    """Smallest Trade Office increase that brings *village* within *budget*."""
+    for delta in range(1, MAX_TRADE_OFFICE_LEVEL - village.trade_office_level + 1):
+        capacity = merchant_model.capacity(village.trade_office_level + delta)
+        needed = sum(
+            cheapest_cycle(
+                route.hourly_total, 2.0 * route.one_way_minutes, capacity, cycles
+            ).merchants_committed
+            for route in routes_from
+        )
+        if needed <= budget:
+            return delta
+    return None
 
 
 @dataclass(frozen=True)
@@ -270,11 +302,22 @@ def build_plan(
                 f"forbid better"
             )
 
+    routes_by_origin: dict[int, list[Route]] = {}
+    for route in routes:
+        routes_by_origin.setdefault(route.origin, []).append(route)
+
     over_budget = tuple(
         OverBudget(
             village_id=vid,
             committed=used,
             available=villages[vid].spare_merchants(merchant_reserve),
+            trade_office_levels_needed=_trade_office_levels_needed(
+                villages[vid],
+                routes_by_origin.get(vid, []),
+                merchant_model,
+                villages[vid].spare_merchants(merchant_reserve),
+                cycles,
+            ),
         )
         for vid, used in sorted(committed.items())
         if used > villages[vid].spare_merchants(merchant_reserve)

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -1,0 +1,289 @@
+"""Turn per-village shipping rates into a concrete set of trade routes.
+
+Written for an account of **any size**. Nothing here knows how many villages
+exist, which ones are hubs, or what any of them are called: village count grows
+as the account expands and every figure changes between runs, so the optimizer
+takes whatever state was fetched and works from that. A village that appears for
+the first time simply has no allocation yet and generates no routes.
+
+Two of the profile's known issues are already impossible by the time we get
+here, because :mod:`.allocation` nets each village to a single figure per
+resource:
+
+* **#2, two-way pairs** -- a village cannot be both sender and receiver of the
+  same resource, so ``A -> B`` and ``B -> A`` for iron cannot both exist.
+* **waterfall for W/C/I** -- for the same reason a village that nets as a
+  receiver of lumber cannot also send lumber, so ``A -> B -> C`` cannot form.
+
+Both are asserted as invariants in the tests rather than defended with runtime
+checks, because the property comes from the data model, not from vigilance here.
+
+First pass, per profile section 14: greedy nearest-sender matching, no hub
+consolidation and no local improvement. It is deterministic, explainable, and a
+baseline the later hub pass has to beat. What it does *not* do is claim
+optimality -- a village over its merchant budget is reported, never hidden.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+from .allocation import EPSILON, Resource, ResourcePlan
+from .geometry import MapGeometry
+from .merchants import DAILY_BEAT_CYCLES, MerchantModel, cheapest_cycle
+
+DEFAULT_MERCHANT_RESERVE = 2
+
+
+@dataclass(frozen=True)
+class VillageState:
+    """Everything the optimizer needs about one village, all of it fetched.
+
+    ``trade_office_level`` defaults to 0 because an unknown level must round
+    *down*: understating it over-provisions merchants, which is wasteful but
+    safe, while overstating it breaches the merchant budget invisibly.
+    """
+
+    village_id: int
+    x: int
+    y: int
+    merchant_count: int
+    trade_office_level: int = 0
+    name: str = ""
+
+    @property
+    def coords(self) -> tuple[int, int]:
+        return (self.x, self.y)
+
+    def spare_merchants(self, reserve: int = DEFAULT_MERCHANT_RESERVE) -> int:
+        return max(0, self.merchant_count - reserve)
+
+
+@dataclass(frozen=True)
+class Route:
+    """One trade route: a sender, a receiver, and mixed cargo per send."""
+
+    origin: int
+    destination: int
+    cargo_per_hour: Mapping[Resource, float]
+    cycle_hours: int
+    merchants_per_send: int
+    sets_in_flight: int
+    one_way_minutes: float
+
+    @property
+    def merchants_committed(self) -> int:
+        return self.merchants_per_send * self.sets_in_flight
+
+    @property
+    def hourly_total(self) -> float:
+        """Merchant capacity is a total across resources, not per resource."""
+        return sum(self.cargo_per_hour.values())
+
+    @property
+    def batch_per_resource(self) -> dict[Resource, float]:
+        """Cargo carried on a single send, before integer rounding."""
+        return {r: amount * self.cycle_hours for r, amount in self.cargo_per_hour.items()}
+
+    @property
+    def latency_hours(self) -> float:
+        """Worst-case wait from production to arrival: one cycle plus the trip."""
+        return self.cycle_hours + self.one_way_minutes / 60.0
+
+
+@dataclass(frozen=True)
+class Shortfall:
+    """Demand that could not be routed, and why."""
+
+    village_id: int
+    resource: Resource
+    per_hour: float
+    reason: str
+
+
+@dataclass(frozen=True)
+class OverBudget:
+    """A village asked to staff more merchants than it has."""
+
+    village_id: int
+    committed: int
+    available: int
+
+    @property
+    def excess(self) -> int:
+        return self.committed - self.available
+
+
+@dataclass(frozen=True)
+class Plan:
+    """A routing plan, plus everything wrong with it."""
+
+    routes: tuple[Route, ...] = ()
+    merchants_committed: Mapping[int, int] = field(default_factory=dict)
+    shortfalls: tuple[Shortfall, ...] = ()
+    over_budget: tuple[OverBudget, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def is_feasible(self) -> bool:
+        return not self.over_budget and not self.shortfalls
+
+    @property
+    def total_merchants(self) -> int:
+        return sum(self.merchants_committed.values())
+
+
+def _flows_for_resource(
+    plan: ResourcePlan,
+    villages: Mapping[int, VillageState],
+    geometry: MapGeometry,
+) -> tuple[dict[tuple[int, int], float], list[Shortfall]]:
+    """Match receivers to their nearest senders, largest demand first.
+
+    Largest-first keeps the awkward villages from being left with only distant
+    surplus, and iterating in a sorted order makes the result deterministic --
+    a re-plan on unchanged input must produce an identical route set, or the
+    diff against the live configuration is meaningless.
+    """
+    surplus: dict[int, float] = {
+        v.village_id: -v.ship_per_hour for v in plan.senders if v.village_id in villages
+    }
+    demand = sorted(
+        (v for v in plan.receivers if v.village_id in villages),
+        key=lambda v: (-v.ship_per_hour, v.village_id),
+    )
+
+    flows: dict[tuple[int, int], float] = {}
+    shortfalls: list[Shortfall] = []
+
+    for receiver in demand:
+        remaining = receiver.ship_per_hour
+        candidates = sorted(
+            (vid for vid, left in surplus.items() if left > EPSILON and vid != receiver.village_id),
+            key=lambda vid: (
+                geometry.distance(villages[vid].coords, villages[receiver.village_id].coords),
+                vid,
+            ),
+        )
+        for origin in candidates:
+            if remaining <= EPSILON:
+                break
+            taken = min(surplus[origin], remaining)
+            flows[(origin, receiver.village_id)] = (
+                flows.get((origin, receiver.village_id), 0.0) + taken
+            )
+            surplus[origin] -= taken
+            remaining -= taken
+
+        if remaining > EPSILON:
+            shortfalls.append(
+                Shortfall(
+                    village_id=receiver.village_id,
+                    resource=plan.resource,
+                    per_hour=remaining,
+                    reason="no village has surplus left to cover this demand",
+                )
+            )
+    return flows, shortfalls
+
+
+def build_plan(
+    villages: Mapping[int, VillageState],
+    resource_plans: Mapping[Resource, ResourcePlan],
+    geometry: MapGeometry,
+    merchant_model: MerchantModel,
+    *,
+    merchant_reserve: int = DEFAULT_MERCHANT_RESERVE,
+    cycles: Sequence[int] = DAILY_BEAT_CYCLES,
+    max_latency_hours: float | None = 2.0,
+) -> Plan:
+    """Build a route set from fetched state. Works for any village count.
+
+    Flows for the four resources are merged per ``(origin, destination)`` pair
+    into one route, because a Travian route carries all four together and its
+    merchant cost is driven by the *combined* tonnage.
+
+    Args:
+        villages: fetched state, keyed by village id. Villages referenced by an
+            allocation but absent here are skipped and reported.
+        resource_plans: output of :func:`~.allocation.resolve_resource`.
+        geometry: distances and travel times for this server.
+        merchant_model: capacity per Trade Office level.
+        merchant_reserve: merchants to leave idle per village.
+        cycles: candidate cycle lengths. Defaults to those dividing 24h so the
+            schedule has a daily period.
+        max_latency_hours: soft target; exceeding it warns rather than fails,
+            because geometry can make it impossible.
+
+    Returns:
+        A :class:`Plan`. Over-budget villages and unroutable demand are reported
+        in the plan, never silently dropped or quietly trimmed to fit.
+    """
+    warnings: list[str] = []
+    pair_cargo: dict[tuple[int, int], dict[Resource, float]] = {}
+    shortfalls: list[Shortfall] = []
+
+    for resource in sorted(resource_plans, key=lambda r: r.value):
+        plan = resource_plans[resource]
+        missing = {v.village_id for v in plan.villages} - set(villages)
+        if missing:
+            warnings.append(
+                f"{resource.value}: no fetched state for village(s) "
+                f"{sorted(missing)}; excluded from routing"
+            )
+        flows, resource_shortfalls = _flows_for_resource(plan, villages, geometry)
+        shortfalls.extend(resource_shortfalls)
+        for pair, amount in flows.items():
+            pair_cargo.setdefault(pair, {})[resource] = amount
+
+    routes: list[Route] = []
+    committed: dict[int, int] = {vid: 0 for vid in villages}
+
+    for origin, destination in sorted(pair_cargo):
+        cargo = pair_cargo[(origin, destination)]
+        hourly_total = sum(cargo.values())
+        if hourly_total <= EPSILON:
+            continue
+
+        sender = villages[origin]
+        one_way = geometry.one_way_minutes(sender.coords, villages[destination].coords)
+        capacity = merchant_model.capacity(sender.trade_office_level)
+        cost = cheapest_cycle(hourly_total, 2.0 * one_way, capacity, cycles)
+
+        route = Route(
+            origin=origin,
+            destination=destination,
+            cargo_per_hour=dict(sorted(cargo.items(), key=lambda kv: kv[0].value)),
+            cycle_hours=cost.cycle_hours,
+            merchants_per_send=cost.merchants_per_send,
+            sets_in_flight=cost.sets_in_flight,
+            one_way_minutes=one_way,
+        )
+        routes.append(route)
+        committed[origin] += route.merchants_committed
+
+        if max_latency_hours is not None and route.latency_hours > max_latency_hours:
+            warnings.append(
+                f"route {origin} -> {destination} has {route.latency_hours:.1f}h "
+                f"latency against a {max_latency_hours:.0f}h target; geometry may "
+                f"forbid better"
+            )
+
+    over_budget = tuple(
+        OverBudget(
+            village_id=vid,
+            committed=used,
+            available=villages[vid].spare_merchants(merchant_reserve),
+        )
+        for vid, used in sorted(committed.items())
+        if used > villages[vid].spare_merchants(merchant_reserve)
+    )
+
+    return Plan(
+        routes=tuple(routes),
+        merchants_committed=committed,
+        shortfalls=tuple(shortfalls),
+        over_budget=over_budget,
+        warnings=tuple(warnings),
+    )

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -18,10 +18,20 @@ resource:
 Both are asserted as invariants in the tests rather than defended with runtime
 checks, because the property comes from the data model, not from vigilance here.
 
-First pass, per profile section 14: greedy nearest-sender matching, no hub
-consolidation and no local improvement. It is deterministic, explainable, and a
-baseline the later hub pass has to beat. What it does *not* do is claim
-optimality -- a village over its merchant budget is reported, never hidden.
+Two stages, per profile section 14 (``cluster -> assign -> improve``):
+
+1. **Greedy seed** -- :func:`_flows_for_resource` matches each receiver to its
+   nearest senders, largest demand first. Deterministic and explainable, but
+   order-dependent and blind to merchant cost.
+2. **Merchant-aware local search** -- :func:`_improve_flows` reassigns that seed
+   with 2x2 swaps, keeping only moves that strictly lower the lexicographic
+   objective ``(over_budget_excess, total_merchants, route_count)``. It never
+   returns a plan worse than the seed, and cross-resource bundling falls out of
+   costing the *merged* pair cargo.
+
+What it still does *not* do is claim global optimality (the problem is NP-hard,
+section 14) or relay crop through a sub-hub (single-leg flows only). A village
+over its merchant budget is reported, never hidden.
 """
 
 from __future__ import annotations
@@ -220,6 +230,206 @@ def _flows_for_resource(
     return flows, shortfalls
 
 
+# ---------------------------------------------------------------------------
+# Merchant-aware improvement: seed with the greedy flows, then local search
+# ---------------------------------------------------------------------------
+
+# A directed flow: (origin, destination) -> rate, one map per resource.
+FlowKey = tuple[int, int]
+Assignment = dict[Resource, dict[FlowKey, float]]
+
+# Backstop against a pathological non-converging sweep. Each accepted swap
+# strictly lowers the integer objective, so convergence is guaranteed well
+# inside this on any real account; the cap only bounds the worst case.
+MAX_IMPROVE_PASSES = 200
+
+
+def _merge_pair_cargo(assignment: Assignment) -> dict[FlowKey, dict[Resource, float]]:
+    """Collapse the per-resource flows into one mixed cargo per village pair.
+
+    A Travian route carries all four resources together, so merchant cost is a
+    function of the *combined* tonnage on a pair — never the per-resource legs.
+    """
+    pair: dict[FlowKey, dict[Resource, float]] = {}
+    for resource, flows in assignment.items():
+        for key, amount in flows.items():
+            if amount > EPSILON:
+                pair.setdefault(key, {})[resource] = pair.get(key, {}).get(resource, 0.0) + amount
+    return pair
+
+
+def _pair_merchants(
+    origin: int,
+    destination: int,
+    cargo: Mapping[Resource, float],
+    villages: Mapping[int, VillageState],
+    geometry: MapGeometry,
+    merchant_model: MerchantModel,
+    cycles: Sequence[int],
+) -> int:
+    """Merchants one pair commits at its cheapest cycle. Zero for empty cargo."""
+    hourly_total = sum(cargo.values())
+    if hourly_total <= EPSILON:
+        return 0
+    one_way = geometry.one_way_minutes(villages[origin].coords, villages[destination].coords)
+    capacity = merchant_model.capacity(villages[origin].trade_office_level)
+    return cheapest_cycle(hourly_total, 2.0 * one_way, capacity, cycles).merchants_committed
+
+
+def _route_for_pair(
+    origin: int,
+    destination: int,
+    cargo: Mapping[Resource, float],
+    villages: Mapping[int, VillageState],
+    geometry: MapGeometry,
+    merchant_model: MerchantModel,
+    cycles: Sequence[int],
+) -> Route:
+    """Build the concrete :class:`Route` for one merged pair."""
+    hourly_total = sum(cargo.values())
+    one_way = geometry.one_way_minutes(villages[origin].coords, villages[destination].coords)
+    capacity = merchant_model.capacity(villages[origin].trade_office_level)
+    cost = cheapest_cycle(hourly_total, 2.0 * one_way, capacity, cycles)
+    return Route(
+        origin=origin,
+        destination=destination,
+        cargo_per_hour=dict(sorted(cargo.items(), key=lambda kv: kv[0].value)),
+        cycle_hours=cost.cycle_hours,
+        merchants_per_send=cost.merchants_per_send,
+        sets_in_flight=cost.sets_in_flight,
+        one_way_minutes=one_way,
+    )
+
+
+def _improve_flows(
+    assignment: Assignment,
+    villages: Mapping[int, VillageState],
+    geometry: MapGeometry,
+    merchant_model: MerchantModel,
+    cycles: Sequence[int],
+    budgets: Mapping[int, int],
+) -> Assignment:
+    """Lower merchant commitment by reassigning flow, seeded by the greedy plan.
+
+    The greedy seed matches each receiver to its nearest senders, which is
+    order-dependent and blind to merchant cost: a remote village's surplus can
+    land on far-flung leftover receivers and blow its merchant budget. This is
+    the "local improvement" pass the profile (§14) always intended.
+
+    The one move is a **2x2 swap** within a single resource: two flows
+    ``o1->d1`` and ``o2->d2`` become ``o1->d2`` and ``o2->d1``, shifting the
+    same rate ``t = min(both)``. It preserves every origin's total outflow and
+    every destination's total inflow, so conservation, the surplus ceiling, the
+    no-two-way-pair rule and the no-waterfall rule all survive untouched — a
+    sender stays a sender, a receiver stays a receiver. Cross-resource bundling
+    falls out for free: cost is measured on the *merged* pair cargo, so a swap
+    that lands a resource on a pair another resource already uses is rewarded.
+
+    The objective is lexicographic ``(over_budget_excess, total_merchants,
+    route_count)`` — feasibility first, then merchants (§8.3 objective 1), then
+    route count (objective 4). A swap is applied only when it strictly lowers
+    that tuple, so the result is deterministic and never worse than the seed.
+    """
+    # Working state, kept in sync: per-resource flows, merged pair cargo, the
+    # merchant cost of each pair, and the running per-origin commitment.
+    flows: Assignment = {resource: dict(legs) for resource, legs in assignment.items()}
+    pair = _merge_pair_cargo(flows)
+    pair_merch: dict[FlowKey, int] = {
+        key: _pair_merchants(key[0], key[1], cargo, villages, geometry, merchant_model, cycles)
+        for key, cargo in pair.items()
+    }
+    committed: dict[int, int] = {}
+    for (origin, _destination), merchants in pair_merch.items():
+        committed[origin] = committed.get(origin, 0) + merchants
+
+    def excess(origin: int, count: int) -> int:
+        return max(0, count - budgets.get(origin, 0))
+
+    for _pass in range(MAX_IMPROVE_PASSES):
+        applied = False
+        for resource in sorted(flows, key=lambda r: r.value):
+            legs = flows[resource]
+            edges = sorted(key for key, amount in legs.items() if amount > EPSILON)
+            for i, (o1, d1) in enumerate(edges):
+                for o2, d2 in edges[i + 1 :]:
+                    if o1 == o2 or d1 == d2:
+                        continue
+                    t = min(legs[(o1, d1)], legs[(o2, d2)])
+                    if t <= EPSILON:
+                        continue
+
+                    # Cargo of the four pairs the swap touches, after the move.
+                    moved = [((o1, d1), -t), ((o2, d2), -t), ((o1, d2), t), ((o2, d1), t)]
+                    new_cargo: dict[FlowKey, dict[Resource, float]] = {}
+                    for key, delta in moved:
+                        cargo = dict(pair.get(key, {}))
+                        updated = cargo.get(resource, 0.0) + delta
+                        if updated > EPSILON:
+                            cargo[resource] = updated
+                        else:
+                            cargo.pop(resource, None)
+                        new_cargo[key] = cargo
+                    new_merch = {
+                        key: _pair_merchants(
+                            key[0], key[1], cargo, villages, geometry, merchant_model, cycles
+                        )
+                        for key, cargo in new_cargo.items()
+                    }
+
+                    d_o1 = (new_merch[(o1, d1)] - pair_merch.get((o1, d1), 0)) + (
+                        new_merch[(o1, d2)] - pair_merch.get((o1, d2), 0)
+                    )
+                    d_o2 = (new_merch[(o2, d2)] - pair_merch.get((o2, d2), 0)) + (
+                        new_merch[(o2, d1)] - pair_merch.get((o2, d1), 0)
+                    )
+                    new_o1, new_o2 = committed.get(o1, 0) + d_o1, committed.get(o2, 0) + d_o2
+
+                    over_delta = (
+                        excess(o1, new_o1)
+                        - excess(o1, committed.get(o1, 0))
+                        + excess(o2, new_o2)
+                        - excess(o2, committed.get(o2, 0))
+                    )
+                    total_delta = sum(new_merch.values()) - sum(
+                        pair_merch.get(key, 0) for key, _ in moved
+                    )
+                    rc_delta = sum(1 for key, _ in moved if new_merch[key] > 0) - sum(
+                        1 for key, _ in moved if pair_merch.get(key, 0) > 0
+                    )
+
+                    # The whole objective only shifts by these deltas, so the
+                    # full tuple improves exactly when the delta tuple is < 0.
+                    if (over_delta, total_delta, rc_delta) >= (0, 0, 0):
+                        continue
+
+                    for key, cargo in new_cargo.items():
+                        if cargo:
+                            pair[key] = cargo
+                        else:
+                            pair.pop(key, None)
+                        if new_merch[key] > 0:
+                            pair_merch[key] = new_merch[key]
+                        else:
+                            pair_merch.pop(key, None)
+                    committed[o1], committed[o2] = new_o1, new_o2
+                    legs[(o1, d1)] -= t
+                    legs[(o2, d2)] -= t
+                    legs[(o1, d2)] = legs.get((o1, d2), 0.0) + t
+                    legs[(o2, d1)] = legs.get((o2, d1), 0.0) + t
+                    for key in ((o1, d1), (o2, d2)):
+                        if legs[key] <= EPSILON:
+                            del legs[key]
+                    applied = True
+                    break
+                if applied:
+                    break
+            if applied:
+                break
+        if not applied:
+            break
+    return flows
+
+
 def build_plan(
     villages: Mapping[int, VillageState],
     resource_plans: Mapping[Resource, ResourcePlan],
@@ -253,7 +463,7 @@ def build_plan(
         in the plan, never silently dropped or quietly trimmed to fit.
     """
     warnings: list[str] = []
-    pair_cargo: dict[tuple[int, int], dict[Resource, float]] = {}
+    assignment: Assignment = {}
     shortfalls: list[Shortfall] = []
 
     for resource in sorted(resource_plans, key=lambda r: r.value):
@@ -266,31 +476,24 @@ def build_plan(
             )
         flows, resource_shortfalls = _flows_for_resource(plan, villages, geometry)
         shortfalls.extend(resource_shortfalls)
-        for pair, amount in flows.items():
-            pair_cargo.setdefault(pair, {})[resource] = amount
+        assignment[resource] = {key: amount for key, amount in flows.items() if amount > EPSILON}
+
+    # Reassign the greedy seed to cut merchants and relieve over-budget villages
+    # wherever a cheaper routing exists; never worse than the seed (§8.3, §14).
+    budgets = {vid: villages[vid].spare_merchants(merchant_reserve) for vid in villages}
+    assignment = _improve_flows(assignment, villages, geometry, merchant_model, cycles, budgets)
+    pair_cargo = _merge_pair_cargo(assignment)
 
     routes: list[Route] = []
     committed: dict[int, int] = {vid: 0 for vid in villages}
 
     for origin, destination in sorted(pair_cargo):
         cargo = pair_cargo[(origin, destination)]
-        hourly_total = sum(cargo.values())
-        if hourly_total <= EPSILON:
+        if sum(cargo.values()) <= EPSILON:
             continue
 
-        sender = villages[origin]
-        one_way = geometry.one_way_minutes(sender.coords, villages[destination].coords)
-        capacity = merchant_model.capacity(sender.trade_office_level)
-        cost = cheapest_cycle(hourly_total, 2.0 * one_way, capacity, cycles)
-
-        route = Route(
-            origin=origin,
-            destination=destination,
-            cargo_per_hour=dict(sorted(cargo.items(), key=lambda kv: kv[0].value)),
-            cycle_hours=cost.cycle_hours,
-            merchants_per_send=cost.merchants_per_send,
-            sets_in_flight=cost.sets_in_flight,
-            one_way_minutes=one_way,
+        route = _route_for_pair(
+            origin, destination, cargo, villages, geometry, merchant_model, cycles
         )
         routes.append(route)
         committed[origin] += route.merchants_committed

--- a/src/travian_api/services/distribution/optimizer.py
+++ b/src/travian_api/services/distribution/optimizer.py
@@ -41,12 +41,18 @@ Three stages, per profile section 14 (``cluster -> assign -> improve``):
 
 4. **Crop relay** -- :func:`_improve_flows` may also reroute a crop flow through
    an intermediate village that forwards it (profile section 3.5 permits this for
-   crop, never for materials). Relay cannot lower total merchants -- cost is
-   essentially ``cargo x round_trip / capacity``, linear in both, so the long haul
-   costs the same consolidated as split and the collection legs are pure addition
-   -- but it *moves* commitment off a village that cannot staff its own haul, and
-   occasionally sheds a merchant to integer rounding. Because excess is the first
-   objective key, it is adopted exactly when it pays and never merely to shuffle.
+   crop, never for materials). Its main use is *moving* commitment off a village
+   that cannot staff its own haul, but it can also genuinely lower the total:
+   the cost ``ceil(batch/capacity) x sets_in_flight`` multiplies each send's
+   partial-vehicle waste by every set in flight, and pooling several part-loads
+   onto one trunk removes that waste (five 900/h flows over a 1,200-min round
+   trip at capacity 1,000 cost 100 vehicles direct, 95 pooled). The continuous
+   relaxation -- where cost is linear in cargo x distance and relay can never
+   win -- only approximates the regime where batches are large relative to
+   capacity. Because excess is the first objective key, relay is adopted exactly
+   when it pays. NOTE: single-flow moves harvest pooling only partially; fully
+   pooling several senders needs a compound move each step of which is
+   break-even, which first-improvement cannot cross.
 
 What it still does *not* do is claim global optimality (the problem is NP-hard,
 section 14) or relay materials. A village over its merchant budget is reported,
@@ -461,9 +467,11 @@ def _improve_flows(
     that lands a resource on a pair another resource already uses is rewarded.
 
     The objective is lexicographic ``(over_budget_excess, total_merchants,
-    route_count)`` — feasibility first, then merchants (§8.3 objective 1), then
-    route count (objective 4). A swap is applied only when it strictly lowers
-    that tuple, so the result is deterministic and never worse than the seed.
+    route_count, cargo_weighted_round_trip)`` — feasibility first, then
+    merchants (§8.3 objective 1), then route count (objective 4), then shorter
+    hauls as the tie-break so equal-cost plans prefer nearer assignments. A move
+    is applied only when it strictly lowers that tuple, so the result is
+    deterministic and never worse than the seed.
 
     Returns:
         ``(flows, converged)``. ``converged`` is False when ``max_passes`` ran
@@ -494,6 +502,13 @@ def _improve_flows(
         return cheapest_cycle(
             hourly_total, 2.0 * one_way, capacities[origin], cycles
         ).merchants_committed
+
+    def _one_way(key: FlowKey) -> float:
+        cached = one_way_cache.get(key)
+        if cached is None:
+            cached = geometry.one_way_minutes(villages[key[0]].coords, villages[key[1]].coords)
+            one_way_cache[key] = cached
+        return cached
 
     pair = _merge_pair_cargo(flows)
     pair_merch: dict[FlowKey, int] = {
@@ -588,7 +603,22 @@ def _improve_flows(
         rc_delta = sum(route_weight(key) for key in touched_keys if new_merch[key] > 0) - sum(
             route_weight(key) for key in touched_keys if pair_merch.get(key, 0) > 0
         )
-        return (over_delta, total_delta, rc_delta), (
+        # Cargo-weighted round-trip, the final tie-break. Plans that tie on
+        # excess, merchants and route count used to be tie-broken by whatever
+        # move happened to be scanned first, which left the search actively
+        # latency-blind: two equal-cost assignments where one hauls the cargo
+        # twice as far were interchangeable. Rounded to an integer so the
+        # objective stays a strictly-decreasing bounded integer tuple and
+        # termination remains guaranteed.
+        rt_delta = round(
+            sum(
+                (sum(new_cargo[key].values()) - sum(pair.get(key, {}).values()))
+                * 2.0
+                * _one_way(key)
+                for key in touched_keys
+            )
+        )
+        return (over_delta, total_delta, rc_delta, rt_delta), (
             touched_keys,
             new_cargo,
             new_merch,
@@ -625,14 +655,16 @@ def _improve_flows(
     def _relay_scan() -> bool:
         """Reroute a crop flow through an intermediate village that forwards it.
 
-        Relay can never lower TOTAL merchants: cost is essentially
-        ``cargo x round_trip / capacity``, linear in both, so the long haul costs
-        the same consolidated as split and the collection legs are pure addition
-        (measured across every cluster geometry: best case break-even). What it
-        does is *move* commitment off a village that cannot staff its own haul
-        onto one with spare capacity. Since ``over_budget_excess`` is the first
-        objective key and merchants only the second, the accept test below adopts
-        relay exactly when it buys feasibility and never merely to shuffle load.
+        Two ways relay pays. It *moves* commitment off a village that cannot
+        staff its own haul onto one with spare capacity -- the feasibility case,
+        first key of the objective. And in the ceiling-waste regime it lowers
+        the TOTAL: each send's partial-vehicle waste ``batch mod capacity`` is
+        multiplied by ``sets_in_flight``, and pooling part-loads onto one trunk
+        eliminates it. An earlier version of this docstring claimed the second
+        case was impossible, from a linearity argument that only holds when
+        batches dwarf capacity; a sweep confined to that regime then "confirmed"
+        it. The acceptance test below never depended on the claim -- moves are
+        adopted whenever the objective strictly falls, whichever key improves.
 
         Crop only, per profile section 3.5: materials must not chain A->B->C, and
         restricting relay to crop keeps that no-waterfall rule true by
@@ -686,7 +718,7 @@ def _improve_flows(
                     ((hub, destination), Resource.CROP, amount),
                 ]
                 delta, state = _score_changes(changes)
-                if delta >= (0, 0, 0):
+                if delta >= (0, 0, 0, 0):
                     continue
                 # Tie-break on the collection leg: when two hubs cost the same,
                 # the nearer one is the better place to send cargo, and it keeps
@@ -701,134 +733,129 @@ def _improve_flows(
                 return True
         return False
 
-    converged = False
-    for _pass in range(max_passes):
-        applied = False
+    def _swap_changes(resource, o1, d1, o2, d2, t):
+        return [
+            ((o1, d1), resource, -t),
+            ((o2, d2), resource, -t),
+            ((o1, d2), resource, t),
+            ((o2, d1), resource, t),
+        ]
+
+    def _swap_shape_ok(resource, legs, o1, d1, o2, d2, t) -> bool:
+        # Swaps are blind to relay: rewiring a hub's legs can lengthen the chain
+        # or close a loop, either of which the beat cannot then schedule.
+        # Checked on the prospective edge set, never applied-then-undone.
+        if resource is not Resource.CROP or not relay_hubs:
+            return True
+        prospective = _crop_edges() | {(o1, d2), (o2, d1)}
+        for key in ((o1, d1), (o2, d2)):
+            if legs.get(key, 0.0) - t <= EPSILON:
+                prospective.discard(key)
+        return _crop_shape_ok(prospective)
+
+    def _breakpoint_ts(resource, o1, d1, o2, d2, t_full):
+        """Transfer sizes worth trying besides all-of-min.
+
+        Vehicle cost is a staircase, so the best transfer is often a breakpoint
+        BELOW min(both): the size that lands a growing pair's batch exactly on a
+        multiple of its origin's capacity, wasting nothing. All-of-min restricts
+        the search to transportation-polytope vertices; these interior points
+        are where the ceiling-waste savings live.
+        """
+        candidates = {t_full}
+        for origin, dest in ((o1, d2), (o2, d1)):
+            capacity = capacities[origin]
+            old_rate = sum(pair.get((origin, dest), {}).values())
+            round_trip = 2.0 * _one_way((origin, dest))
+            cycle = cheapest_cycle(old_rate + t_full, round_trip, capacity, cycles).cycle_hours
+            step = capacity / cycle  # rate that fills one vehicle exactly
+            k = int((old_rate + t_full) // step)
+            while k >= 1:
+                t = k * step - old_rate
+                if t <= EPSILON:
+                    break
+                if t < t_full - EPSILON:
+                    candidates.add(t)
+                k -= 1
+                if len(candidates) >= 8:
+                    break
+        return sorted(candidates, reverse=True)
+
+    def _best_swap(refinement: bool):
+        """One full sweep; return the single best improving swap, or None.
+
+        Best-improvement, not first-improvement. An order-perturbation audit
+        (reversed plus two seeded shuffles over 30 accounts) showed the previous
+        first-improving-in-sorted-order scan was beaten by some other order in
+        24 of 30 cases -- the scan order, which follows village ids, was quietly
+        deciding which local optimum the search landed in. Scanning everything
+        and taking the best removes that positional bias; ties break on the
+        sorted candidate tuple, so determinism is preserved.
+
+        ``refinement`` widens the neighbourhood to breakpoint transfer sizes.
+        It ignores ``settled``, whose entries only assert that the FULL transfer
+        does not improve, and it never adds to it for the same reason.
+        """
+        best = None
         for resource in sorted(flows, key=lambda r: r.value):
             legs = flows[resource]
             edges = sorted(key for key, amount in legs.items() if amount > EPSILON)
             for i, (o1, d1) in enumerate(edges):
                 for o2, d2 in edges[i + 1 :]:
-                    # Skip pairs already proven non-improving that no swap since
-                    # has touched. This is the whole speedup: it preserves the
-                    # first-improving-in-sorted-order trajectory exactly (and so
-                    # the resulting plan), while avoiding the re-evaluation of
-                    # every untouched pair after each swap.
-                    if (resource, (o1, d1), (o2, d2)) in settled:
+                    if not refinement and (resource, (o1, d1), (o2, d2)) in settled:
                         continue
-                    # o1 == d2 (or o2 == d1) would create a self-loop, whose
-                    # zero travel time makes it cost zero merchants -- the most
+                    # o1 == d2 (or o2 == d1) would create a self-loop, whose zero
+                    # travel time makes it cost zero merchants -- the most
                     # attractive move there is, silently deleting real delivery.
-                    # Unreachable while a village is either sender or receiver of
-                    # a resource but never both, but this must not depend on an
-                    # invariant owned by another module to stay correct.
                     if o1 in (o2, d2) or d1 in (d2, o2):
                         continue
-                    t = min(legs.get((o1, d1), 0.0), legs.get((o2, d2), 0.0))
-                    if t <= EPSILON:
+                    t_full = min(legs.get((o1, d1), 0.0), legs.get((o2, d2), 0.0))
+                    if t_full <= EPSILON:
                         continue
-                    candidate = (resource, (o1, d1), (o2, d2))
-
-                    # Cargo of the four pairs the swap touches, after the move.
-                    moved = [((o1, d1), -t), ((o2, d2), -t), ((o1, d2), t), ((o2, d1), t)]
-                    new_cargo: dict[FlowKey, dict[Resource, float]] = {}
-                    for key, delta in moved:
-                        cargo = dict(pair.get(key, {}))
-                        updated = cargo.get(resource, 0.0) + delta
-                        if updated > EPSILON:
-                            cargo[resource] = updated
-                        else:
-                            cargo.pop(resource, None)
-                        new_cargo[key] = cargo
-                    new_merch = {
-                        key: merchants_for(key[0], key[1], cargo)
-                        for key, cargo in new_cargo.items()
-                    }
-
-                    d_o1 = (new_merch[(o1, d1)] - pair_merch.get((o1, d1), 0)) + (
-                        new_merch[(o1, d2)] - pair_merch.get((o1, d2), 0)
+                    ts = (
+                        _breakpoint_ts(resource, o1, d1, o2, d2, t_full)
+                        if refinement
+                        else (t_full,)
                     )
-                    d_o2 = (new_merch[(o2, d2)] - pair_merch.get((o2, d2), 0)) + (
-                        new_merch[(o2, d1)] - pair_merch.get((o2, d1), 0)
-                    )
-                    new_o1, new_o2 = committed.get(o1, 0) + d_o1, committed.get(o2, 0) + d_o2
-
-                    over_delta = (
-                        excess(o1, new_o1)
-                        - excess(o1, committed.get(o1, 0))
-                        + excess(o2, new_o2)
-                        - excess(o2, committed.get(o2, 0))
-                    )
-                    total_delta = sum(new_merch.values()) - sum(
-                        pair_merch.get(key, 0) for key, _ in moved
-                    )
-                    rc_delta = sum(
-                        route_weight(key) for key, _ in moved if new_merch[key] > 0
-                    ) - sum(route_weight(key) for key, _ in moved if pair_merch.get(key, 0) > 0)
-
-                    # The whole objective only shifts by these deltas, so the
-                    # full tuple improves exactly when the delta tuple is < 0.
-                    if (over_delta, total_delta, rc_delta) >= (0, 0, 0):
-                        settled.add(candidate)
-                        continue
-
-                    if resource is Resource.CROP and relay_hubs:
-                        # Swaps are blind to relay: rewiring a hub's legs can
-                        # lengthen the chain or close a loop, either of which the
-                        # beat cannot then schedule. Checked on the prospective
-                        # edge set, never applied-then-undone.
-                        prospective = _crop_edges() | {(o1, d2), (o2, d1)}
-                        for key in ((o1, d1), (o2, d2)):
-                            if legs.get(key, 0.0) - t <= EPSILON:
-                                prospective.discard(key)
-                        if not _crop_shape_ok(prospective):
-                            settled.add(candidate)
+                    improving = None
+                    for t in ts:
+                        changes = _swap_changes(resource, o1, d1, o2, d2, t)
+                        delta, state = _score_changes(changes)
+                        if delta >= (0, 0, 0, 0):
                             continue
+                        if not _swap_shape_ok(resource, legs, o1, d1, o2, d2, t):
+                            continue
+                        if improving is None or delta < improving[0]:
+                            improving = (delta, changes, state)
+                    if improving is None:
+                        if not refinement:
+                            settled.add((resource, (o1, d1), (o2, d2)))
+                        continue
+                    # Deterministic tie-break: the sorted scan order itself.
+                    if best is None or improving[0] < best[0]:
+                        best = improving
+        return best
 
-                    for key, cargo in new_cargo.items():
-                        if cargo:
-                            pair[key] = cargo
-                        else:
-                            pair.pop(key, None)
-                        if new_merch[key] > 0:
-                            pair_merch[key] = new_merch[key]
-                        else:
-                            pair_merch.pop(key, None)
-                    committed[o1], committed[o2] = new_o1, new_o2
-                    legs[(o1, d1)] -= t
-                    legs[(o2, d2)] -= t
-                    legs[(o1, d2)] = legs.get((o1, d2), 0.0) + t
-                    legs[(o2, d1)] = legs.get((o2, d1), 0.0) + t
-                    for key in ((o1, d1), (o2, d2)):
-                        if legs[key] <= EPSILON:
-                            del legs[key]
-
-                    # This swap moved cargo on four pairs and changed the
-                    # commitment of two origins, so any cached verdict involving
-                    # those villages is stale. Everything else is untouched and
-                    # stays settled -- that is what makes the rescan cheap.
-                    touched = {o1, o2, d1, d2}
-                    settled.difference_update(
-                        [
-                            entry
-                            for entry in settled
-                            if touched & {entry[1][0], entry[1][1], entry[2][0], entry[2][1]}
-                        ]
-                    )
-                    applied = True
-                    break
-                if applied:
-                    break
-            if applied:
-                break
-        if not applied:
-            # Swaps are exhausted. Relay is tried only now, so a plan with no
-            # over-budget village -- where relay can never improve anything --
-            # comes out identical to one produced without this move at all.
-            applied = _relay_scan()
-        if not applied:
-            converged = True
-            break
+    converged = False
+    for _pass in range(max_passes):
+        move = _best_swap(refinement=False)
+        if move is not None:
+            _delta, changes, state = move
+            _commit_changes(changes, state)
+            continue
+        # Swaps are exhausted. Relay is tried only now, so a plan with no
+        # over-budget village and no ceiling waste comes out identical to one
+        # produced without the move at all.
+        if _relay_scan():
+            continue
+        # Both exhausted at full transfer sizes: widen to breakpoint transfers.
+        move = _best_swap(refinement=True)
+        if move is not None:
+            _delta, changes, state = move
+            _commit_changes(changes, state)
+            continue
+        converged = True
+        break
     return flows, converged
 
 
@@ -887,7 +914,11 @@ def build_plan(
         assignment[resource] = {key: amount for key, amount in flows.items() if amount > EPSILON}
 
     # Reassign the greedy seed to cut merchants and relieve over-budget villages
-    # wherever a cheaper routing exists; never worse than the seed (§8.3, §14).
+    # wherever a cheaper routing exists. Never worse than the seed on
+    # (excess, merchants) AT THIS STAGE -- the latency pass afterwards spends
+    # idle merchants on speed deliberately, so the end-to-end guarantee is
+    # per-phase: excess never rises anywhere; the merchant total is minimal here
+    # and may rise later, strictly within per-village budgets (§8.3, §14).
     budgets = {vid: villages[vid].spare_merchants(merchant_reserve) for vid in villages}
     assignment, converged = _improve_flows(
         assignment,

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -17,7 +17,7 @@ import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
-from .allocation import Allocation, Resource, ResourcePlan, resolve_resource
+from .allocation import EPSILON, Allocation, Resource, ResourcePlan, resolve_resource
 from .geometry import MapGeometry
 from .merchants import CEIL_DUST_TOLERANCE, DAILY_BEAT_CYCLES, MerchantModel
 from .optimizer import (
@@ -77,14 +77,16 @@ class SheetRow:
 
     @property
     def first_delivery_hours(self) -> float:
-        """Hours from creating the route to its first delivery landing.
+        """WORST-CASE hours from creating the route to its first delivery landing.
 
-        Every other figure on the sheet is steady-state, which quietly assumes
-        the route has been running long enough to have a full batch waiting and
-        merchants already on the road. Neither is true on the day it is created:
-        the cargo has to accumulate over one cycle and then travel. Reading the
-        steady-state numbers as immediate is how a cold start gets mistaken for
-        a broken route.
+        A Gold Club route sends at its scheduled ``dispatch_minute`` ("Send at")
+        time, so the first delivery lands at the next occurrence of that time plus
+        travel. The longest that can be — the route created just after its send
+        time — is one whole cycle plus travel, which is what this returns. It is
+        an upper bound on the manual-coverage window, not a fixed startup: create
+        the route shortly before its send time and the first crop lands in roughly
+        travel time. The steady-state figures elsewhere on the sheet assume a full
+        batch already waiting and merchants on the road, neither true on day one.
         """
         return self.cycle_hours + self.one_way_minutes / 60.0
 
@@ -109,7 +111,22 @@ class DistributionPlan:
 
     @property
     def is_feasible(self) -> bool:
-        return self.routing.is_feasible
+        # Routing feasibility is not enough: an allocation that over-claims the
+        # account drives the remainder village's target negative, which the
+        # optimizer will faithfully route as if the village could ship more than
+        # it produces. That sheet is unsustainable and must not read as feasible.
+        return self.routing.is_feasible and not self.over_allocated
+
+    @property
+    def over_allocated(self) -> tuple[Resource, ...]:
+        """Resources whose explicit allocations exceed production (the remainder
+        village would have to ship more than it makes). Diagnostic-only rows may
+        still be shown, but the plan is not executable."""
+        return tuple(
+            resource
+            for resource, rp in self.resource_plans.items()
+            if rp.remainder_village_id is not None and rp.unallocated < -EPSILON
+        )
 
     @property
     def over_budget(self) -> tuple[OverBudget, ...]:

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -163,7 +163,9 @@ def craft_plan(
             cycle_hours=scheduled.route.cycle_hours,
             dispatch_minute=scheduled.dispatch_minute,
             arrival_minute=scheduled.first_arrival_minute,
-            merchants=scheduled.route.merchants_committed,
+            # Per SEND: the row describes one Gold Club route definition. The
+            # total commitment (x sets in flight) lives in the budget section.
+            merchants=scheduled.route.merchants_per_send,
         )
         for scheduled in beat.routes
     )

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -69,10 +69,24 @@ class SheetRow:
     dispatch_minute: int
     arrival_minute: int
     merchants: int
+    one_way_minutes: float = 0.0
 
     @property
     def total_cargo(self) -> int:
         return sum(self.cargo.values())
+
+    @property
+    def first_delivery_hours(self) -> float:
+        """Hours from creating the route to its first delivery landing.
+
+        Every other figure on the sheet is steady-state, which quietly assumes
+        the route has been running long enough to have a full batch waiting and
+        merchants already on the road. Neither is true on the day it is created:
+        the cargo has to accumulate over one cycle and then travel. Reading the
+        steady-state numbers as immediate is how a cold start gets mistaken for
+        a broken route.
+        """
+        return self.cycle_hours + self.one_way_minutes / 60.0
 
     def dispatch_clock(self) -> str:
         return f"{self.dispatch_minute // 60:02d}:{self.dispatch_minute % 60:02d}"
@@ -182,6 +196,7 @@ def craft_plan(
             # Per SEND: the row describes one Gold Club route definition. The
             # total commitment (x sets in flight) lives in the budget section.
             merchants=scheduled.route.merchants_per_send,
+            one_way_minutes=scheduled.route.one_way_minutes,
         )
         for scheduled in beat.routes
     )

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -1,0 +1,175 @@
+"""Orchestration: fetched account state in, setup sheet out.
+
+This is the only module that knows the order of operations. Everything it calls
+is pure, so a plan is reproducible from its inputs and none of it needs a
+session:
+
+    state + targets -> allocation -> routing -> beat -> integer cargo -> sheet
+
+The account is a moving target -- villages are added, production changes between
+runs -- so nothing is cached across calls and no village list is assumed. Every
+run plans from the snapshot it is given.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+
+from .allocation import Allocation, Resource, ResourcePlan, resolve_resource
+from .geometry import MapGeometry
+from .merchants import DAILY_BEAT_CYCLES, MerchantModel
+from .optimizer import (
+    DEFAULT_MERCHANT_RESERVE,
+    OverBudget,
+    Plan,
+    Shortfall,
+    VillageState,
+    build_plan,
+)
+from .rounding import round_preserving_total
+from .schedule import DEFAULT_MIN_ARRIVAL_GAP_MINUTES, Beat, build_beat
+
+
+@dataclass(frozen=True)
+class PlannerConfig:
+    """Everything tunable, in one place. No account facts belong here."""
+
+    geometry: MapGeometry
+    merchant_model: MerchantModel
+    merchant_reserve: int = DEFAULT_MERCHANT_RESERVE
+    cycles: Sequence[int] = DAILY_BEAT_CYCLES
+    max_latency_hours: float | None = 2.0
+    min_arrival_gap_minutes: int = DEFAULT_MIN_ARRIVAL_GAP_MINUTES
+    reserved_window: tuple[int, int] | None = None
+
+
+@dataclass(frozen=True)
+class SheetRow:
+    """One line of the setup sheet, ready to copy into the game."""
+
+    origin: int
+    destination: int
+    cargo: Mapping[Resource, int]
+    cycle_hours: int
+    dispatch_minute: int
+    arrival_minute: int
+    merchants: int
+
+    @property
+    def total_cargo(self) -> int:
+        return sum(self.cargo.values())
+
+    def dispatch_clock(self) -> str:
+        return f"{self.dispatch_minute // 60:02d}:{self.dispatch_minute % 60:02d}"
+
+    def arrival_clock(self) -> str:
+        return f"{self.arrival_minute // 60:02d}:{self.arrival_minute % 60:02d}"
+
+
+@dataclass(frozen=True)
+class DistributionPlan:
+    """The complete result of a planning run."""
+
+    rows: tuple[SheetRow, ...] = ()
+    merchants_committed: Mapping[int, int] = field(default_factory=dict)
+    spare_merchants: Mapping[int, int] = field(default_factory=dict)
+    resource_plans: Mapping[Resource, ResourcePlan] = field(default_factory=dict)
+    routing: Plan = field(default_factory=Plan)
+    beat: Beat = field(default_factory=Beat)
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def is_feasible(self) -> bool:
+        return self.routing.is_feasible
+
+    @property
+    def over_budget(self) -> tuple[OverBudget, ...]:
+        return self.routing.over_budget
+
+    @property
+    def shortfalls(self) -> tuple[Shortfall, ...]:
+        return self.routing.shortfalls
+
+    @property
+    def total_merchants(self) -> int:
+        return sum(self.merchants_committed.values())
+
+    def free_merchants(self, village_id: int) -> int:
+        return self.spare_merchants.get(village_id, 0) - self.merchants_committed.get(village_id, 0)
+
+
+def craft_plan(
+    villages: Mapping[int, VillageState],
+    productions: Mapping[Resource, Mapping[int, float]],
+    allocations: Mapping[Resource, Mapping[int, Allocation]],
+    config: PlannerConfig,
+) -> DistributionPlan:
+    """Plan resource distribution for whatever account state is supplied.
+
+    Args:
+        villages: fetched per-village state, keyed by village id.
+        productions: per resource, village id -> own net production per hour.
+            Crop may be negative.
+        allocations: per resource, village id -> allocation. Resources absent
+            here are simply not planned; villages absent within a resource keep
+            what they produce.
+        config: tunables.
+
+    Returns:
+        A :class:`DistributionPlan` carrying the setup sheet, the merchant
+        budget per village, and every warning, shortfall and over-budget village
+        raised along the way. Nothing is dropped to make the plan look clean.
+    """
+    resource_plans: dict[Resource, ResourcePlan] = {}
+    warnings: list[str] = []
+
+    for resource in sorted(productions, key=lambda r: r.value):
+        plan = resolve_resource(resource, productions[resource], allocations.get(resource, {}))
+        resource_plans[resource] = plan
+        warnings.extend(plan.warnings)
+
+    routing = build_plan(
+        villages,
+        resource_plans,
+        config.geometry,
+        config.merchant_model,
+        merchant_reserve=config.merchant_reserve,
+        cycles=config.cycles,
+        max_latency_hours=config.max_latency_hours,
+    )
+    warnings.extend(routing.warnings)
+
+    beat = build_beat(
+        routing.routes,
+        min_arrival_gap_minutes=config.min_arrival_gap_minutes,
+        reserved_window=config.reserved_window,
+    )
+    warnings.extend(beat.warnings)
+
+    rows = tuple(
+        SheetRow(
+            origin=scheduled.route.origin,
+            destination=scheduled.route.destination,
+            # Integer cargo, rounded so the send total is preserved.
+            cargo=round_preserving_total(scheduled.route.batch_per_resource),
+            cycle_hours=scheduled.route.cycle_hours,
+            dispatch_minute=scheduled.dispatch_minute,
+            arrival_minute=scheduled.first_arrival_minute,
+            merchants=scheduled.route.merchants_committed,
+        )
+        for scheduled in beat.routes
+    )
+
+    return DistributionPlan(
+        rows=rows,
+        merchants_committed=dict(routing.merchants_committed),
+        spare_merchants={
+            vid: village.spare_merchants(config.merchant_reserve)
+            for vid, village in villages.items()
+        },
+        resource_plans=resource_plans,
+        routing=routing,
+        beat=beat,
+        warnings=tuple(warnings),
+    )

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -23,6 +23,7 @@ from .merchants import DAILY_BEAT_CYCLES, MerchantModel
 from .optimizer import (
     DEFAULT_MERCHANT_RESERVE,
     MAX_IMPROVE_PASSES,
+    MAX_RELAY_HOPS,
     MIN_SEND_FILL,
     OverBudget,
     Plan,
@@ -53,6 +54,8 @@ class PlannerConfig:
     plan, so it belongs here rather than buried as a module constant.
     """
     max_improve_passes: int = MAX_IMPROVE_PASSES
+    max_relay_hops: int = MAX_RELAY_HOPS
+    """Levels of crop relay allowed; 0 ships everything direct."""
 
 
 @dataclass(frozen=True)
@@ -150,6 +153,7 @@ def craft_plan(
         max_latency_hours=config.max_latency_hours,
         min_send_fill=config.min_send_fill,
         max_improve_passes=config.max_improve_passes,
+        max_relay_hops=config.max_relay_hops,
     )
     warnings.extend(routing.warnings)
 

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 
 from .allocation import Allocation, Resource, ResourcePlan, resolve_resource
 from .geometry import MapGeometry
-from .merchants import DAILY_BEAT_CYCLES, MerchantModel
+from .merchants import CEIL_DUST_TOLERANCE, DAILY_BEAT_CYCLES, MerchantModel
 from .optimizer import (
     DEFAULT_MERCHANT_RESERVE,
     MAX_IMPROVE_PASSES,
@@ -195,7 +195,9 @@ def craft_plan(
             # falls below .5.
             cargo=round_preserving_total(
                 scheduled.route.batch_per_resource,
-                target_total=math.ceil(sum(scheduled.route.batch_per_resource.values())),
+                target_total=math.ceil(
+                    sum(scheduled.route.batch_per_resource.values()) - CEIL_DUST_TOLERANCE
+                ),
             ),
             cycle_hours=scheduled.route.cycle_hours,
             dispatch_minute=scheduled.dispatch_minute,

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -151,9 +151,15 @@ def craft_plan(
     """
     resource_plans: dict[Resource, ResourcePlan] = {}
     warnings: list[str] = []
+    # Warnings are read by a person, so they name villages the way that person
+    # does. Derived here rather than passed in: the caller already gave us the
+    # villages, and a second source of names could disagree with the first.
+    names = {vid: village.name for vid, village in villages.items() if village.name}
 
     for resource in sorted(productions, key=lambda r: r.value):
-        plan = resolve_resource(resource, productions[resource], allocations.get(resource, {}))
+        plan = resolve_resource(
+            resource, productions[resource], allocations.get(resource, {}), names
+        )
         resource_plans[resource] = plan
         warnings.extend(plan.warnings)
 
@@ -175,6 +181,7 @@ def craft_plan(
         routing.routes,
         min_arrival_gap_minutes=config.min_arrival_gap_minutes,
         reserved_window=config.reserved_window,
+        names=names,
     )
     warnings.extend(beat.warnings)
 

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -22,6 +22,8 @@ from .geometry import MapGeometry
 from .merchants import DAILY_BEAT_CYCLES, MerchantModel
 from .optimizer import (
     DEFAULT_MERCHANT_RESERVE,
+    MAX_IMPROVE_PASSES,
+    MIN_SEND_FILL,
     OverBudget,
     Plan,
     Shortfall,
@@ -43,6 +45,14 @@ class PlannerConfig:
     max_latency_hours: float | None = 2.0
     min_arrival_gap_minutes: int = DEFAULT_MIN_ARRIVAL_GAP_MINUTES
     reserved_window: tuple[int, int] | None = None
+    min_send_fill: float = MIN_SEND_FILL
+    """How full a merchant must stay when idle merchants are spent on speed.
+
+    The latency/fill trade-off dial: lower it and routes get faster on emptier
+    merchants, raise it and they stay full but slower. It materially moves the
+    plan, so it belongs here rather than buried as a module constant.
+    """
+    max_improve_passes: int = MAX_IMPROVE_PASSES
 
 
 @dataclass(frozen=True)
@@ -138,6 +148,8 @@ def craft_plan(
         merchant_reserve=config.merchant_reserve,
         cycles=config.cycles,
         max_latency_hours=config.max_latency_hours,
+        min_send_fill=config.min_send_fill,
+        max_improve_passes=config.max_improve_passes,
     )
     warnings.extend(routing.warnings)
 

--- a/src/travian_api/services/distribution/planner.py
+++ b/src/travian_api/services/distribution/planner.py
@@ -13,6 +13,7 @@ run plans from the snapshot it is given.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
@@ -151,8 +152,14 @@ def craft_plan(
         SheetRow(
             origin=scheduled.route.origin,
             destination=scheduled.route.destination,
-            # Integer cargo, rounded so the send total is preserved.
-            cargo=round_preserving_total(scheduled.route.batch_per_resource),
+            # Integer cargo, summing to the same ceil(batch) the merchant
+            # budget in route_cost was sized for — round(sum) would ship one
+            # resource less than budgeted on every cycle when the fraction
+            # falls below .5.
+            cargo=round_preserving_total(
+                scheduled.route.batch_per_resource,
+                target_total=math.ceil(sum(scheduled.route.batch_per_resource.values())),
+            ),
             cycle_hours=scheduled.route.cycle_hours,
             dispatch_minute=scheduled.dispatch_minute,
             arrival_minute=scheduled.first_arrival_minute,

--- a/src/travian_api/services/distribution/rounding.py
+++ b/src/travian_api/services/distribution/rounding.py
@@ -1,0 +1,56 @@
+"""Sum-preserving integer rounding for cargo amounts.
+
+A send carries whole resources, but the rates that produce it are fractional.
+Rounding each resource independently changes the total, which either invents
+resources or loses them -- profile section 12 requires that rounding "must not
+create or destroy resources".
+
+Largest-remainder (Hare-Niemeyer): floor everything, then hand the leftover
+units to the largest fractional parts. The result sums to exactly
+``round(sum(values))`` and each entry is within one of its exact value.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Hashable, Mapping
+from typing import TypeVar
+
+K = TypeVar("K", bound=Hashable)
+
+
+def round_preserving_total(values: Mapping[K, float]) -> dict[K, int]:
+    """Round *values* to integers whose sum is ``round(sum(values))``.
+
+    Ties in the fractional part are broken by the key's sorted order, so the
+    result is deterministic -- a re-plan on unchanged input must produce an
+    identical setup sheet or the diff against the live routes is noise.
+
+    Raises:
+        ValueError: if any value is negative. Cargo is never negative, and the
+            largest-remainder argument does not carry over to mixed signs.
+    """
+    if any(value < 0 for value in values.values()):
+        raise ValueError(f"cargo amounts cannot be negative: {dict(values)}")
+    if not values:
+        return {}
+
+    floors = {key: math.floor(value) for key, value in values.items()}
+    shortfall = round(sum(values.values())) - sum(floors.values())
+
+    if shortfall <= 0:
+        return floors
+
+    # Hand out the leftover units to the largest fractional parts first.
+    ranked = sorted(
+        values,
+        key=lambda key: (-(values[key] - floors[key]), _sort_key(key)),
+    )
+    for key in ranked[:shortfall]:
+        floors[key] += 1
+    return floors
+
+
+def _sort_key(key: Hashable) -> str:
+    """Stable ordering for tie-breaks across heterogeneous key types."""
+    return str(key)

--- a/src/travian_api/services/distribution/rounding.py
+++ b/src/travian_api/services/distribution/rounding.py
@@ -19,8 +19,15 @@ from typing import TypeVar
 K = TypeVar("K", bound=Hashable)
 
 
-def round_preserving_total(values: Mapping[K, float]) -> dict[K, int]:
-    """Round *values* to integers whose sum is ``round(sum(values))``.
+def round_preserving_total(
+    values: Mapping[K, float], *, target_total: int | None = None
+) -> dict[K, int]:
+    """Round *values* to integers whose sum is *target_total*.
+
+    The default target is ``round(sum(values))``. The planner passes
+    ``ceil(batch)`` instead: merchants are budgeted for the ceiling in
+    ``route_cost``, so rounding the sheet down would under-deliver on every
+    cycle while the reserved merchants ride part-empty.
 
     Ties in the fractional part are broken by the key's sorted order, so the
     result is deterministic -- a re-plan on unchanged input must produce an
@@ -35,8 +42,9 @@ def round_preserving_total(values: Mapping[K, float]) -> dict[K, int]:
     if not values:
         return {}
 
+    total = round(sum(values.values())) if target_total is None else target_total
     floors = {key: math.floor(value) for key, value in values.items()}
-    shortfall = round(sum(values.values())) - sum(floors.values())
+    shortfall = total - sum(floors.values())
 
     if shortfall <= 0:
         return floors

--- a/src/travian_api/services/distribution/schedule.py
+++ b/src/travian_api/services/distribution/schedule.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from .allocation import Resource
 from .optimizer import Route
 
 MINUTES_PER_DAY = 24 * 60
@@ -84,6 +85,25 @@ def _circular_gap(a: int, b: int) -> int:
     return min(raw, MINUTES_PER_DAY - raw)
 
 
+def _staleness(dispatches: Sequence[int], inbound_arrivals: Sequence[int]) -> int:
+    """How long the worst dispatch waits after the freshest inbound cargo.
+
+    Both schedules repeat daily, so "after" is measured modulo the day. For each
+    firing, the wait is the time since the most recent inbound arrival; the
+    figure returned is the worst of those, which is what the scheduler minimises
+    so a relay hub forwards cargo it has just collected rather than cargo it will
+    only receive later in the cycle.
+
+    Zero when there is no inbound to wait for, so ordinary routes are unaffected.
+    """
+    if not inbound_arrivals:
+        return 0
+    return max(
+        min((dispatch - arrival) % MINUTES_PER_DAY for arrival in inbound_arrivals)
+        for dispatch in dispatches
+    )
+
+
 def _worst_gap(candidate_arrivals: Sequence[int], taken: Sequence[int]) -> int:
     """Tightest spacing this candidate would create against already-placed ones."""
     if not taken:
@@ -127,23 +147,42 @@ def build_beat(
     warnings: list[str] = []
     # Arrivals already claimed, per destination.
     claimed: dict[int, list[int]] = {}
+    # Crop arrivals only, per village: what a relay hub is waiting to forward.
+    crop_arrivals: dict[int, list[int]] = {}
+
+    # A village that both receives and sends crop is forwarding it -- the crop
+    # relay the optimizer builds to lift load off villages that cannot staff
+    # their own haul. Its outbound must be scheduled after its inbound lands, or
+    # the route ships from the hub's own granary and the relay only refills it.
+    crop_senders = {r.origin for r in routes if Resource.CROP in r.cargo_per_hour}
+    crop_receivers = {r.destination for r in routes if Resource.CROP in r.cargo_per_hour}
+    relay_hubs = crop_senders & crop_receivers
 
     # Deterministic order: the busiest destinations are placed first, while they
-    # still have the whole day to spread across.
+    # still have the whole day to spread across. A hub's outbound goes last, so
+    # the inbound it must follow is already on the clock when it is placed.
     inbound_count: dict[int, int] = {}
     for route in routes:
         inbound_count[route.destination] = inbound_count.get(route.destination, 0) + 1
     ordered = sorted(
         routes,
-        key=lambda r: (-inbound_count[r.destination], r.destination, r.origin, r.cycle_hours),
+        key=lambda r: (
+            r.origin in relay_hubs and Resource.CROP in r.cargo_per_hour,
+            -inbound_count[r.destination],
+            r.destination,
+            r.origin,
+            r.cycle_hours,
+        ),
     )
 
     for route in ordered:
         window = route.cycle_hours * 60
         taken = claimed.setdefault(route.destination, [])
+        forwards_crop = route.origin in relay_hubs and Resource.CROP in route.cargo_per_hour
+        inbound = crop_arrivals.get(route.origin, []) if forwards_crop else []
 
         best_offset = 0
-        best_score: tuple[int, int] | None = None
+        best_score: tuple[int, int, int] | None = None
         for offset in range(0, window, step_minutes):
             candidate = ScheduledRoute(route=route, dispatch_minute=offset)
             arrivals = candidate.arrival_minutes
@@ -153,17 +192,23 @@ def build_beat(
                 if reserved_window is None
                 else sum(1 for minute in arrivals if _in_window(minute, reserved_window))
             )
-            # Prefer avoiding the reserved window, then the widest spacing.
-            # Every offset is evaluated: stopping at the first one that merely
-            # clears the minimum gap would crowd arrivals that had a whole day
-            # of room. The full sweep is pure CPU and runs off the event loop.
-            score = (-clear, gap)
+            # Collect-then-ship: how long the stalest dispatch waits after the
+            # freshest crop landed here. Zero for everything that is not a relay
+            # hub, which leaves non-relay scheduling byte-identical.
+            stale = _staleness(candidate.dispatch_minutes, inbound)
+            # Prefer avoiding the reserved window, then shipping soon after
+            # collecting, then the widest spacing. Every offset is evaluated:
+            # stopping at the first that merely clears the minimum gap would
+            # crowd arrivals that had a whole day of room.
+            score = (-clear, -stale, gap)
             if best_score is None or score > best_score:
                 best_score, best_offset = score, offset
 
         placement = ScheduledRoute(route=route, dispatch_minute=best_offset)
         scheduled.append(placement)
         taken.extend(placement.arrival_minutes)
+        if Resource.CROP in route.cargo_per_hour:
+            crop_arrivals.setdefault(route.destination, []).extend(placement.arrival_minutes)
 
         # A cycle shorter than the gap target violates the constraint all by
         # itself — no dispatch offset can space a route's own repeats.
@@ -176,7 +221,8 @@ def build_beat(
                 f"choosing a dispatch offset"
             )
 
-        achieved = best_score[1] if best_score else MINUTES_PER_DAY
+        # score is (-clear, -stale, gap); the achieved spacing is the last term.
+        achieved = best_score[2] if best_score else MINUTES_PER_DAY
         if achieved < min_arrival_gap_minutes:
             warnings.append(
                 f"route {route.origin} -> {route.destination} lands within "

--- a/src/travian_api/services/distribution/schedule.py
+++ b/src/travian_api/services/distribution/schedule.py
@@ -159,21 +159,55 @@ def build_beat(
     relay_hubs = crop_senders & crop_receivers
 
     # Deterministic order: the busiest destinations are placed first, while they
-    # still have the whole day to spread across. A hub's outbound goes last, so
-    # the inbound it must follow is already on the clock when it is placed.
+    # still have the whole day to spread across.
     inbound_count: dict[int, int] = {}
     for route in routes:
         inbound_count[route.destination] = inbound_count.get(route.destination, 0) + 1
-    ordered = sorted(
-        routes,
-        key=lambda r: (
-            r.origin in relay_hubs and Resource.CROP in r.cargo_per_hour,
-            -inbound_count[r.destination],
-            r.destination,
-            r.origin,
-            r.cycle_hours,
-        ),
+
+    def placement_key(route: Route) -> tuple[int, int, int, int]:
+        return (
+            -inbound_count[route.destination],
+            route.destination,
+            route.origin,
+            route.cycle_hours,
+        )
+
+    # A crop route out of a hub must be placed after the routes feeding that hub,
+    # or its inbound arrivals are not on the clock yet and collect-then-ship
+    # quietly does nothing. Merely sorting hub-outbound last is not enough: in a
+    # chain A -> B -> C -> D every leg is hub-outbound, and the tie-break decides
+    # their relative order by destination id, which has nothing to do with the
+    # direction cargo flows. So this is a real topological pass over the crop
+    # graph, with the ordinary key breaking ties inside each layer.
+    crop_routes = [r for r in routes if Resource.CROP in r.cargo_per_hour]
+    pending = {id(r): r for r in crop_routes}
+    feeders: dict[int, list[Route]] = {}
+    for route in crop_routes:
+        feeders.setdefault(route.destination, []).append(route)
+
+    layered: list[Route] = []
+    placed_ids: set[int] = set()
+    while pending:
+        ready = [
+            route
+            for route in pending.values()
+            if all(id(feed) in placed_ids for feed in feeders.get(route.origin, ()))
+        ]
+        if not ready:
+            # A cycle in the crop graph (a two-way pair, or a longer loop). No
+            # ordering can satisfy every leg, so fall back to the ordinary key
+            # for the remainder and let the staleness warning report the cost
+            # rather than looping here forever.
+            ready = sorted(pending.values(), key=placement_key)[:1]
+        for route in sorted(ready, key=placement_key):
+            layered.append(route)
+            placed_ids.add(id(route))
+            pending.pop(id(route), None)
+
+    non_crop = sorted(
+        (r for r in routes if Resource.CROP not in r.cargo_per_hour), key=placement_key
     )
+    ordered = non_crop + layered
 
     for route in ordered:
         window = route.cycle_hours * 60
@@ -182,7 +216,7 @@ def build_beat(
         inbound = crop_arrivals.get(route.origin, []) if forwards_crop else []
 
         best_offset = 0
-        best_score: tuple[int, int, int] | None = None
+        best_score: tuple[int, int, int, int] | None = None
         for offset in range(0, window, step_minutes):
             candidate = ScheduledRoute(route=route, dispatch_minute=offset)
             arrivals = candidate.arrival_minutes
@@ -196,11 +230,19 @@ def build_beat(
             # freshest crop landed here. Zero for everything that is not a relay
             # hub, which leaves non-relay scheduling byte-identical.
             stale = _staleness(candidate.dispatch_minutes, inbound)
-            # Prefer avoiding the reserved window, then shipping soon after
-            # collecting, then the widest spacing. Every offset is evaluated:
-            # stopping at the first that merely clears the minimum gap would
-            # crowd arrivals that had a whole day of room.
-            score = (-clear, -stale, gap)
+            # Order of preference: clear the reserved window, then MEET the
+            # arrival-gap target, then ship soon after collecting, then widen
+            # the spacing further.
+            #
+            # The gap term saturates at the target deliberately. Ranking raw
+            # staleness above raw gap made the target unenforceable for relay
+            # hubs: staleness takes a different value at nearly every candidate
+            # minute, so it decided every comparison and the gap was never
+            # consulted -- measured as arrivals colliding at 0 minutes apart
+            # where the previous scheduler kept them 15 apart. Saturating means
+            # a few minutes of extra staleness can never buy a collision, while
+            # beyond the target staleness is still free to choose.
+            score = (-clear, min(gap, min_arrival_gap_minutes), -stale, gap)
             if best_score is None or score > best_score:
                 best_score, best_offset = score, offset
 
@@ -221,8 +263,8 @@ def build_beat(
                 f"choosing a dispatch offset"
             )
 
-        # score is (-clear, -stale, gap); the achieved spacing is the last term.
-        achieved = best_score[2] if best_score else MINUTES_PER_DAY
+        # score is (-clear, saturated_gap, -stale, gap); spacing is the last term.
+        achieved = best_score[3] if best_score else MINUTES_PER_DAY
         if achieved < min_arrival_gap_minutes:
             warnings.append(
                 f"route {route.origin} -> {route.destination} lands within "

--- a/src/travian_api/services/distribution/schedule.py
+++ b/src/travian_api/services/distribution/schedule.py
@@ -154,11 +154,12 @@ def build_beat(
                 else sum(1 for minute in arrivals if _in_window(minute, reserved_window))
             )
             # Prefer avoiding the reserved window, then the widest spacing.
+            # Every offset is evaluated: stopping at the first one that merely
+            # clears the minimum gap would crowd arrivals that had a whole day
+            # of room. The full sweep is pure CPU and runs off the event loop.
             score = (-clear, gap)
             if best_score is None or score > best_score:
                 best_score, best_offset = score, offset
-            if clear == 0 and gap >= min_arrival_gap_minutes:
-                break
 
         placement = ScheduledRoute(route=route, dispatch_minute=best_offset)
         scheduled.append(placement)

--- a/src/travian_api/services/distribution/schedule.py
+++ b/src/travian_api/services/distribution/schedule.py
@@ -1,0 +1,193 @@
+"""Assign each route a slot in a repeating 24-hour beat.
+
+Every cycle length divides 24 hours (see :data:`~.merchants.DAILY_BEAT_CYCLES`),
+so the whole schedule repeats daily and can be written down as one table. That
+restriction is what makes this module possible: with an arbitrary cycle set the
+pattern's period is the lowest common multiple of every cycle, which is not a
+schedule anyone can read.
+
+A route with a 3-hour cycle fires eight times a day. Scheduling therefore works
+on a 1440-minute timeline and places *every* firing, rather than a minute-of-hour
+offset -- a 60-minute table cannot express a multi-hour cycle at all (review R5).
+
+Two things this deliberately does not do:
+
+* **Collect-then-ship ordering at hubs** is moot in the current model. Netting in
+  :mod:`.allocation` leaves each village either a sender or a receiver of a given
+  resource, never both, so no village relays a resource and there is no inbound
+  that an outbound must wait for.
+* **Crop relay through a sub-hub**, which profile section 3.5 permits, cannot be
+  expressed for the same reason. Supporting it needs multi-leg flows in the
+  optimizer, not scheduling changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .optimizer import Route
+
+MINUTES_PER_DAY = 24 * 60
+DEFAULT_MIN_ARRIVAL_GAP_MINUTES = 3
+
+
+@dataclass(frozen=True)
+class ScheduledRoute:
+    """A route plus the minute of the day its first send leaves."""
+
+    route: Route
+    dispatch_minute: int
+    """Minutes past midnight for the first send. Repeats every cycle."""
+
+    @property
+    def dispatch_minutes(self) -> tuple[int, ...]:
+        """Every firing across the day."""
+        step = self.route.cycle_hours * 60
+        return tuple(
+            (self.dispatch_minute + offset) % MINUTES_PER_DAY
+            for offset in range(0, MINUTES_PER_DAY, step)
+        )
+
+    @property
+    def arrival_minutes(self) -> tuple[int, ...]:
+        """When each send lands."""
+        travel = round(self.route.one_way_minutes)
+        return tuple((minute + travel) % MINUTES_PER_DAY for minute in self.dispatch_minutes)
+
+    @property
+    def first_arrival_minute(self) -> int:
+        return self.arrival_minutes[0]
+
+
+@dataclass(frozen=True)
+class Beat:
+    """The daily schedule, plus anything that could not be honoured."""
+
+    routes: tuple[ScheduledRoute, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    def arrivals_at(self, village_id: int) -> tuple[tuple[int, ScheduledRoute], ...]:
+        """Every arrival at *village_id* through the day, in time order."""
+        arrivals = [
+            (minute, scheduled)
+            for scheduled in self.routes
+            if scheduled.route.destination == village_id
+            for minute in scheduled.arrival_minutes
+        ]
+        return tuple(sorted(arrivals, key=lambda pair: (pair[0], pair[1].route.origin)))
+
+
+def _circular_gap(a: int, b: int) -> int:
+    """Shortest distance between two minutes of the day, either way round."""
+    raw = abs(a - b)
+    return min(raw, MINUTES_PER_DAY - raw)
+
+
+def _worst_gap(candidate_arrivals: Sequence[int], taken: Sequence[int]) -> int:
+    """Tightest spacing this candidate would create against already-placed ones."""
+    if not taken:
+        return MINUTES_PER_DAY
+    return min(_circular_gap(arrival, other) for arrival in candidate_arrivals for other in taken)
+
+
+def build_beat(
+    routes: Sequence[Route],
+    *,
+    min_arrival_gap_minutes: int = DEFAULT_MIN_ARRIVAL_GAP_MINUTES,
+    reserved_window: tuple[int, int] | None = None,
+    step_minutes: int = 1,
+) -> Beat:
+    """Place every route on the daily beat, spacing arrivals at each destination.
+
+    Arrivals are staggered so a receiving village's stock climbs in steps rather
+    than in one lump, which is what keeps a hub from overflowing between its own
+    outbound sends.
+
+    Args:
+        routes: routes to schedule. Order does not affect the result.
+        min_arrival_gap_minutes: desired spacing between arrivals at the same
+            village. Honoured where possible; a shortfall warns rather than
+            fails, because a village with many inbound routes may not have room.
+        reserved_window: ``(start_minute, end_minute)`` to keep clear for the
+            manual NPC burst. Arrivals avoid it when an alternative exists.
+        step_minutes: granularity of candidate dispatch minutes. 1 tries every
+            minute; coarser values trade precision for speed on large accounts.
+
+    Returns:
+        A :class:`Beat`. Every route is always scheduled -- a route that cannot
+        be spaced politely still gets a slot, with a warning naming it.
+    """
+    if min_arrival_gap_minutes < 0:
+        raise ValueError("min_arrival_gap_minutes cannot be negative")
+    if step_minutes < 1:
+        raise ValueError("step_minutes must be at least 1")
+
+    scheduled: list[ScheduledRoute] = []
+    warnings: list[str] = []
+    # Arrivals already claimed, per destination.
+    claimed: dict[int, list[int]] = {}
+
+    # Deterministic order: the busiest destinations are placed first, while they
+    # still have the whole day to spread across.
+    inbound_count: dict[int, int] = {}
+    for route in routes:
+        inbound_count[route.destination] = inbound_count.get(route.destination, 0) + 1
+    ordered = sorted(
+        routes,
+        key=lambda r: (-inbound_count[r.destination], r.destination, r.origin, r.cycle_hours),
+    )
+
+    for route in ordered:
+        window = route.cycle_hours * 60
+        taken = claimed.setdefault(route.destination, [])
+
+        best_offset = 0
+        best_score: tuple[int, int] | None = None
+        for offset in range(0, window, step_minutes):
+            candidate = ScheduledRoute(route=route, dispatch_minute=offset)
+            arrivals = candidate.arrival_minutes
+            gap = _worst_gap(arrivals, taken)
+            clear = (
+                0
+                if reserved_window is None
+                else sum(1 for minute in arrivals if _in_window(minute, reserved_window))
+            )
+            # Prefer avoiding the reserved window, then the widest spacing.
+            score = (-clear, gap)
+            if best_score is None or score > best_score:
+                best_score, best_offset = score, offset
+            if clear == 0 and gap >= min_arrival_gap_minutes:
+                break
+
+        placement = ScheduledRoute(route=route, dispatch_minute=best_offset)
+        scheduled.append(placement)
+        taken.extend(placement.arrival_minutes)
+
+        achieved = best_score[1] if best_score else MINUTES_PER_DAY
+        if achieved < min_arrival_gap_minutes:
+            warnings.append(
+                f"route {route.origin} -> {route.destination} lands within "
+                f"{achieved} min of another arrival there, against a "
+                f"{min_arrival_gap_minutes} min target; village {route.destination} "
+                f"has {inbound_count[route.destination]} inbound routes and may be "
+                f"too busy to space them"
+            )
+        if reserved_window is not None and best_score and best_score[0] < 0:
+            warnings.append(
+                f"route {route.origin} -> {route.destination} unavoidably lands in "
+                f"the reserved window {reserved_window}"
+            )
+
+    return Beat(
+        routes=tuple(sorted(scheduled, key=lambda s: (s.dispatch_minute, s.route.origin))),
+        warnings=tuple(warnings),
+    )
+
+
+def _in_window(minute: int, window: tuple[int, int]) -> bool:
+    """Is *minute* inside a possibly midnight-wrapping window?"""
+    start, end = window
+    if start <= end:
+        return start <= minute < end
+    return minute >= start or minute < end

--- a/src/travian_api/services/distribution/schedule.py
+++ b/src/travian_api/services/distribution/schedule.py
@@ -165,6 +165,17 @@ def build_beat(
         scheduled.append(placement)
         taken.extend(placement.arrival_minutes)
 
+        # A cycle shorter than the gap target violates the constraint all by
+        # itself — no dispatch offset can space a route's own repeats.
+        cycle_minutes = route.cycle_hours * 60
+        if cycle_minutes < min_arrival_gap_minutes:
+            warnings.append(
+                f"route {route.origin} -> {route.destination} fires every "
+                f"{cycle_minutes} min, closer than the {min_arrival_gap_minutes} "
+                f"min arrival-gap target; its own arrivals cannot be spaced by "
+                f"choosing a dispatch offset"
+            )
+
         achieved = best_score[1] if best_score else MINUTES_PER_DAY
         if achieved < min_arrival_gap_minutes:
             warnings.append(

--- a/src/travian_api/services/distribution/schedule.py
+++ b/src/travian_api/services/distribution/schedule.py
@@ -23,10 +23,10 @@ Two things this deliberately does not do:
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
-from .allocation import Resource
+from .allocation import Resource, village_label
 from .optimizer import Route
 
 MINUTES_PER_DAY = 24 * 60
@@ -117,6 +117,7 @@ def build_beat(
     min_arrival_gap_minutes: int = DEFAULT_MIN_ARRIVAL_GAP_MINUTES,
     reserved_window: tuple[int, int] | None = None,
     step_minutes: int = 1,
+    names: Mapping[int, str] | None = None,
 ) -> Beat:
     """Place every route on the daily beat, spacing arrivals at each destination.
 
@@ -257,7 +258,8 @@ def build_beat(
         cycle_minutes = route.cycle_hours * 60
         if cycle_minutes < min_arrival_gap_minutes:
             warnings.append(
-                f"route {route.origin} -> {route.destination} fires every "
+                f"route {village_label(route.origin, names)} -> "
+                f"{village_label(route.destination, names)} fires every "
                 f"{cycle_minutes} min, closer than the {min_arrival_gap_minutes} "
                 f"min arrival-gap target; its own arrivals cannot be spaced by "
                 f"choosing a dispatch offset"
@@ -267,15 +269,17 @@ def build_beat(
         achieved = best_score[3] if best_score else MINUTES_PER_DAY
         if achieved < min_arrival_gap_minutes:
             warnings.append(
-                f"route {route.origin} -> {route.destination} lands within "
+                f"route {village_label(route.origin, names)} -> "
+                f"{village_label(route.destination, names)} lands within "
                 f"{achieved} min of another arrival there, against a "
-                f"{min_arrival_gap_minutes} min target; village {route.destination} "
+                f"{min_arrival_gap_minutes} min target; {village_label(route.destination, names)} "
                 f"has {inbound_count[route.destination]} inbound routes and may be "
                 f"too busy to space them"
             )
         if reserved_window is not None and best_score and best_score[0] < 0:
             warnings.append(
-                f"route {route.origin} -> {route.destination} unavoidably lands in "
+                f"route {village_label(route.origin, names)} -> "
+                f"{village_label(route.destination, names)} unavoidably lands in "
                 f"the reserved window {reserved_window}"
             )
 

--- a/src/travian_api/services/distribution/storage.py
+++ b/src/travian_api/services/distribution/storage.py
@@ -29,7 +29,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 
-from .allocation import Resource
+from .allocation import Resource, village_label
 from .schedule import MINUTES_PER_DAY, Beat
 
 # Rates below this are treated as level rather than drifting. Dividing by a rate
@@ -267,6 +267,7 @@ def storage_warnings(
     statuses: Sequence[StoreStatus],
     overflows: Sequence[OverflowEvent],
     warn_hours: float = DEFAULT_WARN_HOURS,
+    names: Mapping[int, str] | None = None,
 ) -> tuple[str, ...]:
     """Operator-facing lines. Starvation first: it destroys troops, not surplus."""
     warnings: list[str] = []
@@ -276,7 +277,7 @@ def storage_warnings(
     ):
         if (status.hours_remaining or 0.0) < warn_hours:
             warnings.append(
-                f"village {status.village_id}: {status.resource.value} runs out in "
+                f"{village_label(status.village_id, names)}: {status.resource.value} runs out in "
                 f"{status.hours_remaining:.1f}h at {status.net_per_hour:+.0f}/h "
                 f"({status.stock:,} in store)"
             )
@@ -286,13 +287,14 @@ def storage_warnings(
     ):
         if (status.hours_remaining or 0.0) < warn_hours:
             warnings.append(
-                f"village {status.village_id}: {status.resource.value} fills its store in "
+                f"{village_label(status.village_id, names)}: {status.resource.value} "
+                f"fills its store in "
                 f"{status.hours_remaining:.1f}h at {status.net_per_hour:+.0f}/h; "
                 f"anything past the cap is lost"
             )
     for event in overflows:
         warnings.append(
-            f"village {event.village_id}: {event.resource.value} hits the cap at "
+            f"{village_label(event.village_id, names)}: {event.resource.value} hits the cap at "
             f"{event.minute // 60:02d}:{event.minute % 60:02d} and loses about "
             f"{event.wasted_per_day:,.0f}/day — an arriving batch overflows even "
             f"though the average rate fits"

--- a/src/travian_api/services/distribution/storage.py
+++ b/src/travian_api/services/distribution/storage.py
@@ -1,0 +1,236 @@
+"""Will a village overflow its warehouse, or starve its granary?
+
+A route set that balances perfectly on paper can still be wrong in the game.
+Two failure modes, and the profile records both because both have bitten:
+
+* **Overflow** (section 10). Resources arriving faster than they are spent stop
+  at the cap and the excess is simply lost.
+* **Starvation** (review R7). The same arithmetic run on a village with negative
+  net crop returns a *negative* fill time, which reads as "no problem" while the
+  granary is emptying and troops are about to die. R7's point is that
+  ``fill_time = (capacity - stock) / net`` only models one direction, and the
+  direction it ignores is the one that kills armies.
+
+So this module never returns a single "time to trouble" number: it returns which
+way the village is heading and how long it has, and treats a zero-ish rate as
+"no trouble either way" rather than dividing by it.
+
+The second half is known issue #12: a continuous-rate check passes while a lumpy
+arrival overflows. Rates are averages, but cargo lands in discrete batches, so
+:func:`simulate_day` replays the actual beat against the actual capacity instead
+of trusting the average.
+
+Pure functions over already-fetched state. Nothing here spends a game request.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .allocation import Resource
+from .schedule import MINUTES_PER_DAY, Beat
+
+# Rates below this are treated as level rather than drifting. Dividing by a rate
+# of 0.01/h yields a "time to full" of centuries, which is noise dressed as a
+# number.
+NEGLIGIBLE_RATE = 1.0
+
+# Hours of headroom below which the operator wants telling. Section 10 asks for
+# 18h on the filling side; the same threshold is applied to starvation, because
+# a granary emptying inside 18h is at least as urgent.
+DEFAULT_WARN_HOURS = 18.0
+
+
+class Trend(StrEnum):
+    FILLING = "filling"
+    DRAINING = "draining"
+    STEADY = "steady"
+
+
+@dataclass(frozen=True)
+class StoreStatus:
+    """Where one store on one village is heading, and how fast."""
+
+    village_id: int
+    resource: Resource
+    stock: int
+    capacity: int | None
+    net_per_hour: float
+    trend: Trend
+    hours_remaining: float | None
+    """Hours until full (filling) or empty (draining). None when unknowable:
+    a steady rate, or a filling store whose capacity was never read."""
+
+    @property
+    def is_urgent(self) -> bool:
+        return self.hours_remaining is not None and self.hours_remaining < DEFAULT_WARN_HOURS
+
+
+def store_status(
+    village_id: int,
+    resource: Resource,
+    stock: int,
+    capacity: int | None,
+    net_per_hour: float,
+    negligible_rate: float = NEGLIGIBLE_RATE,
+) -> StoreStatus:
+    """Classify one store. Both directions, never a negative "time to full"."""
+    if abs(net_per_hour) < negligible_rate:
+        return StoreStatus(village_id, resource, stock, capacity, net_per_hour, Trend.STEADY, None)
+    if net_per_hour < 0:
+        # Emptying: what matters is the stock on hand, and capacity is
+        # irrelevant -- which is why this branch needs no capacity reading and
+        # always produces an answer.
+        return StoreStatus(
+            village_id,
+            resource,
+            stock,
+            capacity,
+            net_per_hour,
+            Trend.DRAINING,
+            stock / -net_per_hour,
+        )
+    if capacity is None:
+        return StoreStatus(village_id, resource, stock, capacity, net_per_hour, Trend.FILLING, None)
+    return StoreStatus(
+        village_id,
+        resource,
+        stock,
+        capacity,
+        net_per_hour,
+        Trend.FILLING,
+        max(0.0, (capacity - stock) / net_per_hour),
+    )
+
+
+@dataclass(frozen=True)
+class OverflowEvent:
+    """A store that hits its cap during the simulated day."""
+
+    village_id: int
+    resource: Resource
+    minute: int
+    """Minute of the day the cap was first reached."""
+    wasted_per_day: float
+    """Resources lost to the cap over one day at this rate and beat."""
+
+
+def simulate_day(
+    beat: Beat,
+    stocks: Mapping[int, Mapping[Resource, int]],
+    capacities: Mapping[int, Mapping[Resource, int]],
+    net_per_hour: Mapping[int, Mapping[Resource, float]],
+    step_minutes: int = 5,
+) -> tuple[OverflowEvent, ...]:
+    """Replay one day of the beat against real capacities. Known issue #12.
+
+    The continuous check asks whether the *average* inflow overruns the cap. This
+    asks whether the store is ever actually full, which is a different question:
+    a village can sit comfortably under its cap on average and still lose a whole
+    batch because a 24h route dumps it all at once.
+
+    Production accrues continuously between steps; each scheduled arrival lands
+    as a lump at its minute. Anything above the cap is lost, exactly as the game
+    does it, and the loss is accumulated so the report can say what it costs per
+    day rather than merely that it happened.
+    """
+    # Cargo leaves the origin when the merchants depart and lands at the
+    # destination when they arrive. Both halves are needed: modelling only the
+    # arrivals would let every sender's store grow without bound and report an
+    # overflow that the outbound route is in fact preventing.
+    moves: dict[int, list[tuple[int, Resource, float]]] = {}
+    for scheduled in beat.routes:
+        batch = scheduled.route.batch_per_resource
+        for resource, amount in batch.items():
+            for minute in scheduled.dispatch_minutes:
+                moves.setdefault(minute, []).append((scheduled.route.origin, resource, -amount))
+            for minute in scheduled.arrival_minutes:
+                moves.setdefault(minute, []).append((scheduled.route.destination, resource, amount))
+
+    level: dict[tuple[int, Resource], float] = {}
+    for vid, per_resource in stocks.items():
+        for resource, amount in per_resource.items():
+            level[(vid, resource)] = float(amount)
+
+    wasted: dict[tuple[int, Resource], float] = {}
+    first_full: dict[tuple[int, Resource], int] = {}
+
+    def cap_for(vid: int, resource: Resource) -> float | None:
+        value = capacities.get(vid, {}).get(resource)
+        return None if value is None else float(value)
+
+    def apply(vid: int, resource: Resource, amount: float, minute: int) -> None:
+        key = (vid, resource)
+        cap = cap_for(vid, resource)
+        current = level.get(key, 0.0)
+        updated = current + amount
+        if cap is not None and updated > cap:
+            wasted[key] = wasted.get(key, 0.0) + (updated - cap)
+            first_full.setdefault(key, minute)
+            updated = cap
+        level[key] = max(0.0, updated)
+
+    for minute in range(0, MINUTES_PER_DAY, step_minutes):
+        # Production for this slice, then whatever landed inside it.
+        for vid, per_resource in net_per_hour.items():
+            for resource, rate in per_resource.items():
+                if rate:
+                    apply(vid, resource, rate * step_minutes / 60.0, minute)
+        for event_minute in range(minute, minute + step_minutes):
+            for vid, resource, amount in moves.get(event_minute, ()):
+                apply(vid, resource, amount, event_minute)
+
+    return tuple(
+        sorted(
+            (
+                OverflowEvent(
+                    village_id=vid,
+                    resource=resource,
+                    minute=first_full[(vid, resource)],
+                    wasted_per_day=amount,
+                )
+                for (vid, resource), amount in wasted.items()
+                if amount > 0
+            ),
+            key=lambda event: (-event.wasted_per_day, event.village_id, event.resource.value),
+        )
+    )
+
+
+def storage_warnings(
+    statuses: Sequence[StoreStatus],
+    overflows: Sequence[OverflowEvent],
+    warn_hours: float = DEFAULT_WARN_HOURS,
+) -> tuple[str, ...]:
+    """Operator-facing lines. Starvation first: it destroys troops, not surplus."""
+    warnings: list[str] = []
+    for status in sorted(
+        (s for s in statuses if s.trend is Trend.DRAINING and s.hours_remaining is not None),
+        key=lambda s: s.hours_remaining or 0.0,
+    ):
+        if (status.hours_remaining or 0.0) < warn_hours:
+            warnings.append(
+                f"village {status.village_id}: {status.resource.value} runs out in "
+                f"{status.hours_remaining:.1f}h at {status.net_per_hour:+.0f}/h "
+                f"({status.stock:,} in store)"
+            )
+    for status in sorted(
+        (s for s in statuses if s.trend is Trend.FILLING and s.hours_remaining is not None),
+        key=lambda s: s.hours_remaining or 0.0,
+    ):
+        if (status.hours_remaining or 0.0) < warn_hours:
+            warnings.append(
+                f"village {status.village_id}: {status.resource.value} fills its store in "
+                f"{status.hours_remaining:.1f}h at {status.net_per_hour:+.0f}/h; "
+                f"anything past the cap is lost"
+            )
+    for event in overflows:
+        warnings.append(
+            f"village {event.village_id}: {event.resource.value} hits the cap at "
+            f"{event.minute // 60:02d}:{event.minute % 60:02d} and loses about "
+            f"{event.wasted_per_day:,.0f}/day — an arriving batch overflows even "
+            f"though the average rate fits"
+        )
+    return tuple(warnings)

--- a/src/travian_api/services/distribution/storage.py
+++ b/src/travian_api/services/distribution/storage.py
@@ -300,3 +300,181 @@ def storage_warnings(
             f"though the average rate fits"
         )
     return tuple(warnings)
+
+
+@dataclass(frozen=True)
+class ProfileSegment:
+    """One allocation profile's share of the day.
+
+    ``start_minute``/``end_minute`` are minutes past midnight; a segment may
+    wrap (start > end). ``ship_rates`` is what the profile's plan adds to or
+    removes from each village per hour while it is the one running --
+    ``village -> resource -> rate``, positive into the village.
+    """
+
+    name: str
+    start_minute: int
+    end_minute: int
+    ship_rates: Mapping[int, Mapping[Resource, float]]
+
+    def covers(self, minute: int) -> bool:
+        if self.start_minute == self.end_minute:
+            return False  # zero-width: validated away upstream, inert here
+        if self.start_minute < self.end_minute:
+            return self.start_minute <= minute < self.end_minute
+        return minute >= self.start_minute or minute < self.end_minute
+
+
+@dataclass(frozen=True)
+class TrajectoryBreach:
+    """A stock line crossing something it should not, with when and why."""
+
+    village_id: int
+    resource: Resource
+    kind: str  # "ceiling" | "capacity" | "empty"
+    day: int
+    minute: int
+    segment: str
+    """Which profile was running when the line crossed."""
+
+
+@dataclass(frozen=True)
+class VillageTrajectory:
+    """One village's crop-store day at steady state (or while still drifting)."""
+
+    village_id: int
+    resource: Resource
+    daily_net: float
+    """The UNCLAMPED nominal drift per day. Deliberately not measured off the
+    simulated levels: a store that hits its cap clamps there and its measured
+    net collapses to zero, which reads as "stable" about a village that is in
+    fact overflowing every day. The nominal keeps telling the truth."""
+    low: float
+    high: float
+    settled: bool
+
+
+def simulate_profile_cycle(
+    segments: Sequence[ProfileSegment],
+    own_rates: Mapping[int, Mapping[Resource, float]],
+    stocks: Mapping[int, Mapping[Resource, int]],
+    capacities: Mapping[int, Mapping[Resource, int]],
+    ceilings: Mapping[int, float] | None = None,
+    step_minutes: int = 15,
+    max_days: int = 45,
+) -> tuple[list[VillageTrajectory], list[TrajectoryBreach]]:
+    """Replay a day that switches between allocation profiles.
+
+    Each profile is planned in isolation, but the account lives through all of
+    them every day: what the day profile ships decides the stock the night
+    profile starts from. This runs the composite -- each segment's net shipping
+    active only inside its own hours, production always on, gaps between
+    segments meaning "no routes running" -- so questions like "does the capital
+    cross 90k during the night?" have an answer with an hour on it.
+
+    Deliberate approximation: segments contribute RATES, not discrete batches.
+    Route phases do not survive a profile switch (the operator recreates the
+    routes), so batch timing across the boundary is unknowable; within a single
+    profile the discrete check is :func:`simulate_day`. Overflow and starvation
+    still clamp, exactly as the game does.
+
+    ``ceilings`` is an operator-set alert level for CROP, below capacity --
+    typically an NPC trigger. Crossing it is reported with the day, minute and
+    the segment that was running.
+
+    Runs until the daily trajectory repeats (steady state) or ``max_days``.
+    A store still drifting at the horizon is reported unsettled with its daily
+    net, which is itself the answer: it will cross everything eventually.
+    """
+    level: dict[tuple[int, Resource], float] = {}
+    for vid, per in stocks.items():
+        for resource, amount in per.items():
+            level[(vid, resource)] = float(amount)
+
+    ceilings = ceilings or {}
+    nominal: dict[tuple[int, Resource], float] = {}
+    breaches: list[TrajectoryBreach] = []
+    breached: set[tuple[int, Resource, str]] = set()
+    lows: dict[tuple[int, Resource], float] = {}
+    highs: dict[tuple[int, Resource], float] = {}
+    day_nets: dict[tuple[int, Resource], float] = {}
+    settled_day = -1
+
+    def segment_at(minute: int) -> ProfileSegment | None:
+        for segment in segments:
+            if segment.covers(minute):
+                return segment
+        return None
+
+    for day in range(max_days):
+        opening = dict(level)
+        if day == max_days - 1 or settled_day >= 0:
+            lows = {k: v for k, v in level.items()}
+            highs = {k: v for k, v in level.items()}
+        for minute in range(0, MINUTES_PER_DAY, step_minutes):
+            active = segment_at(minute)
+            for vid, per in own_rates.items():
+                for resource, own in per.items():
+                    key = (vid, resource)
+                    ship = (
+                        float(active.ship_rates.get(vid, {}).get(resource, 0.0)) if active else 0.0
+                    )
+                    rate = own + ship
+                    if day == 0:
+                        nominal[key] = nominal.get(key, 0.0) + rate * step_minutes / 60.0
+                    if not rate:
+                        continue
+                    updated = level.get(key, 0.0) + rate * step_minutes / 60.0
+                    cap = capacities.get(vid, {}).get(resource)
+                    segment_name = active.name if active else "no profile"
+                    if resource is Resource.CROP:
+                        ceiling = ceilings.get(vid)
+                        if (
+                            ceiling is not None
+                            and updated > ceiling
+                            and (vid, resource, "ceiling") not in breached
+                        ):
+                            breached.add((vid, resource, "ceiling"))
+                            breaches.append(
+                                TrajectoryBreach(
+                                    vid, resource, "ceiling", day, minute, segment_name
+                                )
+                            )
+                    if cap is not None and updated > cap:
+                        if (vid, resource, "capacity") not in breached:
+                            breached.add((vid, resource, "capacity"))
+                            breaches.append(
+                                TrajectoryBreach(
+                                    vid, resource, "capacity", day, minute, segment_name
+                                )
+                            )
+                        updated = float(cap)
+                    if updated <= 0.0:
+                        if rate < 0 and (vid, resource, "empty") not in breached:
+                            breached.add((vid, resource, "empty"))
+                            breaches.append(
+                                TrajectoryBreach(vid, resource, "empty", day, minute, segment_name)
+                            )
+                        updated = 0.0
+                    level[key] = updated
+                    if settled_day >= 0 or day == max_days - 1:
+                        lows[key] = min(lows.get(key, updated), updated)
+                        highs[key] = max(highs.get(key, updated), updated)
+        day_nets = nominal
+        if settled_day >= 0:
+            break  # the settled day has now been measured; done
+        if all(abs(level[key] - opening.get(key, 0.0)) < 1.0 for key in level):
+            settled_day = day  # measure min/max over one more identical day
+
+    trajectories = [
+        VillageTrajectory(
+            village_id=vid,
+            resource=resource,
+            daily_net=day_nets.get((vid, resource), 0.0),
+            low=lows.get((vid, resource), level.get((vid, resource), 0.0)),
+            high=highs.get((vid, resource), level.get((vid, resource), 0.0)),
+            settled=settled_day >= 0,
+        )
+        for (vid, resource) in sorted(level)
+    ]
+    return trajectories, breaches

--- a/src/travian_api/services/distribution/storage.py
+++ b/src/travian_api/services/distribution/storage.py
@@ -107,14 +107,31 @@ def store_status(
 
 @dataclass(frozen=True)
 class OverflowEvent:
-    """A store that hits its cap during the simulated day."""
+    """A store that hits its cap on a *repeating* day of the beat."""
 
     village_id: int
     resource: Resource
     minute: int
     """Minute of the day the cap was first reached."""
     wasted_per_day: float
-    """Resources lost to the cap over one day at this rate and beat."""
+    """Resources lost to the cap on a settled day -- a genuinely recurring rate.
+
+    Deliberately measured after the simulation has reached a steady state. Read
+    off day one it would be an artifact of whatever the store happened to hold
+    at snapshot time: a village sitting near its cap loses one batch, settles,
+    and never loses anything again, which is a different problem with a
+    different fix and is already covered by the continuous fill-time check.
+    """
+
+
+# Waste below this is float residue from the settling loop, not a loss. A
+# store that converges to exactly its cap leaves a few nano-resources of
+# rounding behind, and reporting that as a daily loss is noise.
+MIN_REPORTED_WASTE = 1.0
+
+# Days to run before believing the numbers. Convergence is normally immediate
+# once the transient has drained; this only bounds a pathological input.
+MAX_SETTLING_DAYS = 14
 
 
 def simulate_day(
@@ -124,63 +141,110 @@ def simulate_day(
     net_per_hour: Mapping[int, Mapping[Resource, float]],
     step_minutes: int = 5,
 ) -> tuple[OverflowEvent, ...]:
-    """Replay one day of the beat against real capacities. Known issue #12.
+    """Replay the beat against real capacities until it settles. Issue #12.
 
     The continuous check asks whether the *average* inflow overruns the cap. This
     asks whether the store is ever actually full, which is a different question:
     a village can sit comfortably under its cap on average and still lose a whole
-    batch because a 24h route dumps it all at once.
+    batch every cycle because a long-cycle route dumps it all at once.
 
-    Production accrues continuously between steps; each scheduled arrival lands
-    as a lump at its minute. Anything above the cap is lost, exactly as the game
-    does it, and the loss is accumulated so the report can say what it costs per
-    day rather than merely that it happened.
+    Two things this is careful about, both of which produce confident nonsense if
+    skipped:
+
+    **It runs to a steady state, not for one day.** Seeded from the observed
+    stock, day one measures the transient -- a store that happens to be nearly
+    full right now loses a batch, settles, and never loses anything again. That
+    is real, but it is a "drain this village today" problem, already reported by
+    the continuous fill-time check, and calling it a *per-day* loss overstates it
+    indefinitely. Only waste that survives to a settled day is a property of the
+    beat, and only that is reported.
+
+    **Cargo is conserved.** A dispatch takes what the origin actually has; the
+    matching arrival delivers exactly that. Crediting the destination a full
+    batch the origin could not fund invents resources, and the invented cargo
+    then shows up as overflow at the far end.
+
+    ``net_per_hour`` is each village's OWN production. The routes are applied
+    here as discrete events, so folding them into the rate as well would count
+    every delivery twice.
     """
-    # Cargo leaves the origin when the merchants depart and lands at the
-    # destination when they arrive. Both halves are needed: modelling only the
-    # arrivals would let every sender's store grow without bound and report an
-    # overflow that the outbound route is in fact preventing.
-    moves: dict[int, list[tuple[int, Resource, float]]] = {}
+    # (route index, firing index, resource) -> what actually left the origin.
+    firings: list[tuple[int, int, int, int, Resource, float]] = []
     for scheduled in beat.routes:
-        batch = scheduled.route.batch_per_resource
-        for resource, amount in batch.items():
-            for minute in scheduled.dispatch_minutes:
-                moves.setdefault(minute, []).append((scheduled.route.origin, resource, -amount))
-            for minute in scheduled.arrival_minutes:
-                moves.setdefault(minute, []).append((scheduled.route.destination, resource, amount))
+        dispatches = scheduled.dispatch_minutes
+        arrivals = scheduled.arrival_minutes
+        for out_minute, in_minute in zip(dispatches, arrivals, strict=True):
+            for resource, amount in scheduled.route.batch_per_resource.items():
+                firings.append(
+                    (
+                        out_minute,
+                        in_minute,
+                        scheduled.route.origin,
+                        scheduled.route.destination,
+                        resource,
+                        amount,
+                    )
+                )
+
+    departures: dict[int, list[tuple[int, int, int, Resource, float]]] = {}
+    arrivals_at: dict[int, list[int]] = {}
+    for index, (out_minute, in_minute, origin, destination, resource, amount) in enumerate(firings):
+        departures.setdefault(out_minute, []).append((index, origin, destination, resource, amount))
+        arrivals_at.setdefault(in_minute, []).append(index)
 
     level: dict[tuple[int, Resource], float] = {}
     for vid, per_resource in stocks.items():
         for resource, amount in per_resource.items():
             level[(vid, resource)] = float(amount)
 
-    wasted: dict[tuple[int, Resource], float] = {}
-    first_full: dict[tuple[int, Resource], int] = {}
-
     def cap_for(vid: int, resource: Resource) -> float | None:
         value = capacities.get(vid, {}).get(resource)
         return None if value is None else float(value)
 
-    def apply(vid: int, resource: Resource, amount: float, minute: int) -> None:
-        key = (vid, resource)
-        cap = cap_for(vid, resource)
-        current = level.get(key, 0.0)
-        updated = current + amount
-        if cap is not None and updated > cap:
-            wasted[key] = wasted.get(key, 0.0) + (updated - cap)
-            first_full.setdefault(key, minute)
-            updated = cap
-        level[key] = max(0.0, updated)
+    wasted: dict[tuple[int, Resource], float] = {}
+    first_full: dict[tuple[int, Resource], int] = {}
+    in_flight: dict[int, float] = {}
+    previous_close: dict[tuple[int, Resource], float] | None = None
 
-    for minute in range(0, MINUTES_PER_DAY, step_minutes):
-        # Production for this slice, then whatever landed inside it.
-        for vid, per_resource in net_per_hour.items():
-            for resource, rate in per_resource.items():
-                if rate:
-                    apply(vid, resource, rate * step_minutes / 60.0, minute)
-        for event_minute in range(minute, minute + step_minutes):
-            for vid, resource, amount in moves.get(event_minute, ()):
-                apply(vid, resource, amount, event_minute)
+    for _day in range(MAX_SETTLING_DAYS):
+        wasted = {}
+        first_full = {}
+
+        def add(vid: int, resource: Resource, amount: float, minute: int) -> None:
+            key = (vid, resource)
+            cap = cap_for(vid, resource)
+            updated = level.get(key, 0.0) + amount
+            if cap is not None and updated > cap:
+                wasted[key] = wasted.get(key, 0.0) + (updated - cap)  # noqa: B023
+                first_full.setdefault(key, minute)  # noqa: B023
+                updated = cap
+            level[key] = max(0.0, updated)
+
+        for minute in range(0, MINUTES_PER_DAY, step_minutes):
+            for vid, per_resource in net_per_hour.items():
+                for resource, rate in per_resource.items():
+                    if rate:
+                        add(vid, resource, rate * step_minutes / 60.0, minute)
+            for event_minute in range(minute, min(minute + step_minutes, MINUTES_PER_DAY)):
+                # Arrivals before departures within the same minute: cargo that
+                # lands now is available to a route leaving now, which is what
+                # the beat's collect-then-ship ordering is arranging for.
+                for index in arrivals_at.get(event_minute, ()):
+                    _o, _i, _origin, destination, resource, batch = firings[index]
+                    add(destination, resource, in_flight.get(index, batch), event_minute)
+                for index, origin, _dest, resource, batch in departures.get(event_minute, ()):
+                    available = level.get((origin, resource), 0.0)
+                    shipped = min(batch, available)
+                    in_flight[index] = shipped
+                    level[(origin, resource)] = available - shipped
+
+        closing = dict(level)
+        if previous_close is not None and all(
+            abs(closing.get(key, 0.0) - previous_close.get(key, 0.0)) < 1e-6
+            for key in set(closing) | set(previous_close)
+        ):
+            break
+        previous_close = closing
 
     return tuple(
         sorted(
@@ -192,7 +256,7 @@ def simulate_day(
                     wasted_per_day=amount,
                 )
                 for (vid, resource), amount in wasted.items()
-                if amount > 0
+                if amount >= MIN_REPORTED_WASTE
             ),
             key=lambda event: (-event.wasted_per_day, event.village_id, event.resource.value),
         )

--- a/src/travian_api/services/distribution/storage.py
+++ b/src/travian_api/services/distribution/storage.py
@@ -331,7 +331,7 @@ class TrajectoryBreach:
 
     village_id: int
     resource: Resource
-    kind: str  # "ceiling" | "capacity" | "empty"
+    kind: str  # "ceiling" | "above" | "capacity" | "empty"
     day: int
     minute: int
     segment: str
@@ -379,8 +379,9 @@ def simulate_profile_cycle(
     still clamp, exactly as the game does.
 
     ``ceilings`` is an operator-set alert level for CROP, below capacity --
-    typically an NPC trigger. Crossing it is reported with the day, minute and
-    the segment that was running.
+    typically an NPC trigger. Crossing it (from below, on the post-clamp level)
+    is reported with the day, minute and the segment that was running; a store
+    that already starts the day above it is reported once as kind "above".
 
     Runs until the daily trajectory repeats (steady state) or ``max_days``.
     A store still drifting at the horizon is reported unsettled with its daily
@@ -406,6 +407,19 @@ def simulate_profile_cycle(
                 return segment
         return None
 
+    # A store that BEGINS the day above its alert level never "crosses" it --
+    # for a draining store that claim would be factually inverted. Report the
+    # standing condition once, as its own kind, before any simulation runs.
+    for vid, ceiling in ceilings.items():
+        key = (vid, Resource.CROP)
+        if key in level and level[key] > ceiling:
+            first = segment_at(0)
+            breaches.append(
+                TrajectoryBreach(
+                    vid, Resource.CROP, "above", 0, 0, first.name if first else "no profile"
+                )
+            )
+
     for day in range(max_days):
         opening = dict(level)
         if day == max_days - 1 or settled_day >= 0:
@@ -424,22 +438,10 @@ def simulate_profile_cycle(
                         nominal[key] = nominal.get(key, 0.0) + rate * step_minutes / 60.0
                     if not rate:
                         continue
-                    updated = level.get(key, 0.0) + rate * step_minutes / 60.0
+                    previous = level.get(key, 0.0)
+                    updated = previous + rate * step_minutes / 60.0
                     cap = capacities.get(vid, {}).get(resource)
                     segment_name = active.name if active else "no profile"
-                    if resource is Resource.CROP:
-                        ceiling = ceilings.get(vid)
-                        if (
-                            ceiling is not None
-                            and updated > ceiling
-                            and (vid, resource, "ceiling") not in breached
-                        ):
-                            breached.add((vid, resource, "ceiling"))
-                            breaches.append(
-                                TrajectoryBreach(
-                                    vid, resource, "ceiling", day, minute, segment_name
-                                )
-                            )
                     if cap is not None and updated > cap:
                         if (vid, resource, "capacity") not in breached:
                             breached.add((vid, resource, "capacity"))
@@ -449,6 +451,24 @@ def simulate_profile_cycle(
                                 )
                             )
                         updated = float(cap)
+                    if resource is Resource.CROP:
+                        ceiling = ceilings.get(vid)
+                        # A crossing needs a below-side and an above-side: a store
+                        # already past the alert (reported as "above" up front)
+                        # must not fire "crosses" while it drains. Tested on the
+                        # post-clamp value so a ceiling misconfigured above the
+                        # cap can never fire at a level the store cannot reach.
+                        if (
+                            ceiling is not None
+                            and previous <= ceiling < updated
+                            and (vid, resource, "ceiling") not in breached
+                        ):
+                            breached.add((vid, resource, "ceiling"))
+                            breaches.append(
+                                TrajectoryBreach(
+                                    vid, resource, "ceiling", day, minute, segment_name
+                                )
+                            )
                     if updated <= 0.0:
                         if rate < 0 and (vid, resource, "empty") not in breached:
                             breached.add((vid, resource, "empty"))

--- a/src/travian_api/services/farm_list_service.py
+++ b/src/travian_api/services/farm_list_service.py
@@ -134,6 +134,9 @@ class FarmListService:
                 "useShip": False,
                 "onlyLosses": False,
             },
+            # Non-idempotent: if the server commits the create but the response
+            # connection drops, a transport retry would make a second list.
+            safe_to_retry=False,
         )
         list_id = resp.get("id", 0)
         logger.info(f"Created farm list '{name}' (id={list_id}) for village {village_id}")
@@ -143,6 +146,7 @@ class FarmListService:
         """Delete a farm list."""
         await self.http_client.delete_json(
             f"/api/v1/farm-list/{list_id}",
+            safe_to_retry=False,
         )
         logger.info(f"Deleted farm list {list_id}")
 
@@ -175,6 +179,8 @@ class FarmListService:
                 ]
             },
             request_type="xhr",
+            # Non-idempotent: a retry after a committed add would duplicate the slot.
+            safe_to_retry=False,
         )
         logger.info(f"Added slot ({x},{y}) to list {list_id}")
 
@@ -184,6 +190,7 @@ class FarmListService:
             "/api/v1/farm-list/slot",
             data={"slots": slot_ids, "abandoned": False},
             request_type="xhr",
+            safe_to_retry=False,
         )
         logger.info(f"Deleted slots: {slot_ids}")
 

--- a/src/travian_api/services/military_service.py
+++ b/src/travian_api/services/military_service.py
@@ -159,6 +159,24 @@ class MilitaryService:
                 x, y, troops, event_type, scout_target, village_id
             )
 
+    @staticmethod
+    def _send_succeeded(result_html: str, action_token: str) -> bool:
+        """Decide whether a confirmed troop send actually dispatched.
+
+        After confirming, the server returns the rally-point page. The send
+        failed if the confirmation form reappears with the SAME action token
+        (it was not processed) or an error div is present. 'confirmSendTroops'
+        is always a button on that page and is NOT a stuck-confirming signal.
+
+        A "troopMovement" element is deliberately NOT treated as a positive
+        signal: an account with other raids already in flight always shows one,
+        so trusting it would report a rejected send (form reappeared, or an
+        error present) as dispatched.
+        """
+        form_reappeared = bool(action_token) and f'value="{action_token}"' in result_html
+        has_error = bool(re.search(r'class="error[^"]*"', result_html))
+        return not form_reappeared and not has_error
+
     async def _send_troops_unlocked(
         self,
         x: int,
@@ -274,23 +292,7 @@ class MilitaryService:
                 rally_url, final_data, safe_to_retry=False
             )
 
-            # Success detection: after confirming, the server returns the rally point
-            # page. The key negative indicator is the confirmation form reappearing
-            # with the SAME action token (means it wasn't processed).
-            # Positive indicators: troop movements, rally overview, or simply
-            # a valid page without the form reappearing or an error message.
-            action_token = final_data.get("action", "")
-            form_reappeared = action_token and f'value="{action_token}"' in result_html
-            has_error = bool(re.search(r'class="error[^"]*"', result_html))
-            has_troop_movement = "troopMovement" in result_html
-
-            # Success: the old action token was consumed (not reappearing),
-            # no error divs, and ideally we see troop movements on the page.
-            # Note: 'confirmSendTroops' always appears as a button on the
-            # rally point page — it does NOT indicate we're stuck confirming.
-            success = not form_reappeared and not has_error
-            if has_troop_movement:
-                success = True
+            success = self._send_succeeded(result_html, final_data.get("action", ""))
 
             # Try to extract travel time from the confirmation we parsed
             travel_time = ""

--- a/src/travian_api/services/rebalance_planner.py
+++ b/src/travian_api/services/rebalance_planner.py
@@ -503,7 +503,11 @@ def assign_role_and_list_name(
     # (a single placement landed straight in INACTIVE), so every non-empty set
     # promotes at least its best target.
     high_cut = max(1, int(n * HIGH_FRACTION)) if n else 0
-    mid_cut = max(high_cut, int(n * MID_FRACTION))
+    # Round the MID boundary rather than floor it: flooring int(n * MID_FRACTION)
+    # pulls the cut a whole slot short whenever the fractional part is >= 0.5, so
+    # two placements (2 * 0.80 = 1.6 -> 1) sent the runner-up to INACTIVE instead
+    # of MID, deactivating a live raid target.
+    mid_cut = max(high_cut, round(n * MID_FRACTION))
     for idx, p in enumerate(sorted_placements):
         if idx < high_cut:
             role = "HIGH"

--- a/src/travian_api/services/rebalance_planner.py
+++ b/src/travian_api/services/rebalance_planner.py
@@ -336,24 +336,24 @@ def plan_waves_for_target(
     primary_owner = getattr(target_agg, "primary_owner_village", "")
     slot_instances = list(getattr(target_agg, "slot_instances", []) or [])
 
-    for idx, (village, unit, arrival_min) in enumerate(picks):
+    for village, unit, arrival_min in picks:
         carry = UNIT_CARRY.get(unit, 0)
         if carry <= 0:
             continue
+        # Wave numbering follows COMMITTED waves, not pick position: a pick
+        # can enumerate with supply >= 1 yet lack the units the wave needs,
+        # and truncating there would drop feasible placements from slower
+        # villages with plenty of troops. Skip it and let the next candidate
+        # take this wave slot instead.
         count, haul = size_wave_with_residual_carry(
             avg_loot,
-            wave_index=idx,
+            wave_index=len(plan),
             cumulative_carry_taken=cumulative_taken,
             unit_carry=carry,
         )
         avail = int(troop_supplies.get((village, unit), 0))
         if count > avail:
-            # Supply ran out mid-plan; truncate at the prior wave. The target
-            # gets fewer waves than wanted, which is fine — the operator may
-            # train more troops later and a future run will fill the gap.
-            # of_total is corrected below so the surviving placements do not
-            # advertise waves that were never planned.
-            break
+            continue
         round_trip = arrival_min * 2.0
         raids_per_day = compute_expected_raids_per_day(round_trip)
         plan.append(
@@ -368,7 +368,7 @@ def plan_waves_for_target(
                 target_name=target_name,
                 primary_owner_village=primary_owner,
                 slot_instances=slot_instances,
-                wave_index=idx + 1,  # 1-based for operator-facing output
+                wave_index=len(plan) + 1,  # 1-based over committed waves
                 of_total_waves=of_total,
                 arrival_min=arrival_min,
                 expected_haul=haul,

--- a/src/travian_api/services/rebalance_planner.py
+++ b/src/travian_api/services/rebalance_planner.py
@@ -324,27 +324,37 @@ def plan_waves_for_target(
     if wanted == 0:
         return []
 
-    candidates = enumerate_candidate_waves(target_agg.coord, village_positions, troop_supplies)
-    picks = pick_wave_set_greedy(candidates, wanted)
-    if not picks:
+    candidates = sorted(
+        enumerate_candidate_waves(target_agg.coord, village_positions, troop_supplies),
+        key=lambda c: c[2],
+    )
+    if not candidates:
         return []
 
     plan: list[Placement] = []
     cumulative_taken = 0
-    of_total = len(picks)
+    of_total = min(wanted, len(candidates))
     target_name = getattr(target_agg, "target_name", "")
     primary_owner = getattr(target_agg, "primary_owner_village", "")
     slot_instances = list(getattr(target_agg, "slot_instances", []) or [])
 
-    for village, unit, arrival_min in picks:
+    # Selection and supply-checking run together over ALL candidates rather
+    # than a greedy pre-slice: a candidate can enumerate with supply >= 1 yet
+    # lack the units its wave needs, and pre-slicing would have discarded the
+    # slower candidates (including ones inside the skipped pick's spacing
+    # window) that could still fill the wave.
+    seen_vu: set[tuple[str, str]] = set()
+    last_arrival: float | None = None
+    for village, unit, arrival_min in candidates:
+        if len(plan) >= wanted:
+            break
+        if (village, unit) in seen_vu:
+            continue
+        if last_arrival is not None and arrival_min - last_arrival < WAVE_SPACING_MIN:
+            continue
         carry = UNIT_CARRY.get(unit, 0)
         if carry <= 0:
             continue
-        # Wave numbering follows COMMITTED waves, not pick position: a pick
-        # can enumerate with supply >= 1 yet lack the units the wave needs,
-        # and truncating there would drop feasible placements from slower
-        # villages with plenty of troops. Skip it and let the next candidate
-        # take this wave slot instead.
         count, haul = size_wave_with_residual_carry(
             avg_loot,
             wave_index=len(plan),
@@ -354,6 +364,8 @@ def plan_waves_for_target(
         avail = int(troop_supplies.get((village, unit), 0))
         if count > avail:
             continue
+        seen_vu.add((village, unit))
+        last_arrival = arrival_min
         round_trip = arrival_min * 2.0
         raids_per_day = compute_expected_raids_per_day(round_trip)
         plan.append(

--- a/src/travian_api/services/rebalance_planner.py
+++ b/src/travian_api/services/rebalance_planner.py
@@ -502,11 +502,15 @@ def assign_role_and_list_name(
     # Floored cuts would leave 1-3 placement villages with no HIGH list at all
     # (a single placement landed straight in INACTIVE), so every non-empty set
     # promotes at least its best target.
-    high_cut = max(1, int(n * HIGH_FRACTION)) if n else 0
-    # Round the MID boundary rather than floor it: flooring int(n * MID_FRACTION)
-    # pulls the cut a whole slot short whenever the fractional part is >= 0.5, so
-    # two placements (2 * 0.80 = 1.6 -> 1) sent the runner-up to INACTIVE instead
-    # of MID, deactivating a live raid target.
+    # Round BOTH cuts rather than floor them, so the bands land on the nearest
+    # integer partition of the documented 30/50/20 split. Flooring pulls a cut a
+    # whole slot short whenever the fractional part is >= 0.5: at the MID
+    # boundary that sent the runner-up of two placements (2 * 0.80 = 1.6 -> 1)
+    # to INACTIVE, deactivating a live raid target; at the HIGH boundary it
+    # undersized HIGH and left MID absorbing the shortfall (n=6 gave MID 67%
+    # against a documented 50%). Rounding both is never further from the target
+    # than flooring, for any n -- see test_band_sizes_track_the_documented_split.
+    high_cut = max(1, round(n * HIGH_FRACTION)) if n else 0
     mid_cut = max(high_cut, round(n * MID_FRACTION))
     for idx, p in enumerate(sorted_placements):
         if idx < high_cut:

--- a/src/travian_api/services/rebalance_planner.py
+++ b/src/travian_api/services/rebalance_planner.py
@@ -351,6 +351,8 @@ def plan_waves_for_target(
             # Supply ran out mid-plan; truncate at the prior wave. The target
             # gets fewer waves than wanted, which is fine — the operator may
             # train more troops later and a future run will fill the gap.
+            # of_total is corrected below so the surviving placements do not
+            # advertise waves that were never planned.
             break
         round_trip = arrival_min * 2.0
         raids_per_day = compute_expected_raids_per_day(round_trip)
@@ -374,6 +376,12 @@ def plan_waves_for_target(
         )
         troop_supplies[(village, unit)] = avail - count
         cumulative_taken += haul
+
+    # Truncation (or a zero-carry skip) can leave fewer waves than picked;
+    # advertise the waves that exist, not the ones that were merely wanted.
+    if len(plan) != of_total:
+        for placement in plan:
+            placement.of_total_waves = len(plan)
     return plan
 
 

--- a/src/travian_api/services/rebalance_planner.py
+++ b/src/travian_api/services/rebalance_planner.py
@@ -479,8 +479,11 @@ def assign_role_and_list_name(
     """
     sorted_placements = sorted(placements_for_village, key=lambda p: -p.objective_score)
     n = len(sorted_placements)
-    high_cut = int(n * HIGH_FRACTION)
-    mid_cut = int(n * MID_FRACTION)
+    # Floored cuts would leave 1-3 placement villages with no HIGH list at all
+    # (a single placement landed straight in INACTIVE), so every non-empty set
+    # promotes at least its best target.
+    high_cut = max(1, int(n * HIGH_FRACTION)) if n else 0
+    mid_cut = max(high_cut, int(n * MID_FRACTION))
     for idx, p in enumerate(sorted_placements):
         if idx < high_cut:
             role = "HIGH"

--- a/src/travian_api/services/recon_account.py
+++ b/src/travian_api/services/recon_account.py
@@ -196,17 +196,24 @@ class ReconAccountManager:
         self._auth_lock = asyncio.Lock()
         # Operator-supplied credentials, loaded from the DB at startup and
         # replaced when they are rotated through the UI. None means "no stored
-        # credentials" and the .env values remain in force.
-        self._override: Optional[tuple[str, str]] = None
+        # credentials" and the .env values remain in force. The third element
+        # scopes them to one Travian world (None = any).
+        self._override: Optional[tuple[str, str, Optional[str]]] = None
 
-    def credentials(self) -> tuple[Optional[str], Optional[str]]:
+    def credentials(self, server_url: Optional[str] = None) -> tuple[Optional[str], Optional[str]]:
         """Active recon credentials: stored ones win, .env is the fallback.
 
-        Keeping the env path alive means existing deployments that never touch
-        the UI keep working exactly as before.
+        Stored credentials scoped to a world are only handed out for THAT
+        world: the recon account exists on one server, and using it to mask
+        logins elsewhere fails and silently unmasks the reads. Keeping the env
+        path alive means existing deployments that never touch the UI keep
+        working exactly as before.
         """
         if self._override is not None:
-            return self._override
+            username, password, scope = self._override
+            if scope is not None and server_url is not None and scope != server_url.rstrip("/"):
+                return None, None
+            return username, password
         s = _get_settings()
         if s.recon_username and s.recon_password:
             return s.recon_username, s.recon_password
@@ -231,10 +238,14 @@ class ReconAccountManager:
         username, _ = self.credentials()
         return username or None
 
-    def set_credentials(self, username: str, password: str) -> None:
-        """Install rotated credentials. Caller must invalidate() to apply them
-        to any already-authenticated client."""
-        self._override = (username, password)
+    def set_credentials(
+        self, username: str, password: str, server_url: Optional[str] = None
+    ) -> None:
+        """Install rotated credentials, optionally scoped to one Travian world.
+
+        Caller must invalidate() to apply them to any already-authenticated
+        client."""
+        self._override = (username, password, server_url.rstrip("/") if server_url else None)
 
     def clear_credentials(self) -> None:
         """Forget stored credentials and fall back to .env."""
@@ -264,7 +275,7 @@ class ReconAccountManager:
         Callers MUST tolerate None and fall back to their primary
         HttpClient — this function never raises.
         """
-        username, password = self.credentials()
+        username, password = self.credentials(server_url)
         if not (username and password):
             return None
         key = server_url.rstrip("/")

--- a/src/travian_api/web/__init__.py
+++ b/src/travian_api/web/__init__.py
@@ -1,0 +1,17 @@
+"""Web UI package. Running it requires the ``web`` extra."""
+
+
+def main() -> None:
+    """Entry point for the ``travian-web`` console script.
+
+    Lives here, outside the fastapi import chain, so a base install without the
+    ``web`` extra fails with instructions instead of a bare ModuleNotFoundError.
+    """
+    try:
+        from travian_api.web.app import main as run
+    except ImportError as exc:
+        raise SystemExit(
+            "travian-web needs the web dependencies. "
+            "Install them with: pip install 'travian-api[web]'"
+        ) from exc
+    run()

--- a/src/travian_api/web/__init__.py
+++ b/src/travian_api/web/__init__.py
@@ -1,5 +1,12 @@
 """Web UI package. Running it requires the ``web`` extra."""
 
+# Top-level modules the ``web`` extra provides (see pyproject.toml). Only a
+# failure to find one of THESE means the extra is missing; any other import
+# error is a real bug and must surface as itself, not as install advice.
+_WEB_EXTRA_MODULES = frozenset(
+    {"fastapi", "uvicorn", "sqlalchemy", "aiosqlite", "bcrypt", "jwt", "cryptography", "multipart"}
+)
+
 
 def main() -> None:
     """Entry point for the ``travian-web`` console script.
@@ -9,9 +16,11 @@ def main() -> None:
     """
     try:
         from travian_api.web.app import main as run
-    except ImportError as exc:
-        raise SystemExit(
-            "travian-web needs the web dependencies. "
-            "Install them with: pip install 'travian-api[web]'"
-        ) from exc
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.partition(".")[0] in _WEB_EXTRA_MODULES:
+            raise SystemExit(
+                "travian-web needs the web dependencies. "
+                "Install them with: pip install 'travian-api[web]'"
+            ) from exc
+        raise
     run()

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -19,6 +19,7 @@ from travian_api.web.models import farm_builder as _fb_models  # noqa: F401
 from travian_api.web.models.db import init_db
 from travian_api.web.routes.buildings import router as buildings_router
 from travian_api.web.routes.captcha import router as captcha_router
+from travian_api.web.routes.distribution import router as distribution_router
 from travian_api.web.routes.exec_sessions import router as exec_sessions_router
 from travian_api.web.routes.farm import router as farm_router
 from travian_api.web.routes.farm_builder import router as farm_builder_router
@@ -199,6 +200,7 @@ app.include_router(captcha_router)
 app.include_router(exec_sessions_router)
 app.include_router(farm_builder_router)
 app.include_router(recon_router)
+app.include_router(distribution_router)
 
 # Mount WebSocket routes
 app.include_router(farm_ws_router)

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -58,13 +58,25 @@ def ui_build_exists(static_dir: Path) -> bool:
     The directory alone is not proof: loose files (favicon.svg) can exist
     without a build, and mounting StaticFiles on a missing ``assets/`` raises
     at import — which would crash the server instead of letting the
-    unbuilt-UI fallback explain the situation. Also require at least one hashed
-    JS chunk under ``assets/`` so a half-written or interrupted build (empty
-    assets dir, index.html pointing at chunks that are not there) falls back to
-    the 503 page instead of serving a broken SPA.
+    unbuilt-UI fallback explain the situation. Beyond that, an interrupted Vite
+    build can leave an index.html that references a hashed chunk which was never
+    written — so validate that every local ``<script src>`` index.html points at
+    actually exists on disk. A partial build then falls back to the 503 page
+    instead of serving a broken SPA.
     """
-    assets = static_dir / "assets"
-    return (static_dir / "index.html").is_file() and assets.is_dir() and any(assets.glob("*.js"))
+    import re
+
+    index = static_dir / "index.html"
+    if not index.is_file() or not (static_dir / "assets").is_dir():
+        return False
+    try:
+        html = index.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    refs = [r for r in re.findall(r'<script[^>]+src="([^"]+)"', html) if "://" not in r]
+    if not refs:
+        return False
+    return all((static_dir / ref.lstrip("/")).is_file() for ref in refs)
 
 
 def _quiet_exception_handler(loop: asyncio.AbstractEventLoop, context: dict) -> None:

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -235,8 +235,11 @@ async def serve_ui_not_built(request: Request, full_path: str) -> JSONResponse:
     return JSONResponse(
         {
             "detail": (
-                "The web UI has not been built. Run `npm run build` in frontend/ "
-                "(or use start.bat / start.sh), then restart the server."
+                "The web UI has not been built. From a source checkout, run "
+                "`npm run build` in frontend/ (or use start.bat / start.sh). "
+                "From a pip install, reinstall a wheel that bundles the UI — "
+                "one built with Node available, e.g. `pip install --force-reinstall "
+                "'travian-api[web]'`. Then restart the server."
             )
         },
         status_code=503,

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -59,8 +59,9 @@ def ui_build_exists(static_dir: Path) -> bool:
     without a build, and mounting StaticFiles on a missing ``assets/`` raises
     at import — which would crash the server instead of letting the
     unbuilt-UI fallback explain the situation. Beyond that, an interrupted Vite
-    build can leave an index.html that references a hashed chunk which was never
-    written — so validate that every local ``<script src>`` index.html points at
+    build can leave an index.html that references a hashed asset which was never
+    written — script, stylesheet, or modulepreload chunk. So validate that every
+    local ``assets/`` reference (``src`` or ``href``) index.html points at
     actually exists on disk. A partial build then falls back to the 503 page
     instead of serving a broken SPA.
     """
@@ -73,10 +74,14 @@ def ui_build_exists(static_dir: Path) -> bool:
         html = index.read_text(encoding="utf-8")
     except OSError:
         return False
-    refs = [r for r in re.findall(r'<script[^>]+src="([^"]+)"', html) if "://" not in r]
+    # Every hashed build output Vite emits (entry script, CSS, preloaded chunks)
+    # lives under assets/ and is referenced by a src= or href=.
+    refs = [
+        r for r in re.findall(r'(?:src|href)="([^"]+)"', html) if "://" not in r and "assets/" in r
+    ]
     if not refs:
         return False
-    return all((static_dir / ref.lstrip("/")).is_file() for ref in refs)
+    return all((static_dir / r.lstrip("/")).is_file() for r in refs)
 
 
 def _quiet_exception_handler(loop: asyncio.AbstractEventLoop, context: dict) -> None:

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -211,6 +211,27 @@ app.include_router(analyzer_ws_router)
 app.include_router(oasis_raider_ws_router)
 app.include_router(farm_builder_ws_router)
 
+
+async def serve_ui_not_built(request: Request, full_path: str) -> JSONResponse:
+    """Registered instead of the SPA when no frontend build exists.
+
+    `pip install travian-api[web]` alone ships no static assets, so without
+    this the advertised `travian-web` command serves a blank 404 at `/` and
+    nothing explains why.
+    """
+    if full_path.startswith(("api/", "ws/")):
+        return JSONResponse({"detail": "Not found"}, status_code=404)
+    return JSONResponse(
+        {
+            "detail": (
+                "The web UI has not been built. Run `npm run build` in frontend/ "
+                "(or use start.bat / start.sh), then restart the server."
+            )
+        },
+        status_code=503,
+    )
+
+
 # Serve static frontend files if the build directory exists
 if STATIC_DIR.is_dir():
     app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="assets")
@@ -249,6 +270,8 @@ if STATIC_DIR.is_dir():
             STATIC_DIR / "index.html",
             headers=_SPA_NO_CACHE_HEADERS,
         )
+else:
+    app.get("/{full_path:path}")(serve_ui_not_built)
 
 
 def main():

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -269,7 +269,12 @@ if ui_build_exists(STATIC_DIR):
         if full_path.startswith(("api/", "ws/")):
             return JSONResponse({"detail": "Not found"}, status_code=404)
 
-        file_path = STATIC_DIR / full_path
+        # Resolve and verify containment BEFORE serving: a raw request like
+        # /../../.env would otherwise escape the build directory and download
+        # any readable file on disk, .env and key files included.
+        file_path = (STATIC_DIR / full_path).resolve()
+        if not file_path.is_relative_to(STATIC_DIR.resolve()):
+            return JSONResponse({"detail": "Not found"}, status_code=404)
         if file_path.is_file():
             # Loose static files at the SPA root (favicon.svg, robots.txt,
             # etc.). The content-hashed assets live under /assets via the

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -58,9 +58,13 @@ def ui_build_exists(static_dir: Path) -> bool:
     The directory alone is not proof: loose files (favicon.svg) can exist
     without a build, and mounting StaticFiles on a missing ``assets/`` raises
     at import — which would crash the server instead of letting the
-    unbuilt-UI fallback explain the situation.
+    unbuilt-UI fallback explain the situation. Also require at least one hashed
+    JS chunk under ``assets/`` so a half-written or interrupted build (empty
+    assets dir, index.html pointing at chunks that are not there) falls back to
+    the 503 page instead of serving a broken SPA.
     """
-    return (static_dir / "assets").is_dir() and (static_dir / "index.html").is_file()
+    assets = static_dir / "assets"
+    return (static_dir / "index.html").is_file() and assets.is_dir() and any(assets.glob("*.js"))
 
 
 def _quiet_exception_handler(loop: asyncio.AbstractEventLoop, context: dict) -> None:

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -230,7 +230,7 @@ async def serve_ui_not_built(request: Request, full_path: str) -> JSONResponse:
     this the advertised `travian-web` command serves a blank 404 at `/` and
     nothing explains why.
     """
-    if full_path.startswith(("api/", "ws/")):
+    if full_path.startswith(("api/", "ws/")) or full_path in ("api", "ws"):
         return JSONResponse({"detail": "Not found"}, status_code=404)
     return JSONResponse(
         {
@@ -268,8 +268,8 @@ if ui_build_exists(STATIC_DIR):
 
     @app.get("/{full_path:path}")
     async def serve_spa(request: Request, full_path: str):
-        # Don't intercept API or WebSocket paths
-        if full_path.startswith(("api/", "ws/")):
+        # Don't intercept API or WebSocket paths (including the bare roots).
+        if full_path.startswith(("api/", "ws/")) or full_path in ("api", "ws"):
             return JSONResponse({"detail": "Not found"}, status_code=404)
 
         # Resolve and verify containment BEFORE serving: a raw request like

--- a/src/travian_api/web/app.py
+++ b/src/travian_api/web/app.py
@@ -52,6 +52,17 @@ logger = logging.getLogger(__name__)
 STATIC_DIR = Path(__file__).parent / "static"
 
 
+def ui_build_exists(static_dir: Path) -> bool:
+    """True only when a complete frontend build is present.
+
+    The directory alone is not proof: loose files (favicon.svg) can exist
+    without a build, and mounting StaticFiles on a missing ``assets/`` raises
+    at import — which would crash the server instead of letting the
+    unbuilt-UI fallback explain the situation.
+    """
+    return (static_dir / "assets").is_dir() and (static_dir / "index.html").is_file()
+
+
 def _quiet_exception_handler(loop: asyncio.AbstractEventLoop, context: dict) -> None:
     """Suppress noisy Windows ProactorEventLoop socket teardown errors.
 
@@ -232,8 +243,8 @@ async def serve_ui_not_built(request: Request, full_path: str) -> JSONResponse:
     )
 
 
-# Serve static frontend files if the build directory exists
-if STATIC_DIR.is_dir():
+# Serve static frontend files if a complete build exists
+if ui_build_exists(STATIC_DIR):
     app.mount("/assets", StaticFiles(directory=STATIC_DIR / "assets"), name="assets")
 
     # Catch-all route: serve index.html for any non-API path (SPA routing).

--- a/src/travian_api/web/auth.py
+++ b/src/travian_api/web/auth.py
@@ -117,8 +117,17 @@ def hash_password(password: str) -> str:
 
 
 def verify_password(password: str, hashed: str) -> bool:
-    """Check *password* against a bcrypt *hashed* value."""
-    return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))
+    """Check *password* against a bcrypt *hashed* value.
+
+    A password over bcrypt's 72-byte limit cannot be the right one -- nothing
+    that long was ever hashed -- but bcrypt 5 raises for it rather than
+    returning False. Login must answer "invalid credentials", not a 500, so
+    the impossible length is the answer, not an error.
+    """
+    encoded = password.encode("utf-8")
+    if len(encoded) > 72:
+        return False
+    return bcrypt.checkpw(encoded, hashed.encode("utf-8"))
 
 
 # ---------------------------------------------------------------------------

--- a/src/travian_api/web/auth.py
+++ b/src/travian_api/web/auth.py
@@ -15,7 +15,7 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from travian_api.web.models.db import User, get_db
+from travian_api.web.models.db import DB_DIR, User, get_db
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -25,10 +25,12 @@ ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_HOURS = 24
 _logger = logging.getLogger(__name__)
 
-# Store keys in ~/.travian/ (same directory as the DB) instead of CWD
-_KEYS_DIR = Path.home() / ".travian"
-_KEYS_DIR.mkdir(parents=True, exist_ok=True)
-KEYS_FILE = _KEYS_DIR / ".web_keys"
+# Keys live NEXT TO the database they encrypt for: with a custom
+# TRAVIAN_DB_PATH, keys pinned to ~/.travian mean moving or reusing that DB
+# elsewhere cannot decrypt its own credential rows. The default DB dir is
+# ~/.travian, so default deployments keep their existing key file.
+KEYS_FILE = DB_DIR / ".web_keys"
+_LEGACY_KEYS_FILE = Path.home() / ".travian" / ".web_keys"
 
 # ---------------------------------------------------------------------------
 # Key management
@@ -67,6 +69,19 @@ def get_or_create_keys() -> tuple[str, str]:
     if KEYS_FILE.exists():
         _warn_if_world_readable(KEYS_FILE)
         data = json.loads(KEYS_FILE.read_text(encoding="utf-8"))
+        return data["jwt_secret"], data["fernet_key"]
+
+    # One-time migration: deployments that ran a custom TRAVIAN_DB_PATH before
+    # keys followed the DB have their keys in ~/.travian. Regenerating instead
+    # of migrating would orphan every credential row that DB already holds.
+    if KEYS_FILE != _LEGACY_KEYS_FILE and _LEGACY_KEYS_FILE.exists():
+        data = json.loads(_LEGACY_KEYS_FILE.read_text(encoding="utf-8"))
+        KEYS_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        try:
+            KEYS_FILE.chmod(0o600)
+        except OSError:
+            pass
+        _logger.info("Migrated web keys from %s to %s", _LEGACY_KEYS_FILE, KEYS_FILE)
         return data["jwt_secret"], data["fernet_key"]
 
     jwt_secret = os.urandom(32).hex()

--- a/src/travian_api/web/models/db.py
+++ b/src/travian_api/web/models/db.py
@@ -15,7 +15,9 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 # Configurable via TRAVIAN_DB_PATH env var; defaults to ~/.travian/travian_web.db
 _DEFAULT_DB_DIR = Path.home() / ".travian"
 _DB_PATH = os.environ.get("TRAVIAN_DB_PATH", str(_DEFAULT_DB_DIR / "travian_web.db"))
-_DEFAULT_DB_DIR.mkdir(parents=True, exist_ok=True)
+# Create the directory the database actually lives in, not just the default one,
+# so a custom TRAVIAN_DB_PATH boots on a fresh machine too.
+Path(_DB_PATH).parent.mkdir(parents=True, exist_ok=True)
 DATABASE_URL = f"sqlite+aiosqlite:///{_DB_PATH}"
 
 engine = create_async_engine(DATABASE_URL, echo=False)

--- a/src/travian_api/web/models/db.py
+++ b/src/travian_api/web/models/db.py
@@ -116,10 +116,27 @@ class ReconCredential(Base):
 # ---------------------------------------------------------------------------
 
 
+# Columns added after the first release. create_all() creates missing TABLES
+# but never ALTERs existing ones, so upgrading a live travian_web.db needs
+# these backfilled or every query naming them fails with 'no such column'.
+_COLUMN_BACKFILLS: dict[str, dict[str, str]] = {
+    "travian_credentials": {
+        "label": "VARCHAR(128)",
+        "last_connected": "DATETIME",
+    },
+}
+
+
 async def init_db() -> None:
-    """Create all tables if they don't already exist."""
+    """Create all tables if they don't already exist, and backfill columns."""
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        for table, columns in _COLUMN_BACKFILLS.items():
+            result = await conn.exec_driver_sql(f"PRAGMA table_info({table})")
+            existing = {row[1] for row in result.fetchall()}
+            for name, ddl in columns.items():
+                if existing and name not in existing:
+                    await conn.exec_driver_sql(f"ALTER TABLE {table} ADD COLUMN {name} {ddl}")
 
 
 async def get_db():

--- a/src/travian_api/web/models/db.py
+++ b/src/travian_api/web/models/db.py
@@ -15,9 +15,11 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 # Configurable via TRAVIAN_DB_PATH env var; defaults to ~/.travian/travian_web.db
 _DEFAULT_DB_DIR = Path.home() / ".travian"
 _DB_PATH = os.environ.get("TRAVIAN_DB_PATH", str(_DEFAULT_DB_DIR / "travian_web.db"))
-# Create the directory the database actually lives in, not just the default one,
-# so a custom TRAVIAN_DB_PATH boots on a fresh machine too.
-Path(_DB_PATH).parent.mkdir(parents=True, exist_ok=True)
+# The directory the database actually lives in. Created here (not just the
+# default dir) so a custom TRAVIAN_DB_PATH boots on a fresh machine; also the
+# anchor for machine-local secrets that must travel WITH the database.
+DB_DIR = Path(_DB_PATH).parent
+DB_DIR.mkdir(parents=True, exist_ok=True)
 DATABASE_URL = f"sqlite+aiosqlite:///{_DB_PATH}"
 
 engine = create_async_engine(DATABASE_URL, echo=False)

--- a/src/travian_api/web/models/db.py
+++ b/src/travian_api/web/models/db.py
@@ -102,6 +102,9 @@ class ReconCredential(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     travian_username: Mapped[str] = mapped_column(String(128), nullable=False)
     encrypted_password: Mapped[str] = mapped_column(String(512), nullable=False)
+    # The world this recon account exists on; NULL means "any" (legacy rows
+    # and single-world deployments). The account can only mask reads there.
+    server_url: Mapped[str | None] = mapped_column(String(256), nullable=True, default=None)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),
@@ -125,6 +128,9 @@ _COLUMN_BACKFILLS: dict[str, dict[str, str]] = {
     "travian_credentials": {
         "label": "VARCHAR(128)",
         "last_connected": "DATETIME",
+    },
+    "recon_credentials": {
+        "server_url": "VARCHAR(256)",
     },
 }
 

--- a/src/travian_api/web/rate_limit.py
+++ b/src/travian_api/web/rate_limit.py
@@ -41,7 +41,6 @@ class RateLimiter:
     async def __call__(self, request: Request) -> None:
         key = self._key(request)
         now = time.monotonic()
-        # Prune old entries
         window_start = now - self.window
         self._calls[key] = [t for t in self._calls[key] if t > window_start]
         if len(self._calls[key]) >= self.max_calls:
@@ -50,11 +49,20 @@ class RateLimiter:
                 detail=f"Rate limit exceeded. Max {self.max_calls} requests per {self.window}s.",
             )
         self._calls[key].append(now)
-        # Prune empty keys to prevent unbounded memory growth
+        # Bound memory on a remotely-exposed instance seeing many source IPs.
+        # The current key was just refreshed, so an "empty key" sweep would
+        # never fire (it always has a fresh timestamp); instead prune every
+        # OTHER key down to its in-window timestamps and drop those left empty.
+        # Only sweep past a threshold so the common path stays O(1).
         if len(self._calls) > 100:
-            empty_keys = [k for k, v in self._calls.items() if not v]
-            for k in empty_keys:
-                del self._calls[k]
+            for k in list(self._calls):
+                if k == key:
+                    continue
+                fresh = [t for t in self._calls[k] if t > window_start]
+                if fresh:
+                    self._calls[k] = fresh
+                else:
+                    del self._calls[k]
 
 
 # Pre-configured limiters for different route groups

--- a/src/travian_api/web/rate_limit.py
+++ b/src/travian_api/web/rate_limit.py
@@ -59,3 +59,8 @@ class RateLimiter:
 
 # Pre-configured limiters for different route groups
 action_limiter = RateLimiter(max_calls=5, window_seconds=10)
+
+# Unauthenticated auth endpoints (register/login). These run bcrypt, which is
+# CPU-heavy by design, so an unlimited flood both stalls the event loop and
+# enables password brute force. Keyed by IP (no user_id yet at this point).
+auth_limiter = RateLimiter(max_calls=10, window_seconds=60)

--- a/src/travian_api/web/routes/buildings.py
+++ b/src/travian_api/web/routes/buildings.py
@@ -33,7 +33,10 @@ class UpgradeRequest(BaseModel):
 
 class ConstructRequest(BaseModel):
     slot_id: int = Field(..., ge=19, le=40, description="Empty building slot (19-40)")
-    building_name: str = Field(..., description="Building name (used to resolve GID)")
+    building_name: str | None = Field(
+        default=None,
+        description="Building name (used to resolve GID when building_gid is absent)",
+    )
     building_gid: int | None = Field(
         default=None, description="Building GID (takes precedence over building_name)"
     )
@@ -154,6 +157,11 @@ async def construct_building(
     slot and matches by name (case-insensitive).
     """
     gid = body.building_gid
+    if gid is None and body.building_name is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Provide building_gid or building_name.",
+        )
     vid = body.village_id or session.active_village_id
 
     # Resolve building_name -> gid if gid not provided

--- a/src/travian_api/web/routes/buildings.py
+++ b/src/travian_api/web/routes/buildings.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from travian_api.web.rate_limit import action_limiter
-from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.sessions import TravianSession, get_travian_session, require_village_id
 
 logger = logging.getLogger(__name__)
 
@@ -24,9 +24,8 @@ class UpgradeRequest(BaseModel):
     village_id: int | None = Field(
         default=None,
         description=(
-            "Village to act on. Village switching is client-side only, so the "
-            "session default is forever the login village — pass this whenever "
-            "the UI shows a different village."
+            "Village to act on. Required: village selection is client-side, so "
+            "the server never guesses which village a build targets."
         ),
     )
 
@@ -41,9 +40,7 @@ class ConstructRequest(BaseModel):
         default=None, description="Building GID (takes precedence over building_name)"
     )
     allow_gold: bool = Field(default=False, description="Allow spending gold on master builder")
-    village_id: int | None = Field(
-        default=None, description="Village to act on (default: the session's login village)"
-    )
+    village_id: int | None = Field(default=None, description="Village to act on (required)")
 
 
 # ---------------------------------------------------------------------------
@@ -53,11 +50,11 @@ class ConstructRequest(BaseModel):
 
 @router.get("")
 async def list_buildings(
-    village_id: Optional[int] = Query(None, description="Village ID (default: active village)"),
+    village_id: Optional[int] = Query(None, description="Village ID (required)"),
     session: TravianSession = Depends(get_travian_session),
 ):
     """List all buildings for a village."""
-    vid = village_id or session.active_village_id
+    vid = require_village_id(village_id)
     try:
         buildings = await session.building_service.get_village_buildings(village_id=vid)
     except Exception as exc:
@@ -75,11 +72,11 @@ async def list_buildings(
 
 @router.get("/resources")
 async def get_resources(
-    village_id: Optional[int] = Query(None, description="Village ID (default: active village)"),
+    village_id: Optional[int] = Query(None, description="Village ID (required)"),
     session: TravianSession = Depends(get_travian_session),
 ):
     """Get current resources, production rates, and storage capacity."""
-    vid = village_id or session.active_village_id
+    vid = require_village_id(village_id)
     try:
         resources = await session.building_service.get_resources(village_id=vid)
     except Exception as exc:
@@ -97,11 +94,11 @@ async def get_resources(
 
 @router.get("/queue")
 async def get_construction_queue(
-    village_id: Optional[int] = Query(None, description="Village ID (default: active village)"),
+    village_id: Optional[int] = Query(None, description="Village ID (required)"),
     session: TravianSession = Depends(get_travian_session),
 ):
     """Get the active construction queue."""
-    vid = village_id or session.active_village_id
+    vid = require_village_id(village_id)
     try:
         queue = await session.building_service.get_construction_queue(village_id=vid)
     except Exception as exc:
@@ -128,7 +125,7 @@ async def upgrade_building(
         result = await session.building_service.upgrade_building(
             slot_id=body.slot_id,
             allow_gold=body.allow_gold,
-            village_id=body.village_id or session.active_village_id,
+            village_id=require_village_id(body.village_id),
         )
     except Exception as exc:
         logger.exception("Failed to upgrade building slot %s", body.slot_id)
@@ -162,7 +159,7 @@ async def construct_building(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Provide building_gid or building_name.",
         )
-    vid = body.village_id or session.active_village_id
+    vid = require_village_id(body.village_id)
 
     # Resolve building_name -> gid if gid not provided
     if gid is None:
@@ -216,7 +213,7 @@ async def construct_building(
 @router.get("/{slot_id}")
 async def get_building_detail(
     slot_id: int,
-    village_id: Optional[int] = Query(None, description="Village ID (default: active village)"),
+    village_id: Optional[int] = Query(None, description="Village ID (required)"),
     session: TravianSession = Depends(get_travian_session),
 ):
     """Get detailed information for a specific building slot."""
@@ -226,7 +223,7 @@ async def get_building_detail(
             detail="slot_id must be between 1 and 40",
         )
 
-    vid = village_id or session.active_village_id
+    vid = require_village_id(village_id)
     try:
         detail = await session.building_service.get_building_detail(
             slot_id=slot_id,

--- a/src/travian_api/web/routes/buildings.py
+++ b/src/travian_api/web/routes/buildings.py
@@ -21,6 +21,14 @@ router = APIRouter(prefix="/api/buildings", tags=["buildings"])
 class UpgradeRequest(BaseModel):
     slot_id: int = Field(..., ge=1, le=40, description="Building slot to upgrade")
     allow_gold: bool = Field(default=False, description="Allow spending gold on master builder")
+    village_id: int | None = Field(
+        default=None,
+        description=(
+            "Village to act on. Village switching is client-side only, so the "
+            "session default is forever the login village — pass this whenever "
+            "the UI shows a different village."
+        ),
+    )
 
 
 class ConstructRequest(BaseModel):
@@ -30,6 +38,9 @@ class ConstructRequest(BaseModel):
         default=None, description="Building GID (takes precedence over building_name)"
     )
     allow_gold: bool = Field(default=False, description="Allow spending gold on master builder")
+    village_id: int | None = Field(
+        default=None, description="Village to act on (default: the session's login village)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -114,7 +125,7 @@ async def upgrade_building(
         result = await session.building_service.upgrade_building(
             slot_id=body.slot_id,
             allow_gold=body.allow_gold,
-            village_id=session.active_village_id,
+            village_id=body.village_id or session.active_village_id,
         )
     except Exception as exc:
         logger.exception("Failed to upgrade building slot %s", body.slot_id)
@@ -143,13 +154,14 @@ async def construct_building(
     slot and matches by name (case-insensitive).
     """
     gid = body.building_gid
+    vid = body.village_id or session.active_village_id
 
     # Resolve building_name -> gid if gid not provided
     if gid is None:
         try:
             available = await session.building_service.get_available_buildings(
                 slot_id=body.slot_id,
-                village_id=session.active_village_id,
+                village_id=vid,
             )
         except Exception as exc:
             logger.exception("Failed to list available buildings for slot %s", body.slot_id)
@@ -179,7 +191,7 @@ async def construct_building(
             slot_id=body.slot_id,
             building_gid=gid,
             allow_gold=body.allow_gold,
-            village_id=session.active_village_id,
+            village_id=vid,
         )
     except Exception as exc:
         logger.exception("Failed to construct building on slot %s", body.slot_id)
@@ -196,6 +208,7 @@ async def construct_building(
 @router.get("/{slot_id}")
 async def get_building_detail(
     slot_id: int,
+    village_id: Optional[int] = Query(None, description="Village ID (default: active village)"),
     session: TravianSession = Depends(get_travian_session),
 ):
     """Get detailed information for a specific building slot."""
@@ -205,10 +218,11 @@ async def get_building_detail(
             detail="slot_id must be between 1 and 40",
         )
 
+    vid = village_id or session.active_village_id
     try:
         detail = await session.building_service.get_building_detail(
             slot_id=slot_id,
-            village_id=session.active_village_id,
+            village_id=vid,
         )
     except Exception as exc:
         logger.exception("Failed to get building detail for slot %s", slot_id)
@@ -218,6 +232,6 @@ async def get_building_detail(
         )
 
     return {
-        "village_id": session.active_village_id,
+        "village_id": vid,
         **detail.model_dump(),
     }

--- a/src/travian_api/web/routes/buildings.py
+++ b/src/travian_api/web/routes/buildings.py
@@ -121,11 +121,15 @@ async def upgrade_building(
     _=Depends(action_limiter),
 ):
     """Upgrade an existing building to the next level."""
+    # Resolve BEFORE the try: require_village_id raises a deliberate 400 for a
+    # missing village, and the broad except below would otherwise rewrap that
+    # client error as a misleading 502. Every sibling route hoists it too.
+    vid = require_village_id(body.village_id)
     try:
         result = await session.building_service.upgrade_building(
             slot_id=body.slot_id,
             allow_gold=body.allow_gold,
-            village_id=require_village_id(body.village_id),
+            village_id=vid,
         )
     except Exception as exc:
         logger.exception("Failed to upgrade building slot %s", body.slot_id)

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -1,0 +1,353 @@
+"""Resource distribution planner endpoints.
+
+Split deliberately into a *fetch* and a *plan* call:
+
+* ``GET /api/distribution/snapshot`` spends game requests and returns raw state.
+* ``POST /api/distribution/plan`` spends none -- the caller hands back the
+  snapshot it already holds plus its targets, and the planner is pure.
+
+That split is the whole point. Requests to Travian are the scarce resource, so
+re-planning while the operator tunes allocation targets must cost nothing, and
+every fetch is a deliberate, priced action rather than a side effect of typing.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from travian_api.exceptions import TravianError
+from travian_api.parsers.html_parser import (
+    parse_village_stats_production,
+    parse_village_stats_resources,
+)
+from travian_api.services.distribution.allocation import (
+    Allocation,
+    AllocationError,
+    AllocationMode,
+    Resource,
+)
+from travian_api.services.distribution.geometry import MapGeometry
+from travian_api.services.distribution.merchants import (
+    DAILY_BEAT_CYCLES,
+    EUROPE2_TEUTON,
+    MerchantModel,
+)
+from travian_api.services.distribution.optimizer import VillageState
+from travian_api.services.distribution.planner import PlannerConfig, craft_plan
+from travian_api.web.sessions import TravianSession, get_travian_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/distribution", tags=["distribution"])
+
+# Europe 2 is x1 with coordinates running -200..+200. Exposed in the response so
+# the UI can show what the distances were computed against.
+DEFAULT_MAP_SPAN = 401
+DEFAULT_SPEED_FIELDS_PER_HOUR = 12.0
+
+
+class VillageSnapshot(BaseModel):
+    """Per-village state, all of it read from the game."""
+
+    village_id: int
+    name: str
+    x: int
+    y: int
+    merchants_total: int = 0
+    merchants_free: int = 0
+    lumber_per_hour: float = 0
+    clay_per_hour: float = 0
+    iron_per_hour: float = 0
+    crop_per_hour: float | None = Field(
+        default=None,
+        description=(
+            "NET crop per hour, negative while draining. None when it could not "
+            "be derived -- never silently zero, since zero reads as healthy."
+        ),
+    )
+    crop_stock: int = 0
+    crop_draining: bool = False
+
+
+class SnapshotResponse(BaseModel):
+    villages: list[VillageSnapshot]
+    map_span: int = DEFAULT_MAP_SPAN
+    speed_fields_per_hour: float = DEFAULT_SPEED_FIELDS_PER_HOUR
+    requests_used: int
+    warnings: list[str] = []
+
+
+class AllocationInput(BaseModel):
+    mode: AllocationMode
+    value: float = 0.0
+
+
+class VillageConfig(BaseModel):
+    """Operator-owned state the game will not tell us."""
+
+    village_id: int
+    trade_office_level: int = Field(
+        default=0,
+        ge=0,
+        le=20,
+        description=(
+            "Unknown levels must default to 0: understating capacity "
+            "over-provisions merchants, which is safe, while overstating it "
+            "breaches the merchant budget invisibly."
+        ),
+    )
+
+
+class PlanRequest(BaseModel):
+    snapshot: list[VillageSnapshot]
+    config: list[VillageConfig] = []
+    # resource -> village_id -> allocation
+    allocations: dict[Resource, dict[int, AllocationInput]] = {}
+    merchant_base_capacity: int = EUROPE2_TEUTON.base_capacity
+    trade_office_bonus_per_level: float = EUROPE2_TEUTON.bonus_per_trade_office_level
+    merchant_reserve: int = Field(default=2, ge=0)
+    max_latency_hours: float | None = 2.0
+    min_arrival_gap_minutes: int = Field(default=3, ge=0)
+    map_span: int = Field(default=DEFAULT_MAP_SPAN, gt=0)
+    speed_fields_per_hour: float = Field(default=DEFAULT_SPEED_FIELDS_PER_HOUR, gt=0)
+
+
+class SheetRowResponse(BaseModel):
+    origin: int
+    destination: int
+    cargo: dict[Resource, int]
+    total_cargo: int
+    cycle_hours: int
+    dispatch: str
+    arrival: str
+    merchants: int
+
+
+class BudgetResponse(BaseModel):
+    village_id: int
+    committed: int
+    spare: int
+    free: int
+    over_budget: bool
+    trade_office_levels_needed: int | None = None
+
+
+class ShortfallResponse(BaseModel):
+    village_id: int
+    resource: Resource
+    per_hour: float
+    reason: str
+
+
+class UnallocatedResponse(BaseModel):
+    resource: Resource
+    total_production: float
+    unallocated: float
+    remainder_village_id: int | None
+
+
+class PlanResponse(BaseModel):
+    rows: list[SheetRowResponse]
+    budgets: list[BudgetResponse]
+    shortfalls: list[ShortfallResponse]
+    unallocated: list[UnallocatedResponse]
+    total_merchants: int
+    feasible: bool
+    warnings: list[str]
+
+
+@router.get("/snapshot", response_model=SnapshotResponse)
+async def get_snapshot(session: TravianSession = Depends(get_travian_session)):
+    """Read current account state. Costs 3-4 game requests.
+
+    Production for lumber/clay/iron comes from the account-wide statistics table,
+    where gross equals net -- only crop is consumed. Crop is read separately
+    because that table reports GROSS crop, and using it as net inverts the sign
+    on any village whose troops outeat its fields.
+    """
+    if session.auth_state is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No auth state — reconnect first.",
+        )
+
+    warnings: list[str] = []
+    try:
+        production = parse_village_stats_production(
+            await session.http_client.get_html("/village/statistics/resources/production")
+        )
+        # Fetch the stocks table once and use it for both merchant counts and
+        # the crop derivation, rather than letting the service fetch it again.
+        stocks = parse_village_stats_resources(
+            await session.http_client.get_html("/village/statistics/resources")
+        )
+        crop = await session.building_service.get_all_villages_net_crop(stocks=stocks)
+    except TravianError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Distribution snapshot failed")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Could not read account state: {exc}",
+        ) from exc
+
+    villages: list[VillageSnapshot] = []
+    for village in session.auth_state.villages:
+        vid = village.id
+        rates = production.get(vid, {})
+        balance = crop.get(vid)
+        merchants = stocks.get(vid, {})
+        if balance is None:
+            warnings.append(f"village {vid} has no crop balance; it will not be routed for crop")
+        villages.append(
+            VillageSnapshot(
+                village_id=vid,
+                name=village.name or str(vid),
+                x=village.x,
+                y=village.y,
+                merchants_total=merchants.get("merchants_total", 0),
+                merchants_free=merchants.get("merchants_free", 0),
+                lumber_per_hour=rates.get("lumber", 0),
+                clay_per_hour=rates.get("clay", 0),
+                iron_per_hour=rates.get("iron", 0),
+                crop_per_hour=balance.net_per_hour if balance else None,
+                crop_stock=balance.stock if balance else 0,
+                crop_draining=balance.draining if balance else False,
+            )
+        )
+
+    missing_merchants = [v.village_id for v in villages if v.merchants_total == 0]
+    if missing_merchants:
+        warnings.append(
+            f"no merchant count read for village(s) {missing_merchants}; they cannot "
+            f"send until it is known"
+        )
+
+    return SnapshotResponse(
+        villages=villages,
+        requests_used=4,
+        warnings=warnings,
+    )
+
+
+@router.post("/plan", response_model=PlanResponse)
+async def post_plan(
+    body: PlanRequest,
+    _session: TravianSession = Depends(get_travian_session),
+):
+    """Compute a plan. Costs **zero** game requests.
+
+    The caller supplies the snapshot it already fetched, so tuning allocation
+    targets is free and the planner stays pure.
+    """
+    trade_office = {c.village_id: c.trade_office_level for c in body.config}
+    villages = {
+        v.village_id: VillageState(
+            village_id=v.village_id,
+            x=v.x,
+            y=v.y,
+            merchant_count=v.merchants_total,
+            trade_office_level=trade_office.get(v.village_id, 0),
+            name=v.name,
+        )
+        for v in body.snapshot
+    }
+    if not villages:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Snapshot is empty — fetch account state first.",
+        )
+
+    rate_field = {
+        Resource.LUMBER: "lumber_per_hour",
+        Resource.CLAY: "clay_per_hour",
+        Resource.IRON: "iron_per_hour",
+        Resource.CROP: "crop_per_hour",
+    }
+    productions: dict[Resource, dict[int, float]] = {}
+    for resource, field_name in rate_field.items():
+        rates = {
+            v.village_id: float(getattr(v, field_name))
+            for v in body.snapshot
+            # A village whose net crop could not be derived is excluded rather
+            # than defaulted to 0, which would read as a healthy village.
+            if getattr(v, field_name) is not None
+        }
+        if rates:
+            productions[resource] = rates
+
+    allocations = {
+        resource: {
+            vid: Allocation(mode=item.mode, value=item.value) for vid, item in per_village.items()
+        }
+        for resource, per_village in body.allocations.items()
+    }
+
+    config = PlannerConfig(
+        geometry=MapGeometry(span=body.map_span, speed_fields_per_hour=body.speed_fields_per_hour),
+        merchant_model=MerchantModel(
+            base_capacity=body.merchant_base_capacity,
+            bonus_per_trade_office_level=body.trade_office_bonus_per_level,
+        ),
+        merchant_reserve=body.merchant_reserve,
+        cycles=DAILY_BEAT_CYCLES,
+        max_latency_hours=body.max_latency_hours,
+        min_arrival_gap_minutes=body.min_arrival_gap_minutes,
+    )
+
+    try:
+        plan = craft_plan(villages, productions, allocations, config)
+    except AllocationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    upgrades = {o.village_id: o.trade_office_levels_needed for o in plan.over_budget}
+    over = {o.village_id for o in plan.over_budget}
+
+    return PlanResponse(
+        rows=[
+            SheetRowResponse(
+                origin=row.origin,
+                destination=row.destination,
+                cargo={r: amount for r, amount in row.cargo.items() if amount},
+                total_cargo=row.total_cargo,
+                cycle_hours=row.cycle_hours,
+                dispatch=row.dispatch_clock(),
+                arrival=row.arrival_clock(),
+                merchants=row.merchants,
+            )
+            for row in plan.rows
+        ],
+        budgets=[
+            BudgetResponse(
+                village_id=vid,
+                committed=plan.merchants_committed.get(vid, 0),
+                spare=plan.spare_merchants.get(vid, 0),
+                free=plan.free_merchants(vid),
+                over_budget=vid in over,
+                trade_office_levels_needed=upgrades.get(vid),
+            )
+            for vid in sorted(villages)
+        ],
+        shortfalls=[
+            ShortfallResponse(
+                village_id=s.village_id,
+                resource=s.resource,
+                per_hour=s.per_hour,
+                reason=s.reason,
+            )
+            for s in plan.shortfalls
+        ],
+        unallocated=[
+            UnallocatedResponse(
+                resource=resource,
+                total_production=rp.total_production,
+                unallocated=rp.unallocated,
+                remainder_village_id=rp.remainder_village_id,
+            )
+            for resource, rp in sorted(plan.resource_plans.items(), key=lambda kv: kv[0].value)
+        ],
+        total_merchants=plan.total_merchants,
+        feasible=plan.is_feasible,
+        warnings=list(plan.warnings),
+    )

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -229,6 +229,11 @@ class PlanRequest(BaseModel):
 class SheetRowResponse(BaseModel):
     origin: int
     destination: int
+    # Display names, resolved server-side. The frontend used to look ids up in
+    # its own snapshot, which cannot know foreign tributes -- their negative
+    # ids leaked into the sheet as "-1" instead of the name the operator typed.
+    origin_name: str = ""
+    destination_name: str = ""
     cargo: dict[Resource, int]
     total_cargo: int
     cycle_hours: int
@@ -280,6 +285,7 @@ class BudgetResponse(BaseModel):
 
 class ShortfallResponse(BaseModel):
     village_id: int
+    village_name: str = ""
     resource: Resource
     per_hour: float
     reason: str
@@ -743,6 +749,8 @@ async def post_plan(
         rows=[
             SheetRowResponse(
                 origin=row.origin,
+                origin_name=village_label(row.origin, names),
+                destination_name=village_label(row.destination, names),
                 destination=row.destination,
                 cargo={r: amount for r, amount in row.cargo.items() if amount},
                 total_cargo=row.total_cargo,
@@ -782,6 +790,7 @@ async def post_plan(
         shortfalls=[
             ShortfallResponse(
                 village_id=s.village_id,
+                village_name=village_label(s.village_id, names),
                 resource=s.resource,
                 per_hour=s.per_hour,
                 reason=s.reason,

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -69,7 +69,7 @@ _TRIBE_MERCHANT_SPEED: dict[int, float] = {
     2: 12.0,  # Teuton
     3: 24.0,  # Gaul
     6: 16.0,  # Egyptian
-    7: 12.0,  # Hun
+    7: 20.0,  # Hun
     8: 16.0,  # Spartan
 }
 

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -995,16 +995,20 @@ async def post_plan(
             )
         # Section 7.3: a tribute must not lapse, and the first delivery only
         # lands after a full one-way trip. Saying so is the difference between
-        # a planned gap and an apparent broken promise.
-        first = max(
-            (row.first_delivery_hours for row in plan.rows if row.destination == target_id),
-            default=0.0,
+        # a planned gap and an apparent broken promise. With several suppliers
+        # the first crop lands at the EARLIEST route's startup; the slowest
+        # route only marks when the full rate is flowing.
+        firsts = [row.first_delivery_hours for row in plan.rows if row.destination == target_id]
+        first = min(firsts, default=0.0)
+        full = max(firsts, default=0.0)
+        note = (
+            f"{target.name} ({target.x}|{target.y}): the first crop lands "
+            f"{first:.1f}h after the routes are created"
         )
-        extra_warnings.append(
-            f"{target.name} ({target.x}|{target.y}): first delivery lands "
-            f"{first:.1f}h after the route is created, so the tribute starts "
-            f"late unless it is covered by hand until then"
-        )
+        if full > first + 0.05:
+            note += f" and the full tribute only flows from {full:.1f}h"
+        note += ", so it starts late unless covered by hand until then"
+        extra_warnings.append(note)
 
     upgrades = {o.village_id: o.trade_office_levels_needed for o in plan.over_budget}
     over = {o.village_id for o in plan.over_budget}

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -376,6 +376,12 @@ def _storage_warnings(body: PlanRequest, plan) -> list[str]:
     statuses = []
     stocks: dict[int, dict[Resource, int]] = {}
     capacities: dict[int, dict[Resource, int]] = {}
+    # OWN production only. The two checks need different inputs and mixing them
+    # up double-counts every route: store_status works on the post-plan net rate
+    # (a continuous average, routes folded in), while simulate_day applies the
+    # routes itself as discrete dispatches and arrivals. Feeding the net rate to
+    # the simulation makes a receiver bank its deliveries twice -- 48,000 a day
+    # where 24,000 arrives -- and invent overflows that do not exist.
     own_rates: dict[int, dict[Resource, float]] = {}
 
     # Net rate per village per resource AFTER the plan: own production plus what
@@ -404,7 +410,7 @@ def _storage_warnings(body: PlanRequest, plan) -> list[str]:
             )
             net = float(own) + shipped.get(vid, {}).get(resource, 0.0)
             stocks.setdefault(vid, {})[resource] = stock
-            own_rates.setdefault(vid, {})[resource] = net
+            own_rates.setdefault(vid, {})[resource] = float(own)
             if cap is not None:
                 capacities.setdefault(vid, {})[resource] = cap
             statuses.append(store_status(vid, resource, stock, cap, net))

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -298,7 +298,9 @@ class UnallocatedResponse(BaseModel):
     resource: Resource
     total_production: float
     unallocated: float
-    remainder_village_id: int | None
+    # Optional in meaning (a resource may have no remainder village) and given
+    # an explicit default so the model never depends on the caller supplying it.
+    remainder_village_id: int | None = None
 
 
 class PlanResponse(BaseModel):

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -15,7 +15,7 @@ import asyncio
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from travian_api.exceptions import TravianError
 from travian_api.parsers.html_parser import (
@@ -34,8 +34,19 @@ from travian_api.services.distribution.merchants import (
     EUROPE2_TEUTON,
     MerchantModel,
 )
-from travian_api.services.distribution.optimizer import VillageState
+from travian_api.services.distribution.optimizer import (
+    MAX_IMPROVE_PASSES,
+    MAX_RELAY_HOPS,
+    MIN_SEND_FILL,
+    VillageState,
+)
 from travian_api.services.distribution.planner import PlannerConfig, craft_plan
+from travian_api.services.distribution.schedule import MINUTES_PER_DAY
+from travian_api.services.distribution.storage import (
+    simulate_day,
+    storage_warnings,
+    store_status,
+)
 from travian_api.web.auth import get_current_user
 from travian_api.web.models.db import User
 from travian_api.web.sessions import TravianSession, get_live_travian_session
@@ -83,6 +94,20 @@ class VillageSnapshot(BaseModel):
     )
     crop_stock: int = 0
     crop_draining: bool = False
+    lumber_stock: int = 0
+    clay_stock: int = 0
+    iron_stock: int = 0
+    warehouse_capacity: int | None = Field(
+        default=None,
+        description=(
+            "Per-resource warehouse cap for lumber/clay/iron. None when the "
+            "capacity page was not needed by the crop read and so was not "
+            "fetched -- storage checks skip the village rather than guess."
+        ),
+    )
+    granary_capacity: int | None = Field(
+        default=None, description="Granary cap. None when it could not be read."
+    )
 
 
 class SnapshotResponse(BaseModel):
@@ -128,6 +153,47 @@ class PlanRequest(BaseModel):
     min_arrival_gap_minutes: int = Field(default=3, ge=0)
     map_span: int = Field(default=DEFAULT_MAP_SPAN, gt=0)
     speed_fields_per_hour: float = Field(default=DEFAULT_SPEED_FIELDS_PER_HOUR, gt=0)
+    min_send_fill: float = Field(
+        default=MIN_SEND_FILL,
+        ge=0,
+        le=1,
+        description=(
+            "How full a merchant must stay when idle merchants are spent on speed. "
+            "Lower it for faster routes on emptier merchants, raise it to keep them "
+            "full but slower. This is the latency/fill trade-off dial."
+        ),
+    )
+    max_improve_passes: int = Field(
+        default=MAX_IMPROVE_PASSES,
+        ge=1,
+        description=(
+            "Ceiling on route-search passes. Raise it for very large accounts; a "
+            "search that stops early says so in the warnings, because a truncated "
+            "one overstates how many villages are over budget."
+        ),
+    )
+    max_relay_hops: int = Field(
+        default=MAX_RELAY_HOPS,
+        ge=0,
+        description="Levels of crop relay through a sub-hub; 0 ships everything direct.",
+    )
+    reserved_window: tuple[int, int] | None = Field(
+        default=None,
+        description=(
+            "Minutes past midnight (start, end) to keep clear of arrivals for the "
+            "manual NPC burst. Arrivals avoid it where an alternative exists, and "
+            "the plan warns when geometry forces one into it."
+        ),
+    )
+
+    @field_validator("reserved_window")
+    @classmethod
+    def _window_within_the_day(cls, value: tuple[int, int] | None) -> tuple[int, int] | None:
+        # A window may wrap past midnight (start > end), so only the bounds are
+        # checked -- ordering carries meaning rather than being an error.
+        if value is not None and not all(0 <= minute < MINUTES_PER_DAY for minute in value):
+            raise ValueError(f"reserved_window minutes must be 0-{MINUTES_PER_DAY - 1}")
+        return value
 
 
 class SheetRowResponse(BaseModel):
@@ -139,6 +205,14 @@ class SheetRowResponse(BaseModel):
     dispatch: str
     arrival: str
     merchants: int
+    first_delivery_hours: float = Field(
+        default=0.0,
+        description=(
+            "Hours from creating this route to its first delivery landing. Every "
+            "other figure here is steady-state; on the day the route is created "
+            "the cargo still has to accumulate for one cycle and then travel."
+        ),
+    )
 
 
 class BudgetResponse(BaseModel):
@@ -202,7 +276,7 @@ async def get_snapshot(session: TravianSession = Depends(get_live_travian_sessio
         stocks = parse_village_stats_resources(
             await session.http_client.get_html("/village/statistics/resources")
         )
-        crop, crop_requests = await session.building_service.get_all_villages_net_crop(
+        crop, capacities, crop_requests = await session.building_service.get_all_villages_net_crop(
             stocks=stocks
         )
     except TravianError as exc:
@@ -250,6 +324,11 @@ async def get_snapshot(session: TravianSession = Depends(get_live_travian_sessio
                 crop_per_hour=balance.net_per_hour if balance else None,
                 crop_stock=balance.stock if balance else 0,
                 crop_draining=balance.draining if balance else False,
+                lumber_stock=merchants.get("lumber", 0),
+                clay_stock=merchants.get("clay", 0),
+                iron_stock=merchants.get("iron", 0),
+                warehouse_capacity=capacities.get(vid, {}).get("warehouse"),
+                granary_capacity=capacities.get(vid, {}).get("granary"),
             )
         )
 
@@ -270,6 +349,68 @@ async def get_snapshot(session: TravianSession = Depends(get_live_travian_sessio
         requests_used=2 + crop_requests,
         warnings=warnings,
     )
+
+
+_STOCK_FIELD = {
+    Resource.LUMBER: "lumber_stock",
+    Resource.CLAY: "clay_stock",
+    Resource.IRON: "iron_stock",
+    Resource.CROP: "crop_stock",
+}
+_RATE_FIELD = {
+    Resource.LUMBER: "lumber_per_hour",
+    Resource.CLAY: "clay_per_hour",
+    Resource.IRON: "iron_per_hour",
+    Resource.CROP: "crop_per_hour",
+}
+
+
+def _storage_warnings(body: PlanRequest, plan) -> list[str]:
+    """Overflow and starvation checks over the finished plan. Zero requests.
+
+    Every input is already in the snapshot the caller handed back, so this costs
+    nothing to run. Villages whose capacity was never read are simply skipped
+    rather than assumed -- the capacity page is only fetched when the crop
+    derivation needs it, and inventing a cap would produce confident nonsense.
+    """
+    statuses = []
+    stocks: dict[int, dict[Resource, int]] = {}
+    capacities: dict[int, dict[Resource, int]] = {}
+    own_rates: dict[int, dict[Resource, float]] = {}
+
+    # Net rate per village per resource AFTER the plan: own production plus what
+    # arrives minus what leaves. That is what the store actually sees.
+    shipped: dict[int, dict[Resource, float]] = {}
+    for route in plan.routing.routes:
+        for resource, amount in route.cargo_per_hour.items():
+            shipped.setdefault(route.destination, {})[resource] = (
+                shipped.setdefault(route.destination, {}).get(resource, 0.0) + amount
+            )
+            shipped.setdefault(route.origin, {})[resource] = (
+                shipped.setdefault(route.origin, {}).get(resource, 0.0) - amount
+            )
+
+    for village in body.snapshot:
+        vid = village.village_id
+        for resource in Resource:
+            own = getattr(village, _RATE_FIELD[resource])
+            if own is None:
+                continue  # unreadable rate; the plan already warned about it
+            stock = getattr(village, _STOCK_FIELD[resource])
+            cap = (
+                village.granary_capacity
+                if resource is Resource.CROP
+                else village.warehouse_capacity
+            )
+            net = float(own) + shipped.get(vid, {}).get(resource, 0.0)
+            stocks.setdefault(vid, {})[resource] = stock
+            own_rates.setdefault(vid, {})[resource] = net
+            if cap is not None:
+                capacities.setdefault(vid, {})[resource] = cap
+            statuses.append(store_status(vid, resource, stock, cap, net))
+
+    overflows = simulate_day(plan.beat, stocks, capacities, own_rates)
+    return list(storage_warnings(statuses, overflows))
 
 
 @router.post("/plan", response_model=PlanResponse)
@@ -330,6 +471,10 @@ async def post_plan(
         cycles=DAILY_BEAT_CYCLES,
         max_latency_hours=body.max_latency_hours,
         min_arrival_gap_minutes=body.min_arrival_gap_minutes,
+        reserved_window=body.reserved_window,
+        min_send_fill=body.min_send_fill,
+        max_improve_passes=body.max_improve_passes,
+        max_relay_hops=body.max_relay_hops,
     )
 
     extra_warnings: list[str] = []
@@ -380,6 +525,8 @@ async def post_plan(
                 f"shipments must release the rest before the sheet is executable"
             )
 
+    extra_warnings.extend(_storage_warnings(body, plan))
+
     upgrades = {o.village_id: o.trade_office_levels_needed for o in plan.over_budget}
     over = {o.village_id for o in plan.over_budget}
 
@@ -394,6 +541,7 @@ async def post_plan(
                 dispatch=row.dispatch_clock(),
                 arrival=row.arrival_clock(),
                 merchants=row.merchants,
+                first_delivery_hours=row.first_delivery_hours,
             )
             for row in plan.rows
         ],

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -27,6 +27,7 @@ from travian_api.services.distribution.allocation import (
     AllocationError,
     AllocationMode,
     Resource,
+    resolve_resource,
     village_label,
 )
 from travian_api.services.distribution.geometry import MapGeometry
@@ -44,7 +45,9 @@ from travian_api.services.distribution.optimizer import (
 from travian_api.services.distribution.planner import PlannerConfig, craft_plan
 from travian_api.services.distribution.schedule import MINUTES_PER_DAY
 from travian_api.services.distribution.storage import (
+    ProfileSegment,
     simulate_day,
+    simulate_profile_cycle,
     storage_warnings,
     store_status,
 )
@@ -563,6 +566,205 @@ def _explain_over_budget(
             "nearer, or consume the surplus locally."
         )
     return " ".join(parts)
+
+
+class DaySegmentInput(BaseModel):
+    """One allocation profile plus the hours of the day it actually runs."""
+
+    name: str = Field(min_length=1)
+    window: tuple[int, int]
+    """Minutes past midnight (start, end); may wrap past midnight."""
+    allocations: dict[Resource, dict[int, AllocationInput]] = {}
+
+    @field_validator("window")
+    @classmethod
+    def _window_in_day(cls, value: tuple[int, int]) -> tuple[int, int]:
+        if not all(0 <= minute < MINUTES_PER_DAY for minute in value):
+            raise ValueError(f"window minutes must be 0-{MINUTES_PER_DAY - 1}")
+        if value[0] == value[1]:
+            raise ValueError("window is zero-width; give the profile some hours or omit it")
+        return value
+
+
+class DayCheckRequest(BaseModel):
+    """The whole day at once: every profile, each in its own hours.
+
+    Costs zero game requests. Profiles are planned in isolation, but the account
+    lives through all of them every day -- what the day profile ships decides
+    the stock the night profile starts from, so questions like "does the capital
+    cross 90k during the night?" can only be answered by simulating the day as
+    the profiles will actually run it.
+    """
+
+    snapshot: list[VillageSnapshot]
+    segments: list[DaySegmentInput] = Field(min_length=1)
+    crop_ceilings: dict[int, float] = Field(
+        default={},
+        description=(
+            "Operator alert level for a village's crop stock, below capacity -- "
+            "typically an NPC trigger. Crossing it is reported with the hour and "
+            "the profile that was running."
+        ),
+    )
+
+
+class VillageDayResponse(BaseModel):
+    village_id: int
+    village_name: str
+    resource: Resource
+    daily_net: float
+    low: float
+    high: float
+    settled: bool
+
+
+class DayCheckResponse(BaseModel):
+    villages: list[VillageDayResponse]
+    warnings: list[str]
+
+
+def _clock(minute: int) -> str:
+    return f"{minute // 60:02d}:{minute % 60:02d}"
+
+
+@router.post("/day-check", response_model=DayCheckResponse)
+async def post_day_check(
+    body: DayCheckRequest,
+    _user: User = Depends(get_current_user),
+):
+    """Simulate the full day across every profile. Costs zero game requests.
+
+    Deliberate approximation, stated rather than hidden: each segment
+    contributes its plan's NET RATES, not discrete batches. Route phases do not
+    survive a profile switch (the operator recreates the routes), so batch
+    timing across the boundary is unknowable; the discrete-batch overflow check
+    still runs per profile inside POST /plan.
+    """
+    if not body.snapshot:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Snapshot is empty — fetch account state first.",
+        )
+
+    # Overlapping windows would double-ship: two profiles cannot run at once.
+    minutes_covered: set[int] = set()
+    for segment in body.segments:
+        start, end = segment.window
+        span = range(start, end) if start < end else [*range(start, MINUTES_PER_DAY), *range(end)]
+        span = set(span)
+        clash = minutes_covered & span
+        if clash:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"profile windows overlap around {_clock(min(clash))}: two profiles "
+                    f"cannot run at the same time"
+                ),
+            )
+        minutes_covered |= span
+
+    names = {v.village_id: v.name for v in body.snapshot}
+    rate_field = {
+        Resource.LUMBER: "lumber_per_hour",
+        Resource.CLAY: "clay_per_hour",
+        Resource.IRON: "iron_per_hour",
+        Resource.CROP: "crop_per_hour",
+    }
+    stock_field = {
+        Resource.LUMBER: "lumber_stock",
+        Resource.CLAY: "clay_stock",
+        Resource.IRON: "iron_stock",
+        Resource.CROP: "crop_stock",
+    }
+    productions: dict[Resource, dict[int, float]] = {}
+    own_rates: dict[int, dict[Resource, float]] = {}
+    stocks: dict[int, dict[Resource, int]] = {}
+    capacities: dict[int, dict[Resource, int]] = {}
+    for village in body.snapshot:
+        for resource in Resource:
+            own = getattr(village, rate_field[resource])
+            if own is None:
+                continue  # unreadable rate: the village sits this check out
+            productions.setdefault(resource, {})[village.village_id] = float(own)
+            own_rates.setdefault(village.village_id, {})[resource] = float(own)
+            stocks.setdefault(village.village_id, {})[resource] = getattr(
+                village, stock_field[resource]
+            )
+            cap = (
+                village.granary_capacity
+                if resource is Resource.CROP
+                else village.warehouse_capacity
+            )
+            if cap is not None:
+                capacities.setdefault(village.village_id, {})[resource] = cap
+
+    warnings: list[str] = []
+    segments: list[ProfileSegment] = []
+    for segment in body.segments:
+        ship: dict[int, dict[Resource, float]] = {}
+        for resource, per_village in segment.allocations.items():
+            known = productions.get(resource, {})
+            usable = {
+                vid: Allocation(mode=item.mode, value=item.value)
+                for vid, item in per_village.items()
+                if item.mode is not AllocationMode.KEEP and vid in known
+            }
+            if not usable:
+                continue
+            try:
+                resolved = resolve_resource(resource, known, usable, names)
+            except AllocationError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"{segment.name}: {exc}",
+                ) from exc
+            for village in resolved.villages:
+                if abs(village.ship_per_hour) > 0:
+                    ship.setdefault(village.village_id, {})[resource] = village.ship_per_hour
+        segments.append(
+            ProfileSegment(
+                name=segment.name,
+                start_minute=segment.window[0],
+                end_minute=segment.window[1],
+                ship_rates=ship,
+            )
+        )
+
+    trajectories, breaches = simulate_profile_cycle(
+        segments, own_rates, stocks, capacities, body.crop_ceilings
+    )
+
+    for breach in sorted(breaches, key=lambda b: (b.day, b.minute)):
+        label = village_label(breach.village_id, names)
+        when = f"at {_clock(breach.minute)} during {breach.segment}" + (
+            f" on day {breach.day + 1}" if breach.day else " today"
+        )
+        if breach.kind == "ceiling":
+            ceiling = body.crop_ceilings.get(breach.village_id, 0)
+            warnings.append(f"{label}: crop crosses its {ceiling:,.0f} alert level {when}")
+        elif breach.kind == "capacity":
+            warnings.append(
+                f"{label}: {breach.resource.value} hits its store cap {when}; "
+                f"everything past it is lost"
+            )
+        else:
+            warnings.append(f"{label}: {breach.resource.value} runs dry {when}")
+
+    return DayCheckResponse(
+        villages=[
+            VillageDayResponse(
+                village_id=t.village_id,
+                village_name=village_label(t.village_id, names),
+                resource=t.resource,
+                daily_net=t.daily_net,
+                low=t.low,
+                high=t.high,
+                settled=t.settled,
+            )
+            for t in trajectories
+        ],
+        warnings=warnings,
+    )
 
 
 @router.post("/plan", response_model=PlanResponse)

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -49,6 +49,18 @@ router = APIRouter(prefix="/api/distribution", tags=["distribution"])
 DEFAULT_MAP_SPAN = 401
 DEFAULT_SPEED_FIELDS_PER_HOUR = 12.0
 
+# Merchant travel speed is tribe-specific (fields/hour). Wrong speed inflates
+# travel time -> sets_in_flight -> merchant counts, and can flip over_budget.
+# Keyed by Travian tribe id; unknown tribes fall back to the Teuton default.
+_TRIBE_MERCHANT_SPEED: dict[int, float] = {
+    1: 16.0,  # Roman
+    2: 12.0,  # Teuton
+    3: 24.0,  # Gaul
+    6: 16.0,  # Egyptian
+    7: 12.0,  # Hun
+    8: 16.0,  # Spartan
+}
+
 
 class VillageSnapshot(BaseModel):
     """Per-village state, all of it read from the game."""
@@ -250,6 +262,9 @@ async def get_snapshot(session: TravianSession = Depends(get_live_travian_sessio
 
     return SnapshotResponse(
         villages=villages,
+        speed_fields_per_hour=_TRIBE_MERCHANT_SPEED.get(
+            session.tribe_id or 0, DEFAULT_SPEED_FIELDS_PER_HOUR
+        ),
         # Production + stocks here, plus whatever the crop read actually spent
         # (the capacity page is only fetched when some granary is filling).
         requests_used=2 + crop_requests,

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -598,6 +598,14 @@ class DayCheckRequest(BaseModel):
 
     snapshot: list[VillageSnapshot]
     segments: list[DaySegmentInput] = Field(min_length=1)
+    foreign_targets: list[ForeignTarget] = Field(
+        default=[],
+        description=(
+            "The same tributes POST /plan ships. Each per-profile plan carries "
+            "them as absolute targets, so the composite day must drain them too "
+            "or it reads optimistic by 24x the tribute."
+        ),
+    )
     crop_ceilings: dict[int, float] = Field(
         default={},
         description=(
@@ -699,16 +707,64 @@ async def post_day_check(
                 capacities.setdefault(village.village_id, {})[resource] = cap
 
     warnings: list[str] = []
+    # A village with an unreadable rate sits the check out entirely for that
+    # resource -- its allocations are dropped from every segment and its rows
+    # (crop alert included) never appear. Silence here would let the response
+    # look complete while missing a village, so say so once per resource.
+    for resource in Resource:
+        missing = sorted(
+            v.village_id for v in body.snapshot if getattr(v, rate_field[resource]) is None
+        )
+        if missing:
+            note = (
+                f"{resource.value}: no rate could be read for "
+                + ", ".join(village_label(vid, names) for vid in missing)
+                + f", so their {resource.value} sits out the day check"
+            )
+            if resource is Resource.CROP and any(vid in body.crop_ceilings for vid in missing):
+                note += ", crop alert levels included"
+            warnings.append(note)
+
+    # Foreign tributes drain crop in every profile, exactly as POST /plan ships
+    # them (absolute targets on negative sink ids, margin included). The sinks
+    # get no trajectory of their own -- the drain lives in whoever funds them.
+    foreign_ids: dict[int, ForeignTarget] = {}
+    if body.foreign_targets and Resource.CROP not in productions:
+        warnings.append(
+            "crop: no rate could be read for any village, so the foreign tribute "
+            "cannot be simulated -- the day picture is missing that drain"
+        )
+    elif body.foreign_targets:
+        crop_rates = productions[Resource.CROP]
+        for index, target in enumerate(body.foreign_targets):
+            target_id = -(index + 1)
+            foreign_ids[target_id] = target
+            names[target_id] = target.name
+            crop_rates[target_id] = 0.0  # a tribute grows nothing, it only consumes
+
     segments: list[ProfileSegment] = []
     for segment in body.segments:
         ship: dict[int, dict[Resource, float]] = {}
-        for resource, per_village in segment.allocations.items():
+        for resource in Resource:
+            per_village = segment.allocations.get(resource, {})
             known = productions.get(resource, {})
             usable = {
                 vid: Allocation(mode=item.mode, value=item.value)
                 for vid, item in per_village.items()
                 if item.mode is not AllocationMode.KEEP and vid in known
             }
+            if resource is Resource.CROP and foreign_ids:
+                for target_id, target in foreign_ids.items():
+                    owed = target.crop_per_hour * (1.0 + target.safety_margin_pct / 100.0)
+                    usable[target_id] = Allocation(mode=AllocationMode.ABSOLUTE, value=owed)
+                # The sink's demand is funded through the remainder village; a
+                # profile without one leaves the tribute unpaid in those hours,
+                # which the composite would otherwise model silently.
+                if not any(a.mode is AllocationMode.REMAINDER for a in usable.values()):
+                    warnings.append(
+                        f"{segment.name}: no crop remainder village, so nothing funds "
+                        f"the tribute during it -- modeled as unpaid in those hours"
+                    )
             if not usable:
                 continue
             try:
@@ -719,6 +775,8 @@ async def post_day_check(
                     detail=f"{segment.name}: {exc}",
                 ) from exc
             for village in resolved.villages:
+                if village.village_id < 0:
+                    continue  # the sink itself is not simulated; see above
                 if abs(village.ship_per_hour) > 0:
                     ship.setdefault(village.village_id, {})[resource] = village.ship_per_hour
         segments.append(
@@ -739,7 +797,12 @@ async def post_day_check(
         when = f"at {_clock(breach.minute)} during {breach.segment}" + (
             f" on day {breach.day + 1}" if breach.day else " today"
         )
-        if breach.kind == "ceiling":
+        if breach.kind == "above":
+            ceiling = body.crop_ceilings.get(breach.village_id, 0)
+            warnings.append(
+                f"{label}: crop is already above its {ceiling:,.0f} alert level as the day starts"
+            )
+        elif breach.kind == "ceiling":
             ceiling = body.crop_ceilings.get(breach.village_id, 0)
             warnings.append(f"{label}: crop crosses its {ceiling:,.0f} alert level {when}")
         elif breach.kind == "capacity":

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -107,8 +107,10 @@ class PlanRequest(BaseModel):
     config: list[VillageConfig] = []
     # resource -> village_id -> allocation
     allocations: dict[Resource, dict[int, AllocationInput]] = {}
-    merchant_base_capacity: int = EUROPE2_TEUTON.base_capacity
-    trade_office_bonus_per_level: float = EUROPE2_TEUTON.bonus_per_trade_office_level
+    merchant_base_capacity: int = Field(default=EUROPE2_TEUTON.base_capacity, gt=0)
+    trade_office_bonus_per_level: float = Field(
+        default=EUROPE2_TEUTON.bonus_per_trade_office_level, ge=0
+    )
     merchant_reserve: int = Field(default=2, ge=0)
     max_latency_hours: float | None = 2.0
     min_arrival_gap_minutes: int = Field(default=3, ge=0)
@@ -330,6 +332,19 @@ async def post_plan(
                 extra_warnings.append(
                     f"{resource.value}: no production rate is known for any village, "
                     f"so its allocations were ignored"
+                )
+        # A single village with an unreadable rate (crop_per_hour=None is the
+        # normal no-crop-balance snapshot path) must not fail the whole plan:
+        # drop just its allocations, say so, and plan the rest.
+        for resource, per_village in allocations.items():
+            known = productions[resource]
+            unreadable = sorted(vid for vid in per_village if vid not in known)
+            for vid in unreadable:
+                del per_village[vid]
+            if unreadable:
+                extra_warnings.append(
+                    f"{resource.value}: no rate could be read for village(s) "
+                    f"{unreadable}, so their {resource.value} allocations were ignored"
                 )
         # The beat search is pure CPU; off the event loop so it cannot stall
         # WebSocket frames or stealth-timed game requests while the user replans.

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -140,8 +140,37 @@ class VillageConfig(BaseModel):
     )
 
 
+class ForeignTarget(BaseModel):
+    """Crop owed to a village outside the account (profile section 7.3).
+
+    Not a village and deliberately not modelled as one: it has no production, no
+    merchants and no stores, so it can receive crop and never send any. Giving it
+    a village row would invite treating it as one -- the profile is explicit that
+    foreign targets belong in their own section for exactly that reason.
+
+    Supplied by hand because nothing in the game tells us about it: a name to
+    recognise it by, where it is, and how much crop per hour was promised.
+    """
+
+    name: str = Field(min_length=1)
+    x: int
+    y: int
+    crop_per_hour: float = Field(gt=0)
+    safety_margin_pct: float = Field(
+        default=0.0,
+        ge=0,
+        le=100,
+        description=(
+            "Ship this much above the promise. Travel time and rounding mean a "
+            "route sized exactly to the obligation arrives a little short, and "
+            "being short on a tribute is worse than sending a few crop spare."
+        ),
+    )
+
+
 class PlanRequest(BaseModel):
     snapshot: list[VillageSnapshot]
+    foreign_targets: list[ForeignTarget] = []
     config: list[VillageConfig] = []
     # resource -> village_id -> allocation
     allocations: dict[Resource, dict[int, AllocationInput]] = {}
@@ -399,6 +428,8 @@ def _storage_warnings(body: PlanRequest, plan) -> list[str]:
                 shipped.setdefault(route.origin, {}).get(resource, 0.0) - amount
             )
 
+    # Only real villages have stores. A foreign tribute is a sink with no
+    # granary to overflow or starve, and it never appears in body.snapshot.
     for village in body.snapshot:
         vid = village.village_id
         for resource in Resource:
@@ -455,6 +486,24 @@ async def post_plan(
             detail="Snapshot is empty — fetch account state first.",
         )
 
+    # Foreign tributes join the plan as crop SINKS. Negative ids keep them
+    # clearly apart from real villages (which are always positive) so a target
+    # can never be confused for one, and merchant_count=0 makes it structurally
+    # impossible for one to ship anything: it can receive and nothing else.
+    foreign_ids: dict[int, ForeignTarget] = {}
+    for index, target in enumerate(body.foreign_targets):
+        target_id = -(index + 1)
+        foreign_ids[target_id] = target
+        names[target_id] = target.name
+        villages[target_id] = VillageState(
+            village_id=target_id,
+            x=target.x,
+            y=target.y,
+            merchant_count=0,
+            trade_office_level=0,
+            name=target.name,
+        )
+
     rate_field = {
         Resource.LUMBER: "lumber_per_hour",
         Resource.CLAY: "clay_per_hour",
@@ -470,6 +519,11 @@ async def post_plan(
             # than defaulted to 0, which would read as a healthy village.
             if getattr(v, field_name) is not None
         }
+        if resource is Resource.CROP and foreign_ids and rates:
+            # Zero production: a tribute grows nothing, it only consumes. Adding
+            # it to the crop map is what makes resolve_resource deduct the
+            # obligation from the account pool via the remainder village.
+            rates.update({vid: 0.0 for vid in foreign_ids})
         if rates:
             productions[resource] = rates
 
@@ -502,6 +556,14 @@ async def post_plan(
             }
             for resource, per_village in body.allocations.items()
         }
+        if foreign_ids:
+            # The tribute is a fixed retention target at the sink: it must end up
+            # holding exactly what was promised (plus margin), and since it grows
+            # nothing, all of that has to be shipped in.
+            crop_allocations = allocations.setdefault(Resource.CROP, {})
+            for target_id, target in foreign_ids.items():
+                owed = target.crop_per_hour * (1.0 + target.safety_margin_pct / 100.0)
+                crop_allocations[target_id] = Allocation(mode=AllocationMode.ABSOLUTE, value=owed)
         for resource in sorted(set(allocations) - set(productions), key=lambda r: r.value):
             if allocations.pop(resource):
                 extra_warnings.append(
@@ -539,6 +601,34 @@ async def post_plan(
             )
 
     extra_warnings.extend(_storage_warnings(body, plan))
+
+    for target_id, target in foreign_ids.items():
+        suppliers = sorted({row.origin for row in plan.rows if row.destination == target_id})
+        if not suppliers:
+            extra_warnings.append(
+                f"{target.name} ({target.x}|{target.y}) is owed "
+                f"{target.crop_per_hour:,.0f} crop/h but no village could supply it"
+            )
+            continue
+        if len(suppliers) > 1:
+            extra_warnings.append(
+                f"{target.name} ({target.x}|{target.y}) is supplied by "
+                + ", ".join(village_label(vid, names) for vid in suppliers)
+                + " — several routes to keep track of; consider raising one "
+                "supplier's share so a single route covers it"
+            )
+        # Section 7.3: a tribute must not lapse, and the first delivery only
+        # lands after a full one-way trip. Saying so is the difference between
+        # a planned gap and an apparent broken promise.
+        first = max(
+            (row.first_delivery_hours for row in plan.rows if row.destination == target_id),
+            default=0.0,
+        )
+        extra_warnings.append(
+            f"{target.name} ({target.x}|{target.y}): first delivery lands "
+            f"{first:.1f}h after the route is created, so the tribute starts "
+            f"late unless it is covered by hand until then"
+        )
 
     upgrades = {o.village_id: o.trade_office_levels_needed for o in plan.over_budget}
     over = {o.village_id for o in plan.over_budget}

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -11,6 +11,7 @@ re-planning while the operator tunes allocation targets must cost nothing, and
 every fetch is a deliberate, priced action rather than a side effect of typing.
 """
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -35,6 +36,8 @@ from travian_api.services.distribution.merchants import (
 )
 from travian_api.services.distribution.optimizer import VillageState
 from travian_api.services.distribution.planner import PlannerConfig, craft_plan
+from travian_api.web.auth import get_current_user
+from travian_api.web.models.db import User
 from travian_api.web.sessions import TravianSession, get_travian_session
 
 logger = logging.getLogger(__name__)
@@ -182,7 +185,9 @@ async def get_snapshot(session: TravianSession = Depends(get_travian_session)):
         stocks = parse_village_stats_resources(
             await session.http_client.get_html("/village/statistics/resources")
         )
-        crop = await session.building_service.get_all_villages_net_crop(stocks=stocks)
+        crop, crop_requests = await session.building_service.get_all_villages_net_crop(
+            stocks=stocks
+        )
     except TravianError as exc:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
     except Exception as exc:
@@ -191,6 +196,20 @@ async def get_snapshot(session: TravianSession = Depends(get_travian_session)):
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Could not read account state: {exc}",
         ) from exc
+
+    if not production:
+        warnings.append(
+            "no production rates could be read from the statistics page (is Travian "
+            "Plus active?); lumber/clay/iron default to 0/h, so a plan built from "
+            "this snapshot would move nothing"
+        )
+    else:
+        unread = [v.id for v in session.auth_state.villages if v.id not in production]
+        if unread:
+            warnings.append(
+                f"no production rates read for village(s) {unread}; their "
+                f"lumber/clay/iron default to 0/h"
+            )
 
     villages: list[VillageSnapshot] = []
     for village in session.auth_state.villages:
@@ -226,7 +245,9 @@ async def get_snapshot(session: TravianSession = Depends(get_travian_session)):
 
     return SnapshotResponse(
         villages=villages,
-        requests_used=4,
+        # Production + stocks here, plus whatever the crop read actually spent
+        # (the capacity page is only fetched when some granary is filling).
+        requests_used=2 + crop_requests,
         warnings=warnings,
     )
 
@@ -234,12 +255,14 @@ async def get_snapshot(session: TravianSession = Depends(get_travian_session)):
 @router.post("/plan", response_model=PlanResponse)
 async def post_plan(
     body: PlanRequest,
-    _session: TravianSession = Depends(get_travian_session),
+    _user: User = Depends(get_current_user),
 ):
     """Compute a plan. Costs **zero** game requests.
 
     The caller supplies the snapshot it already fetched, so tuning allocation
-    targets is free and the planner stays pure.
+    targets is free and the planner stays pure. Deliberately auth-only: a
+    Travian-session dependency would auto-reconnect (real login traffic) or 403
+    for a computation that never touches the game.
     """
     trade_office = {c.village_id: c.trade_office_level for c in body.config}
     villages = {
@@ -277,13 +300,6 @@ async def post_plan(
         if rates:
             productions[resource] = rates
 
-    allocations = {
-        resource: {
-            vid: Allocation(mode=item.mode, value=item.value) for vid, item in per_village.items()
-        }
-        for resource, per_village in body.allocations.items()
-    }
-
     config = PlannerConfig(
         geometry=MapGeometry(span=body.map_span, speed_fields_per_hour=body.speed_fields_per_hour),
         merchant_model=MerchantModel(
@@ -296,10 +312,40 @@ async def post_plan(
         min_arrival_gap_minutes=body.min_arrival_gap_minutes,
     )
 
+    extra_warnings: list[str] = []
     try:
-        plan = craft_plan(villages, productions, allocations, config)
+        # Explicit `keep` entries mean exactly what an absent entry means, so
+        # they are dropped here rather than allowed to 400 the whole plan when
+        # they reference a village that has since vanished from the snapshot.
+        allocations = {
+            resource: {
+                vid: Allocation(mode=item.mode, value=item.value)
+                for vid, item in per_village.items()
+                if item.mode is not AllocationMode.KEEP
+            }
+            for resource, per_village in body.allocations.items()
+        }
+        for resource in sorted(set(allocations) - set(productions), key=lambda r: r.value):
+            if allocations.pop(resource):
+                extra_warnings.append(
+                    f"{resource.value}: no production rate is known for any village, "
+                    f"so its allocations were ignored"
+                )
+        # The beat search is pure CPU; off the event loop so it cannot stall
+        # WebSocket frames or stealth-timed game requests while the user replans.
+        plan = await asyncio.to_thread(craft_plan, villages, productions, allocations, config)
     except AllocationError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    free_now = {v.village_id: v.merchants_free for v in body.snapshot}
+    for vid in sorted(plan.merchants_committed):
+        committed = plan.merchants_committed[vid]
+        if committed > free_now.get(vid, 0):
+            extra_warnings.append(
+                f"village {vid}: the plan commits {committed} merchants but only "
+                f"{free_now.get(vid, 0)} are free right now — existing routes or "
+                f"shipments must release the rest before the sheet is executable"
+            )
 
     upgrades = {o.village_id: o.trade_office_levels_needed for o in plan.over_budget}
     over = {o.village_id for o in plan.over_budget}
@@ -349,5 +395,5 @@ async def post_plan(
         ],
         total_merchants=plan.total_merchants,
         feasible=plan.is_feasible,
-        warnings=list(plan.warnings),
+        warnings=[*plan.warnings, *extra_warnings],
     )

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -38,7 +38,7 @@ from travian_api.services.distribution.optimizer import VillageState
 from travian_api.services.distribution.planner import PlannerConfig, craft_plan
 from travian_api.web.auth import get_current_user
 from travian_api.web.models.db import User
-from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.sessions import TravianSession, get_live_travian_session
 
 logger = logging.getLogger(__name__)
 
@@ -163,8 +163,11 @@ class PlanResponse(BaseModel):
 
 
 @router.get("/snapshot", response_model=SnapshotResponse)
-async def get_snapshot(session: TravianSession = Depends(get_travian_session)):
+async def get_snapshot(session: TravianSession = Depends(get_live_travian_session)):
     """Read current account state. Costs 3-4 game requests.
+
+    Uses the live session only: this endpoint prices every game request, and
+    an auto-reconnect would spend unreported login traffic first.
 
     Production for lumber/clay/iron comes from the account-wide statistics table,
     where gross equals net -- only crop is consumed. Crop is read separately

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -245,6 +245,19 @@ class SheetRowResponse(BaseModel):
     )
 
 
+class BudgetLegResponse(BaseModel):
+    """One route's contribution to a village's merchant bill."""
+
+    destination: str
+    per_hour: float
+    distance_fields: float
+    one_way_hours: float
+    cycle_hours: int
+    merchants_per_send: int
+    sets_in_flight: int
+    merchants: int
+
+
 class BudgetResponse(BaseModel):
     village_id: int
     committed: int
@@ -252,6 +265,17 @@ class BudgetResponse(BaseModel):
     free: int
     over_budget: bool
     trade_office_levels_needed: int | None = None
+    legs: list[BudgetLegResponse] = []
+    """Where the merchants actually went, biggest bill first."""
+    explanation: str | None = Field(
+        default=None,
+        description=(
+            "Why this village is over budget, in the operator's terms. 'over by "
+            "2' says what happened but not what to do about it: the same excess "
+            "means something different when the trip is the cost than when the "
+            "Trade Office is."
+        ),
+    )
 
 
 class ShortfallResponse(BaseModel):
@@ -454,6 +478,87 @@ def _storage_warnings(body: PlanRequest, plan) -> list[str]:
     return list(storage_warnings(statuses, overflows, names=names))
 
 
+def _budget_legs(
+    village_id: int,
+    plan,
+    geometry: MapGeometry,
+    names: dict[int, str],
+    coords: dict[int, tuple[int, int]],
+) -> list[BudgetLegResponse]:
+    """Every route this village staffs, dearest first."""
+    legs = []
+    for route in plan.routing.routes:
+        if route.origin != village_id:
+            continue
+        legs.append(
+            BudgetLegResponse(
+                destination=village_label(route.destination, names),
+                per_hour=route.hourly_total,
+                distance_fields=geometry.distance(coords[village_id], coords[route.destination]),
+                one_way_hours=route.one_way_minutes / 60.0,
+                cycle_hours=route.cycle_hours,
+                merchants_per_send=route.merchants_per_send,
+                sets_in_flight=route.sets_in_flight,
+                merchants=route.merchants_committed,
+            )
+        )
+    return sorted(legs, key=lambda leg: (-leg.merchants, leg.destination))
+
+
+def _explain_over_budget(
+    label: str,
+    committed: int,
+    spare: int,
+    legs: list[BudgetLegResponse],
+    trade_office_level: int,
+    capacity: int,
+    upgrade: int | None,
+) -> str:
+    """Say why the merchants ran out, in terms that suggest what to do.
+
+    'over by 2' is true and useless. A village can overrun its merchants for two
+    quite different reasons and the fix is different for each: when the trip is
+    long, merchants are tied up in transit and only a shorter haul or a smaller
+    load helps; when the Trade Office is low, each merchant carries little and
+    the upgrade is the answer. So this names whichever dominates rather than
+    stating the arithmetic back.
+    """
+    if not legs:
+        return f"{label} is over its merchant budget, but no route explains it — this is a bug."
+
+    worst = legs[0]
+    parts = [f"{label} needs {committed} merchants but has {spare}."]
+
+    # The two factors multiply, so explain both rather than declaring a winner:
+    # merchants = (cargo / capacity, rounded up) x (round trip / cycle, rounded
+    # up). Naming only the larger one produced advice that argued with itself --
+    # "the Trade Office won't help much... Trade Office +5 would fix it".
+    parts.append(
+        f"Its biggest haul is {worst.per_hour:,.0f}/h to {worst.destination}, "
+        f"{worst.distance_fields:.0f} fields away, and costs {worst.merchants} merchants: "
+        f"{worst.merchants_per_send} per send "
+        f"(each carries {capacity:,} at Trade Office {trade_office_level}), "
+        f"and with a {worst.one_way_hours * 2:.1f}h round trip against a "
+        f"{worst.cycle_hours}h cycle, {worst.sets_in_flight} send(s) are in the air at once."
+    )
+    if len(legs) > 1:
+        others = sum(leg.merchants for leg in legs[1:])
+        rest = "route takes" if len(legs) == 2 else "routes take"
+        parts.append(f"Its other {len(legs) - 1} {rest} {others} more.")
+
+    if upgrade is not None:
+        parts.append(
+            f"Trade Office +{upgrade} raises what each merchant carries and would make this fit."
+        )
+    else:
+        parts.append(
+            "No Trade Office level fixes this: the merchants are tied up in travel time, "
+            "not short of carrying capacity. Ship less from here, send it somewhere "
+            "nearer, or consume the surplus locally."
+        )
+    return " ".join(parts)
+
+
 @router.post("/plan", response_model=PlanResponse)
 async def post_plan(
     body: PlanRequest,
@@ -632,6 +737,7 @@ async def post_plan(
 
     upgrades = {o.village_id: o.trade_office_levels_needed for o in plan.over_budget}
     over = {o.village_id for o in plan.over_budget}
+    coords = {vid: village.coords for vid, village in villages.items()}
 
     return PlanResponse(
         rows=[
@@ -656,6 +762,20 @@ async def post_plan(
                 free=plan.free_merchants(vid),
                 over_budget=vid in over,
                 trade_office_levels_needed=upgrades.get(vid),
+                legs=_budget_legs(vid, plan, config.geometry, names, coords),
+                explanation=(
+                    _explain_over_budget(
+                        village_label(vid, names),
+                        plan.merchants_committed.get(vid, 0),
+                        plan.spare_merchants.get(vid, 0),
+                        _budget_legs(vid, plan, config.geometry, names, coords),
+                        trade_office.get(vid, 0),
+                        config.merchant_model.capacity(trade_office.get(vid, 0)),
+                        upgrades.get(vid),
+                    )
+                    if vid in over
+                    else None
+                ),
             )
             for vid in sorted(villages)
         ],

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -169,6 +169,18 @@ class ForeignTarget(BaseModel):
             "being short on a tribute is worse than sending a few crop spare."
         ),
     )
+    route_eligible: bool = Field(
+        default=False,
+        description=(
+            "Whether Travian will actually let a Gold Club trade route target "
+            "this village. Routes are only allowed to your OWN villages, Wonder "
+            "of the World villages, or artifact villages in your alliance / "
+            "confederacy — not an ordinary ally or sitter village. The operator "
+            "must assert this (it cannot be verified server-side). When false the "
+            "obligation is reported as a MANUAL transfer and is not emitted as a "
+            "route or given merchants in the plan."
+        ),
+    )
 
 
 class PlanRequest(BaseModel):
@@ -876,8 +888,18 @@ async def post_plan(
     # clearly apart from real villages (which are always positive) so a target
     # can never be confused for one, and merchant_count=0 makes it structurally
     # impossible for one to ship anything: it can receive and nothing else.
+    #
+    # Only route-eligible targets (own / WW / alliance-artifact villages) enter
+    # the route optimizer: Travian will not create a Gold Club route to an
+    # ordinary foreign village, so emitting one would be an unexecutable row that
+    # also reserves merchants and crop the operator cannot actually use that way.
+    # Ineligible targets are reported as manual transfers instead.
     foreign_ids: dict[int, ForeignTarget] = {}
+    manual_targets: list[ForeignTarget] = []
     for index, target in enumerate(body.foreign_targets):
+        if not target.route_eligible:
+            manual_targets.append(target)
+            continue
         target_id = -(index + 1)
         foreign_ids[target_id] = target
         names[target_id] = target.name
@@ -930,6 +952,15 @@ async def post_plan(
     )
 
     extra_warnings: list[str] = []
+    for target in manual_targets:
+        extra_warnings.append(
+            f"{target.name} ({target.x}|{target.y}): Travian only allows Gold Club "
+            f"trade routes to your own, Wonder, or alliance/confederacy artifact "
+            f"villages, so its {target.crop_per_hour:.0f}/h crop obligation is a MANUAL "
+            f"transfer — it is not in the route plan and no merchants are reserved for "
+            f"it. Ship it by hand, or mark it route-eligible if it really is one of "
+            f"those villages."
+        )
     try:
         # Explicit `keep` entries mean exactly what an absent entry means, so
         # they are dropped here rather than allowed to 400 the whole plan when
@@ -1003,21 +1034,24 @@ async def post_plan(
                 + " — several routes to keep track of; consider raising one "
                 "supplier's share so a single route covers it"
             )
-        # Section 7.3: a tribute must not lapse, and the first delivery only
-        # lands after a full one-way trip. Saying so is the difference between
-        # a planned gap and an apparent broken promise. With several suppliers
-        # the first crop lands at the EARLIEST route's startup; the slowest
-        # route only marks when the full rate is flowing.
+        # Section 7.3: a tribute must not lapse. A Gold Club route sends at its
+        # scheduled "Send at" time, so the first delivery lands at the next
+        # occurrence of that time plus travel. Worst case — the route is created
+        # just after its send time — that is a full cycle plus travel; this is the
+        # conservative upper bound on how long the operator must cover it by hand.
+        # With several suppliers the earliest route bounds first crop; the slowest
+        # bounds when the full rate is flowing.
         firsts = [row.first_delivery_hours for row in plan.rows if row.destination == target_id]
         first = min(firsts, default=0.0)
         full = max(firsts, default=0.0)
         note = (
-            f"{target.name} ({target.x}|{target.y}): the first crop lands "
-            f"{first:.1f}h after the routes are created"
+            f"{target.name} ({target.x}|{target.y}): the first crop can take up to "
+            f"{first:.1f}h to land (a full cycle plus travel if the route is created "
+            f"just after its scheduled send time)"
         )
         if full > first + 0.05:
-            note += f" and the full tribute only flows from {full:.1f}h"
-        note += ", so it starts late unless covered by hand until then"
+            note += f", and the full tribute up to {full:.1f}h"
+        note += ", so cover it by hand until the first scheduled send lands"
         extra_warnings.append(note)
 
     upgrades = {o.village_id: o.trade_office_levels_needed for o in plan.over_budget}

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -774,6 +774,14 @@ async def post_day_check(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"{segment.name}: {exc}",
                 ) from exc
+            # A profile that does not conserve mass (an absolute receiver with
+            # no remainder to source it) makes resolve_resource emit a warning
+            # and hand back a receiver inflow no route actually supplies.
+            # Discarding it would let the day picture credit crop from nothing
+            # and still report a green all-clear where /plan would show a
+            # shortfall. Surface the warning so the safety check cannot lie.
+            for warning in resolved.warnings:
+                warnings.append(f"{segment.name}: {warning}")
             for village in resolved.villages:
                 if village.village_id < 0:
                     continue  # the sink itself is not simulated; see above

--- a/src/travian_api/web/routes/distribution.py
+++ b/src/travian_api/web/routes/distribution.py
@@ -27,6 +27,7 @@ from travian_api.services.distribution.allocation import (
     AllocationError,
     AllocationMode,
     Resource,
+    village_label,
 )
 from travian_api.services.distribution.geometry import MapGeometry
 from travian_api.services.distribution.merchants import (
@@ -309,7 +310,8 @@ async def get_snapshot(session: TravianSession = Depends(get_live_travian_sessio
         balance = crop.get(vid)
         merchants = stocks.get(vid, {})
         if balance is None:
-            warnings.append(f"village {vid} has no crop balance; it will not be routed for crop")
+            label = village.name or f"village {vid}"
+            warnings.append(f"{label} has no crop balance; it will not be routed for crop")
         villages.append(
             VillageSnapshot(
                 village_id=vid,
@@ -332,11 +334,12 @@ async def get_snapshot(session: TravianSession = Depends(get_live_travian_sessio
             )
         )
 
-    missing_merchants = [v.village_id for v in villages if v.merchants_total == 0]
+    missing_merchants = [v for v in villages if v.merchants_total == 0]
     if missing_merchants:
         warnings.append(
-            f"no merchant count read for village(s) {missing_merchants}; they cannot "
-            f"send until it is known"
+            "no merchant count read for "
+            + ", ".join(v.name or f"village {v.village_id}" for v in missing_merchants)
+            + "; they cannot send until it is known"
         )
 
     return SnapshotResponse(
@@ -416,7 +419,8 @@ def _storage_warnings(body: PlanRequest, plan) -> list[str]:
             statuses.append(store_status(vid, resource, stock, cap, net))
 
     overflows = simulate_day(plan.beat, stocks, capacities, own_rates)
-    return list(storage_warnings(statuses, overflows))
+    names = {v.village_id: v.name for v in body.snapshot if v.name}
+    return list(storage_warnings(statuses, overflows, names=names))
 
 
 @router.post("/plan", response_model=PlanResponse)
@@ -431,6 +435,8 @@ async def post_plan(
     Travian-session dependency would auto-reconnect (real login traffic) or 403
     for a computation that never touches the game.
     """
+    # Warnings are read by a person: name villages the way they do, never by id.
+    names = {v.village_id: v.name for v in body.snapshot if v.name}
     trade_office = {c.village_id: c.trade_office_level for c in body.config}
     villages = {
         v.village_id: VillageState(
@@ -512,8 +518,9 @@ async def post_plan(
                 del per_village[vid]
             if unreadable:
                 extra_warnings.append(
-                    f"{resource.value}: no rate could be read for village(s) "
-                    f"{unreadable}, so their {resource.value} allocations were ignored"
+                    f"{resource.value}: no rate could be read for "
+                    + ", ".join(village_label(vid, names) for vid in unreadable)
+                    + f", so their {resource.value} allocations were ignored"
                 )
         # The beat search is pure CPU; off the event loop so it cannot stall
         # WebSocket frames or stealth-timed game requests while the user replans.
@@ -526,7 +533,7 @@ async def post_plan(
         committed = plan.merchants_committed[vid]
         if committed > free_now.get(vid, 0):
             extra_warnings.append(
-                f"village {vid}: the plan commits {committed} merchants but only "
+                f"{village_label(vid, names)}: the plan commits {committed} merchants but only "
                 f"{free_now.get(vid, 0)} are free right now — existing routes or "
                 f"shipments must release the rest before the sheet is executable"
             )

--- a/src/travian_api/web/routes/farm.py
+++ b/src/travian_api/web/routes/farm.py
@@ -394,6 +394,12 @@ async def scan_defense_strength(
     """
     import time as _time
 
+    # Defense data comes from this account's own raid reports: the same
+    # coordinates mean different data per account, and per world they are
+    # different villages outright. The scope keeps users out of each other's
+    # cache entries (and in-flight futures).
+    cache_scope = f"{session.server_url.rstrip('/')}|{session.player_name}"
+
     async def _generate():
         scan_start = _time.monotonic()
 
@@ -420,7 +426,9 @@ async def scan_defense_strength(
                 continue  # will emit after classification
             coord_key = (slot.target.x, slot.target.y)
             if not body.force_refresh:
-                cached = defense_cache.get(slot.target.x, slot.target.y, slot.last_raid.time)
+                cached = defense_cache.get(
+                    cache_scope, slot.target.x, slot.target.y, slot.last_raid.time
+                )
                 if cached is not None:
                     cached_count += 1
                     continue
@@ -468,7 +476,9 @@ async def scan_defense_strength(
 
             if coord_key not in needs_fetch:
                 # This is a cache hit
-                cached = defense_cache.get(slot.target.x, slot.target.y, slot.last_raid.time)
+                cached = defense_cache.get(
+                    cache_scope, slot.target.x, slot.target.y, slot.last_raid.time
+                )
                 if cached is not None:
                     yield _line(
                         SlotDefenseInfo(
@@ -500,14 +510,14 @@ async def scan_defense_strength(
             )
 
             # Request coalescing
-            inflight = defense_cache.get_inflight(x, y)
+            inflight = defense_cache.get_inflight(cache_scope, x, y)
             if inflight is not None:
                 try:
                     defense_data = await inflight
                 except Exception:
                     defense_data = None
             else:
-                fut = defense_cache.set_inflight(x, y)
+                fut = defense_cache.set_inflight(cache_scope, x, y)
                 try:
                     defense_data = await _fetch_defense_for_coord(session, x, y)
                     fut.set_result(defense_data)
@@ -515,7 +525,7 @@ async def scan_defense_strength(
                     fut.set_exception(exc)
                     defense_data = None
                 finally:
-                    defense_cache.clear_inflight(x, y)
+                    defense_cache.clear_inflight(cache_scope, x, y)
 
             fetched_count += 1
 
@@ -538,7 +548,11 @@ async def scan_defense_strength(
                         | {"type": "result"}
                     )
                     defense_cache.put(
-                        slot.target.x, slot.target.y, slot.last_raid.time, defense_data
+                        cache_scope,
+                        slot.target.x,
+                        slot.target.y,
+                        slot.last_raid.time,
+                        defense_data,
                     )
                 else:
                     yield _line(

--- a/src/travian_api/web/routes/farm.py
+++ b/src/travian_api/web/routes/farm.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 from travian_api.exceptions import TravianError
 from travian_api.web.auth import get_current_user
-from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.sessions import TravianSession, get_travian_session, require_village_id
 
 logger = logging.getLogger(__name__)
 
@@ -237,12 +237,7 @@ async def create_farm_list(
     session: TravianSession = Depends(get_travian_session),
 ):
     """Create a new farm list. Returns the new list ID."""
-    village_id = body.village_id or session.active_village_id
-    if village_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="No village_id provided and no active village set.",
-        )
+    village_id = require_village_id(body.village_id)
     try:
         list_id = await session.farm_service.create_farm_list(village_id, body.name)
     except TravianError as exc:

--- a/src/travian_api/web/routes/farm_builder.py
+++ b/src/travian_api/web/routes/farm_builder.py
@@ -188,13 +188,17 @@ async def get_scan_cache(
     row = result.scalar_one_or_none()
     if not row:
         return ScanCacheOut(has_cache=False)
-    # Check age
-    age = datetime.now(UTC) - row.updated_at
+    # SQLite returns naive datetimes despite the column's timezone=True; the
+    # value was stored in UTC, so restore it before the aware subtraction.
+    updated_at = (
+        row.updated_at.replace(tzinfo=UTC) if row.updated_at.tzinfo is None else row.updated_at
+    )
+    age = datetime.now(UTC) - updated_at
     if age > timedelta(seconds=SCAN_CACHE_MAX_AGE_SECONDS):
         return ScanCacheOut(has_cache=False)
     return ScanCacheOut(
         has_cache=True,
-        updated_at=row.updated_at,
+        updated_at=updated_at,
         scan=json.loads(row.scan_json),
     )
 

--- a/src/travian_api/web/routes/military.py
+++ b/src/travian_api/web/routes/military.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from travian_api.constants import SCOUT_UNITS, BuildingType, TribeType
 from travian_api.exceptions import InvalidTargetError, MilitaryError, TravianError
 from travian_api.web.rate_limit import action_limiter
-from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.sessions import TravianSession, get_travian_session, require_village_id
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ async def send_scouts(
     _=Depends(action_limiter),
 ):
     """Send scouts to a target location (tribe-aware — correct troop slot)."""
-    village_id = body.village_id or session.active_village_id
+    village_id = require_village_id(body.village_id)
     try:
         result = await _send_scouts_safe(
             session=session,
@@ -199,7 +199,7 @@ async def send_raid(
     _=Depends(action_limiter),
 ):
     """Send a raid to a target location."""
-    village_id = body.village_id or session.active_village_id
+    village_id = require_village_id(body.village_id)
     try:
         result = await session.military_service.send_raid(
             x=body.x,

--- a/src/travian_api/web/routes/military.py
+++ b/src/travian_api/web/routes/military.py
@@ -142,12 +142,13 @@ async def send_scouts(
 
 @router.get("/troops")
 async def get_available_troops(
-    village_id: int = None,
+    village_id: int | None = None,
     session: TravianSession = Depends(get_travian_session),
 ):
     """Get available (idle) troops at the rally point for a village."""
+    vid = require_village_id(village_id)
     try:
-        troops = await session.military_service.get_available_troops(village_id)
+        troops = await session.military_service.get_available_troops(vid)
         return troops
     except Exception as exc:
         logger.warning("Failed to get troops: %s", exc)
@@ -165,9 +166,10 @@ async def get_smithy_levels(
     ``found=False`` means the village has no smithy built yet — research dict
     stays all zeros.
     """
+    vid = require_village_id(village_id)
     try:
         smithy = await session.building_service.find_building(
-            int(BuildingType.BLACKSMITH), village_id=village_id
+            int(BuildingType.BLACKSMITH), village_id=vid
         )
         if not smithy:
             return {
@@ -177,7 +179,7 @@ async def get_smithy_levels(
             }
         research = await session.military_service.get_smithy_research_levels(
             smithy_slot=smithy.slot_id,
-            village_id=village_id,
+            village_id=vid,
             tribe_id=session.tribe_id or 0,
         )
         return {

--- a/src/travian_api/web/routes/queue.py
+++ b/src/travian_api/web/routes/queue.py
@@ -114,7 +114,8 @@ _TEMPLATES = {
         "label": "Resource Focus",
         "description": "Level up all resource fields evenly to 5, then 8",
         "yaml": (
-            "village_id: auto\n"
+            "# Set village_id to your target village id before running.\n"
+            "village_id: 0\n"
             "plan:\n"
             "  - building: Woodcutter\n"
             "    target: 8\n"
@@ -134,7 +135,8 @@ _TEMPLATES = {
         "label": "Roman Military",
         "description": "Barracks, Academy, Smithy, and Horse Drinking Trough",
         "yaml": (
-            "village_id: auto\n"
+            "# Set village_id to your target village id before running.\n"
+            "village_id: 0\n"
             "plan:\n"
             "  - building: Barracks\n"
             "    target: 15\n"
@@ -154,7 +156,8 @@ _TEMPLATES = {
         "label": "Teuton Raider",
         "description": "Barracks and Stable for early raiding",
         "yaml": (
-            "village_id: auto\n"
+            "# Set village_id to your target village id before running.\n"
+            "village_id: 0\n"
             "plan:\n"
             "  - building: Barracks\n"
             "    target: 15\n"
@@ -171,7 +174,8 @@ _TEMPLATES = {
         "label": "Gaul Defense",
         "description": "Palisade, Trapper, and Stable for defensive play",
         "yaml": (
-            "village_id: auto\n"
+            "# Set village_id to your target village id before running.\n"
+            "village_id: 0\n"
             "plan:\n"
             "  - building: Palisade\n"
             "    target: 15\n"
@@ -188,7 +192,8 @@ _TEMPLATES = {
         "label": "Economy Starter",
         "description": "Main Building, Warehouse, Granary, Marketplace",
         "yaml": (
-            "village_id: auto\n"
+            "# Set village_id to your target village id before running.\n"
+            "village_id: 0\n"
             "plan:\n"
             "  - building: Main Building\n"
             "    target: 15\n"
@@ -208,7 +213,8 @@ _TEMPLATES = {
         "label": "Second Village",
         "description": "Residence, Warehouse, and Granary for settling",
         "yaml": (
-            "village_id: auto\n"
+            "# Set village_id to your target village id before running.\n"
+            "village_id: 0\n"
             "plan:\n"
             "  - building: Residence\n"
             "    target: 10\n"
@@ -244,6 +250,14 @@ async def validate_build_plan(
     Nothing is executed -- this is a read-only operation.
     """
     plan = _parse_yaml_to_plan(body.yaml_content)
+
+    # Reject a village-less plan the same way the runner does, so validate and
+    # run agree — a template placeholder must be filled in before either.
+    if not plan.village_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Build plan is missing village_id. Set it to your target village.",
+        )
 
     # Collect status messages emitted during resolve_slots
     messages: list[str] = []

--- a/src/travian_api/web/routes/recon.py
+++ b/src/travian_api/web/routes/recon.py
@@ -11,7 +11,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from travian_api.services.recon_account import recon_account_manager
@@ -34,6 +34,9 @@ class ReconStatusResponse(BaseModel):
     username: str | None = None
     # "stored" (set here), "env" (.env fallback), or None when unconfigured.
     source: str | None = None
+    # False for everyone but the instance operator, so the UI can hide the
+    # management controls instead of offering buttons that will 403.
+    manageable: bool = True
 
 
 class ReconTestResponse(BaseModel):
@@ -42,12 +45,41 @@ class ReconTestResponse(BaseModel):
     detail: str | None = None
 
 
-def _status() -> ReconStatusResponse:
+def _status(manageable: bool) -> ReconStatusResponse:
     return ReconStatusResponse(
         configured=recon_account_manager.is_configured(),
-        username=recon_account_manager.get_proxy_username(),
+        # The recon username is the operator's business only.
+        username=recon_account_manager.get_proxy_username() if manageable else None,
         source=recon_account_manager.credentials_source(),
+        manageable=manageable,
     )
+
+
+async def _first_user_id(db: AsyncSession) -> int | None:
+    result = await db.execute(select(func.min(User.id)))
+    return result.scalar()
+
+
+async def get_instance_operator(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """The earliest-registered user, the only one who manages shared state.
+
+    ReconAccountManager is a process-global singleton backed by a single
+    credential row: letting any authenticated user rotate or clear it would let
+    one web user silently break every other user's recon setup.
+    """
+    first_id = await _first_user_id(db)
+    if first_id is not None and user.id != first_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Only the instance operator (the first registered user) can "
+                "manage the shared background account."
+            ),
+        )
+    return user
 
 
 async def load_stored_credentials(db: AsyncSession) -> bool:
@@ -67,15 +99,19 @@ async def load_stored_credentials(db: AsyncSession) -> bool:
 
 
 @router.get("/status", response_model=ReconStatusResponse)
-async def get_recon_status(_user: User = Depends(get_current_user)):
+async def get_recon_status(
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
     """Whether a background account is available, and where it came from."""
-    return _status()
+    first_id = await _first_user_id(db)
+    return _status(manageable=first_id is None or user.id == first_id)
 
 
 @router.put("/credentials", response_model=ReconStatusResponse)
 async def set_recon_credentials(
     body: ReconCredentialRequest,
-    _user: User = Depends(get_current_user),
+    _operator: User = Depends(get_instance_operator),
     db: AsyncSession = Depends(get_db),
 ):
     """Store rotated credentials and apply them to the live runtime."""
@@ -100,12 +136,12 @@ async def set_recon_credentials(
     await recon_account_manager.invalidate()
     logger.info("Recon credentials rotated; cached recon sessions dropped")
 
-    return _status()
+    return _status(manageable=True)
 
 
 @router.delete("/credentials", response_model=ReconStatusResponse)
 async def clear_recon_credentials(
-    _user: User = Depends(get_current_user),
+    _operator: User = Depends(get_instance_operator),
     db: AsyncSession = Depends(get_db),
 ):
     """Forget stored credentials and fall back to the .env values, if any."""
@@ -118,12 +154,13 @@ async def clear_recon_credentials(
     await recon_account_manager.invalidate()
     logger.info("Stored recon credentials cleared; falling back to environment")
 
-    return _status()
+    return _status(manageable=True)
 
 
 @router.post("/test", response_model=ReconTestResponse)
 async def test_recon_credentials(
     session: TravianSession = Depends(get_travian_session),
+    _operator: User = Depends(get_instance_operator),
 ):
     """Attempt a real login with the active recon credentials.
 

--- a/src/travian_api/web/routes/recon.py
+++ b/src/travian_api/web/routes/recon.py
@@ -27,6 +27,9 @@ router = APIRouter(prefix="/api/recon", tags=["recon"])
 class ReconCredentialRequest(BaseModel):
     username: str = Field(min_length=1)
     password: str = Field(min_length=1)
+    # The world this recon account exists on. None = any (single-world
+    # deployments); when set, the account only masks reads on that server.
+    server_url: str | None = None
 
 
 class ReconStatusResponse(BaseModel):
@@ -93,7 +96,9 @@ async def load_stored_credentials(db: AsyncSession) -> bool:
         recon_account_manager.clear_credentials()
         return False
     recon_account_manager.set_credentials(
-        row.travian_username, decrypt_credential(row.encrypted_password)
+        row.travian_username,
+        decrypt_credential(row.encrypted_password),
+        server_url=getattr(row, "server_url", None),
     )
     return True
 
@@ -118,19 +123,22 @@ async def set_recon_credentials(
     result = await db.execute(select(ReconCredential).order_by(ReconCredential.id).limit(1))
     row = result.scalar_one_or_none()
 
+    server_url = body.server_url.rstrip("/") if body.server_url else None
     if row is None:
         row = ReconCredential(
             travian_username=body.username,
             encrypted_password=encrypt_credential(body.password),
+            server_url=server_url,
         )
         db.add(row)
     else:
         row.travian_username = body.username
         row.encrypted_password = encrypt_credential(body.password)
+        row.server_url = server_url
 
     await db.commit()
 
-    recon_account_manager.set_credentials(body.username, body.password)
+    recon_account_manager.set_credentials(body.username, body.password, server_url=server_url)
     # A cached ReconAccount holds the old password and a sticky failure window;
     # without dropping it the rotation could not take effect.
     await recon_account_manager.invalidate()

--- a/src/travian_api/web/routes/recon.py
+++ b/src/travian_api/web/routes/recon.py
@@ -159,8 +159,10 @@ async def clear_recon_credentials(
 
 @router.post("/test", response_model=ReconTestResponse)
 async def test_recon_credentials(
-    session: TravianSession = Depends(get_travian_session),
+    # Authorization first: dependencies resolve in signature order, and the
+    # session dependency may spend a real auto-reconnect login.
     _operator: User = Depends(get_instance_operator),
+    session: TravianSession = Depends(get_travian_session),
 ):
     """Attempt a real login with the active recon credentials.
 

--- a/src/travian_api/web/routes/recon.py
+++ b/src/travian_api/web/routes/recon.py
@@ -18,6 +18,7 @@ from travian_api.services.recon_account import recon_account_manager
 from travian_api.web.auth import decrypt_credential, encrypt_credential, get_current_user
 from travian_api.web.models.db import ReconCredential, User, get_db
 from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.url_guard import ensure_safe_server_url
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,10 @@ async def set_recon_credentials(
     row = result.scalar_one_or_none()
 
     server_url = body.server_url.rstrip("/") if body.server_url else None
+    if server_url:
+        # The recon account logs into this URL in the background; it must
+        # pass the same SSRF guard as a foreground connect.
+        await ensure_safe_server_url(server_url)
     if row is None:
         row = ReconCredential(
             travian_username=body.username,

--- a/src/travian_api/web/routes/reports.py
+++ b/src/travian_api/web/routes/reports.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from travian_api.exceptions import ReportError, ReportNotFoundError, TravianError
-from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.sessions import TravianSession, get_travian_session, require_village_id
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +125,7 @@ async def analyze_reports(
     """Analyze raid reports and return prioritized target recommendations."""
     from travian_api.models.raid_analyzer import AnalyzerSettings
 
-    village_id = body.village_id or session.active_village_id
+    village_id = require_village_id(body.village_id)
 
     settings = AnalyzerSettings(
         village_id=village_id,

--- a/src/travian_api/web/routes/scout.py
+++ b/src/travian_api/web/routes/scout.py
@@ -7,7 +7,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
-from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.sessions import TravianSession, get_travian_session, require_village_id
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +82,7 @@ async def scan_map(
         )
 
     # Resolve center village
-    vid = body.village_id or session.active_village_id
+    vid = require_village_id(body.village_id)
     center_village = next((v for v in session.auth_state.villages if v.id == vid), None)
     if not center_village:
         raise HTTPException(

--- a/src/travian_api/web/routes/status_export.py
+++ b/src/travian_api/web/routes/status_export.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from travian_api.constants import TROOP_MAPPINGS, TribeType
 from travian_api.exceptions import TravianError
+from travian_api.models.buildings import Resources
 from travian_api.web.sessions import TravianSession, get_travian_session
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,22 @@ def _troop_name(tribe_id: int, key: str) -> str:
     """Resolve t1-t10 key to a human-readable troop name."""
     mapping = TROOP_MAPPINGS.get(TribeType(tribe_id), {})
     return mapping.get(key, key)
+
+
+def _crop_status(resources: Resources) -> dict:
+    """Starvation view for one village, derived from the NET crop rate.
+
+    ``crop_per_hour`` (Travian's ``production.l4``) is the only field that means
+    net crop. ``free_crop`` (``l5``) is not net and can be positive while the
+    granary drains, so it must never drive this — see
+    docs/20-resource-production.md.
+    """
+    net = resources.crop_per_hour
+    return {
+        "net_per_hour": net,
+        "starving": net < 0,
+        "hours_until_empty": round(resources.crop / -net, 2) if net < 0 else None,
+    }
 
 
 @router.get("/export")
@@ -65,6 +82,7 @@ async def export_player_status(
             "x": village.x,
             "y": village.y,
             "resources": None,
+            "crop": None,
             "troops": troops,
         }
 
@@ -77,6 +95,7 @@ async def export_player_status(
             else:
                 resources = await session.building_service.get_resources(village_id=vid)
             entry["resources"] = resources.model_dump()
+            entry["crop"] = _crop_status(resources)
         except Exception as exc:
             logger.warning("Failed to fetch village %s: %s", vid, exc)
             entry["error"] = str(exc)

--- a/src/travian_api/web/routes/status_export.py
+++ b/src/travian_api/web/routes/status_export.py
@@ -15,9 +15,16 @@ router = APIRouter(prefix="/api/status", tags=["status"])
 
 
 def _troop_name(tribe_id: int, key: str) -> str:
-    """Resolve t1-t10 key to a human-readable troop name."""
-    mapping = TROOP_MAPPINGS.get(TribeType(tribe_id), {})
-    return mapping.get(key, key)
+    """Resolve t1-t10 key to a human-readable troop name.
+
+    An unknown tribe — 0 when GraphQL enrichment failed during login — keeps
+    the raw t1-t10 key rather than 500ing the whole export.
+    """
+    try:
+        tribe = TribeType(tribe_id)
+    except ValueError:
+        return key
+    return TROOP_MAPPINGS.get(tribe, {}).get(key, key)
 
 
 def _crop_status(resources: Resources) -> dict:

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -268,12 +268,18 @@ async def save_server(
         )
         .order_by(TravianCredential.id.desc())
     )
-    # first(), not scalar_one_or_none(): legacy databases may hold duplicate
-    # rows for the same account, and resaving must repair, not 500.
-    cred = result.scalars().first()
+    # all(), not scalar_one_or_none(): legacy databases may hold duplicate
+    # rows for the same account, and resaving must repair them, not 500.
+    rows = list(result.scalars().all())
+    cred = rows[0] if rows else None
     if cred is not None:
         cred.encrypted_password = encrypt_credential(body.password)
         cred.label = body.label
+        # Remove stale duplicates outright: auto-restore sorts by
+        # last_connected, so a more recently stamped OLD row would otherwise
+        # keep shadowing the row just rotated.
+        for stale in rows[1:]:
+            await db.delete(stale)
     else:
         cred = TravianCredential(
             user_id=user.id,

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -135,6 +135,10 @@ async def connect(
             username=body.username,
             password=body.password,
         )
+    except HTTPException:
+        # Control-flow errors from the session manager (e.g. 409 while
+        # operations are running) must reach the client as themselves.
+        raise
     except Exception as exc:
         logger.exception("Travian connect failed for user %s", user.id)
         raise HTTPException(
@@ -188,6 +192,8 @@ async def reconnect(
             username=username,
             password=password,
         )
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("Travian reconnect failed for user %s", user.id)
         raise HTTPException(
@@ -296,6 +302,8 @@ async def connect_saved_server(
             username=cred.travian_username,
             password=password,
         )
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception(
             "Travian connect via saved server %s failed for user %s", server_id, user.id

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -111,17 +111,21 @@ async def _update_last_connected(
     try:
         result = await db.execute(
             select(TravianCredential)
-            .where(
-                TravianCredential.user_id == user_id,
-                TravianCredential.server_url == server_url,
-                TravianCredential.travian_username == travian_username,
-            )
+            .where(TravianCredential.user_id == user_id)
             .order_by(TravianCredential.id.desc())
         )
-        # first() on the newest row, not scalar_one_or_none(): databases from
-        # before the upsert in save_server may hold duplicates, and the row
-        # stamped here must be the one save_server keeps current.
-        cred = result.scalars().first()
+        # Matching happens in Python on NORMALIZED urls: the runtime identity
+        # rstrips trailing slashes, and legacy rows may carry either spelling.
+        # Newest matching row first — the one save_server keeps current.
+        server = server_url.rstrip("/")
+        cred = next(
+            (
+                row
+                for row in result.scalars().all()
+                if row.server_url.rstrip("/") == server and row.travian_username == travian_username
+            ),
+            None,
+        )
         if cred is not None:
             cred.last_connected = datetime.now(UTC)
             await db.commit()
@@ -261,18 +265,21 @@ async def save_server(
     """
     result = await db.execute(
         select(TravianCredential)
-        .where(
-            TravianCredential.user_id == user.id,
-            TravianCredential.server_url == body.server_url,
-            TravianCredential.travian_username == body.username,
-        )
+        .where(TravianCredential.user_id == user.id)
         .order_by(TravianCredential.id.desc())
     )
-    # all(), not scalar_one_or_none(): legacy databases may hold duplicate
-    # rows for the same account, and resaving must repair them, not 500.
-    rows = list(result.scalars().all())
+    # Matching happens in Python on NORMALIZED urls (the runtime identity
+    # rstrips trailing slashes), and over all rows — legacy databases may hold
+    # duplicates or either slash spelling, and resaving must repair them.
+    server = body.server_url.rstrip("/")
+    rows = [
+        row
+        for row in result.scalars().all()
+        if row.server_url.rstrip("/") == server and row.travian_username == body.username
+    ]
     cred = rows[0] if rows else None
     if cred is not None:
+        cred.server_url = server  # repair a legacy trailing slash in place
         cred.encrypted_password = encrypt_credential(body.password)
         cred.label = body.label
         # Remove stale duplicates outright: auto-restore sorts by
@@ -283,7 +290,7 @@ async def save_server(
     else:
         cred = TravianCredential(
             user_id=user.id,
-            server_url=body.server_url,
+            server_url=server,
             travian_username=body.username,
             encrypted_password=encrypt_credential(body.password),
             label=body.label,

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -102,18 +102,26 @@ async def _update_last_connected(
     server_url: str,
     travian_username: str,
 ) -> None:
-    """If a saved credential matches the server/username, update its timestamp."""
-    result = await db.execute(
-        select(TravianCredential).where(
-            TravianCredential.user_id == user_id,
-            TravianCredential.server_url == server_url,
-            TravianCredential.travian_username == travian_username,
+    """If a saved credential matches the server/username, update its timestamp.
+
+    Best-effort: this runs AFTER a successful Travian login, so a database
+    hiccup here must not make the whole connect report failure while a live
+    session sits installed in the manager.
+    """
+    try:
+        result = await db.execute(
+            select(TravianCredential).where(
+                TravianCredential.user_id == user_id,
+                TravianCredential.server_url == server_url,
+                TravianCredential.travian_username == travian_username,
+            )
         )
-    )
-    cred = result.scalar_one_or_none()
-    if cred is not None:
-        cred.last_connected = datetime.now(UTC)
-        await db.commit()
+        cred = result.scalar_one_or_none()
+        if cred is not None:
+            cred.last_connected = datetime.now(UTC)
+            await db.commit()
+    except Exception:
+        logger.warning("Connected user %s but could not stamp last_connected", user_id)
 
 
 # ---------------------------------------------------------------------------

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -97,7 +97,15 @@ def _credential_to_response(cred: TravianCredential) -> SavedServerResponse:
         server_url=cred.server_url,
         username=cred.travian_username,
         label=cred.label,
-        last_connected=cred.last_connected.isoformat() if cred.last_connected else None,
+        # SQLite returns DateTime(timezone=True) values with tzinfo stripped,
+        # even though they were written with datetime.now(UTC). Serialized bare,
+        # the ISO string has no offset and a non-UTC browser reads the UTC wall
+        # time as local. Restore the marker before it leaves the server.
+        last_connected=(
+            cred.last_connected.replace(tzinfo=UTC).isoformat()
+            if cred.last_connected and cred.last_connected.tzinfo is None
+            else (cred.last_connected.isoformat() if cred.last_connected else None)
+        ),
     )
 
 

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -412,12 +412,10 @@ async def connect_saved_server(
     # A proven-good login clears any failed-restore backoff (see /connect).
     reset_restore_backoff(user.id)
 
-    # 4. Update last_connected timestamp — best-effort bookkeeping: a DB
-    # hiccup here must not report the successful login as a failure.
-    try:
-        cred.last_connected = datetime.now(UTC)
-        await db.commit()
-    except Exception:
-        logger.warning("Connected user %s but could not stamp last_connected", user.id)
+    # 4. Update last_connected through the shared, duplicate-aware helper the
+    # /connect and /reconnect paths use, so legacy duplicate rows get the row
+    # holding the password that just authenticated stamped — not merely the one
+    # looked up by id. Best-effort: a DB hiccup must not fail the live login.
+    await _update_last_connected(db, user.id, cred.server_url, cred.travian_username, password)
 
     return _session_to_status(session)

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -14,7 +14,7 @@ from travian_api.web.auth import (
     get_current_user,
 )
 from travian_api.web.models.db import TravianCredential, User, get_db
-from travian_api.web.sessions import TravianSession, session_manager
+from travian_api.web.sessions import TravianSession, session_manager, try_restore_session
 
 logger = logging.getLogger(__name__)
 
@@ -160,8 +160,16 @@ async def disconnect(user: User = Depends(get_current_user)):
 
 @router.get("/status", response_model=TravianStatusResponse)
 async def get_status(user: User = Depends(get_current_user)):
-    """Return the current Travian connection state and player info."""
+    """Return the current Travian connection state and player info.
+
+    Attempts a saved-credential restore when no live session exists: the
+    frontend's initial mount and health poll key off this route, so without
+    the attempt a backend restart sends users to /connect despite saved
+    credentials. The restore is best-effort and returns None on failure.
+    """
     session = session_manager.get(user.id)
+    if session is None:
+        session = await try_restore_session(user.id)
     return _session_to_status(session)
 
 

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -116,7 +116,9 @@ async def _update_last_connected(
                 TravianCredential.travian_username == travian_username,
             )
         )
-        cred = result.scalar_one_or_none()
+        # first(), not scalar_one_or_none(): databases from before the upsert
+        # in save_server may hold duplicate rows for the same account.
+        cred = result.scalars().first()
         if cred is not None:
             cred.last_connected = datetime.now(UTC)
             await db.commit()
@@ -248,15 +250,32 @@ async def save_server(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Save new Travian server credentials (password is encrypted at rest)."""
-    cred = TravianCredential(
-        user_id=user.id,
-        server_url=body.server_url,
-        travian_username=body.username,
-        encrypted_password=encrypt_credential(body.password),
-        label=body.label,
+    """Save Travian server credentials (password is encrypted at rest).
+
+    Upserts on (user, server, username): duplicates would break the
+    last_connected stamping and let auto-restore pick an older row with an
+    outdated password, so saving the same account again rotates it in place.
+    """
+    result = await db.execute(
+        select(TravianCredential).where(
+            TravianCredential.user_id == user.id,
+            TravianCredential.server_url == body.server_url,
+            TravianCredential.travian_username == body.username,
+        )
     )
-    db.add(cred)
+    cred = result.scalar_one_or_none()
+    if cred is not None:
+        cred.encrypted_password = encrypt_credential(body.password)
+        cred.label = body.label
+    else:
+        cred = TravianCredential(
+            user_id=user.id,
+            server_url=body.server_url,
+            travian_username=body.username,
+            encrypted_password=encrypt_credential(body.password),
+            label=body.label,
+        )
+        db.add(cred)
     await db.commit()
     await db.refresh(cred)
     return _credential_to_response(cred)

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -412,10 +412,19 @@ async def connect_saved_server(
     # A proven-good login clears any failed-restore backoff (see /connect).
     reset_restore_backoff(user.id)
 
-    # 4. Update last_connected through the shared, duplicate-aware helper the
-    # /connect and /reconnect paths use, so legacy duplicate rows get the row
-    # holding the password that just authenticated stamped — not merely the one
-    # looked up by id. Best-effort: a DB hiccup must not fail the live login.
-    await _update_last_connected(db, user.id, cred.server_url, cred.travian_username, password)
+    # 4. Stamp THIS row directly. Deliberately not the duplicate-aware
+    # _update_last_connected helper that /connect and /reconnect use: there the
+    # password arrives from the request or session and genuinely is not tied to a
+    # row, so the helper has to search for the row it authenticated. Here the
+    # password was just decrypted from `cred` itself, so `cred` always matches --
+    # the helper could only ever pick a *different* duplicate holding the same
+    # password (it orders by id desc), stamping a row the user did not click and
+    # moving which row auto-restore treats as canonical. Best-effort: a DB hiccup
+    # must not report the successful login as a failure.
+    try:
+        cred.last_connected = datetime.now(UTC)
+        await db.commit()
+    except Exception:
+        logger.warning("Connected user %s but could not stamp last_connected", user.id)
 
     return _session_to_status(session)

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -329,8 +329,12 @@ async def connect_saved_server(
             detail=f"Failed to connect to Travian server: {exc}",
         )
 
-    # 4. Update last_connected timestamp
-    cred.last_connected = datetime.now(UTC)
-    await db.commit()
+    # 4. Update last_connected timestamp — best-effort bookkeeping: a DB
+    # hiccup here must not report the successful login as a failure.
+    try:
+        cred.last_connected = datetime.now(UTC)
+        await db.commit()
+    except Exception:
+        logger.warning("Connected user %s but could not stamp last_connected", user.id)
 
     return _session_to_status(session)

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -110,14 +110,17 @@ async def _update_last_connected(
     """
     try:
         result = await db.execute(
-            select(TravianCredential).where(
+            select(TravianCredential)
+            .where(
                 TravianCredential.user_id == user_id,
                 TravianCredential.server_url == server_url,
                 TravianCredential.travian_username == travian_username,
             )
+            .order_by(TravianCredential.id.desc())
         )
-        # first(), not scalar_one_or_none(): databases from before the upsert
-        # in save_server may hold duplicate rows for the same account.
+        # first() on the newest row, not scalar_one_or_none(): databases from
+        # before the upsert in save_server may hold duplicates, and the row
+        # stamped here must be the one save_server keeps current.
         cred = result.scalars().first()
         if cred is not None:
             cred.last_connected = datetime.now(UTC)
@@ -257,13 +260,17 @@ async def save_server(
     outdated password, so saving the same account again rotates it in place.
     """
     result = await db.execute(
-        select(TravianCredential).where(
+        select(TravianCredential)
+        .where(
             TravianCredential.user_id == user.id,
             TravianCredential.server_url == body.server_url,
             TravianCredential.travian_username == body.username,
         )
+        .order_by(TravianCredential.id.desc())
     )
-    cred = result.scalar_one_or_none()
+    # first(), not scalar_one_or_none(): legacy databases may hold duplicate
+    # rows for the same account, and resaving must repair, not 500.
+    cred = result.scalars().first()
     if cred is not None:
         cred.encrypted_password = encrypt_credential(body.password)
         cred.label = body.label

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -381,7 +381,7 @@ async def connect_saved_server(
             "Saved credential %s for user %s is undecryptable: %r", server_id, user.id, exc
         )
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=422,
             detail="Saved credentials could not be decrypted. Re-save this server.",
         )
 

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -14,7 +14,12 @@ from travian_api.web.auth import (
     get_current_user,
 )
 from travian_api.web.models.db import TravianCredential, User, get_db
-from travian_api.web.sessions import TravianSession, session_manager, try_restore_session
+from travian_api.web.sessions import (
+    TravianSession,
+    reset_restore_backoff,
+    session_manager,
+    try_restore_session,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -214,8 +219,11 @@ async def reconnect(
     if session is None:
         # "Current or last": after a restart or eviction there is no in-memory
         # session — exactly when a reconnect is needed most. An explicit
-        # reconnect request also overrides an earlier explicit disconnect.
+        # reconnect overrides an earlier explicit disconnect AND the
+        # failed-restore backoff (which only exists to throttle per-request
+        # auto-reconnects, never an intentional retry).
         session_manager.clear_explicit_disconnect(user.id)
+        reset_restore_backoff(user.id)
         restored = await try_restore_session(user.id)
         if restored is not None:
             return _session_to_status(restored)
@@ -364,8 +372,18 @@ async def connect_saved_server(
             detail="Saved server not found",
         )
 
-    # 2. Decrypt the password
-    password = decrypt_credential(cred.encrypted_password)
+    # 2. Decrypt the password. A row that cannot be decrypted (secret rotated,
+    # corrupt legacy row) is a controlled error, not a 500.
+    try:
+        password = decrypt_credential(cred.encrypted_password)
+    except Exception as exc:
+        logger.warning(
+            "Saved credential %s for user %s is undecryptable: %r", server_id, user.id, exc
+        )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Saved credentials could not be decrypted. Re-save this server.",
+        )
 
     # 3. Connect via session_manager
     try:

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -212,6 +212,13 @@ async def reconnect(
     """
     session = session_manager.get(user.id)
     if session is None:
+        # "Current or last": after a restart or eviction there is no in-memory
+        # session — exactly when a reconnect is needed most. An explicit
+        # reconnect request also overrides an earlier explicit disconnect.
+        session_manager.clear_explicit_disconnect(user.id)
+        restored = await try_restore_session(user.id)
+        if restored is not None:
+            return _session_to_status(restored)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No active session to reconnect. Use POST /api/travian/connect instead.",

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -20,6 +20,7 @@ from travian_api.web.sessions import (
     session_manager,
     try_restore_session,
 )
+from travian_api.web.url_guard import ensure_safe_server_url
 
 logger = logging.getLogger(__name__)
 
@@ -302,6 +303,9 @@ async def save_server(
     last_connected stamping and let auto-restore pick an older row with an
     outdated password, so saving the same account again rotates it in place.
     """
+    # Validated at save time as well as at connect time: a saved row is
+    # replayed later by auto-restore, which deliberately skips the guard.
+    await ensure_safe_server_url(body.server_url)
     result = await db.execute(
         select(TravianCredential)
         .where(TravianCredential.user_id == user.id)

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -101,6 +101,7 @@ async def _update_last_connected(
     user_id: int,
     server_url: str,
     travian_username: str,
+    password: str | None = None,
 ) -> None:
     """If a saved credential matches the server/username, update its timestamp.
 
@@ -116,16 +117,26 @@ async def _update_last_connected(
         )
         # Matching happens in Python on NORMALIZED urls: the runtime identity
         # rstrips trailing slashes, and legacy rows may carry either spelling.
-        # Newest matching row first — the one save_server keeps current.
         server = server_url.rstrip("/")
-        cred = next(
-            (
-                row
-                for row in result.scalars().all()
-                if row.server_url.rstrip("/") == server and row.travian_username == travian_username
-            ),
-            None,
-        )
+        rows = [
+            row
+            for row in result.scalars().all()
+            if row.server_url.rstrip("/") == server and row.travian_username == travian_username
+        ]
+        # Among legacy duplicates, stamp the row holding the password that
+        # JUST authenticated — bumping the newest regardless would keep
+        # auto-restore (which sorts by last_connected) pinned to a stale one.
+        cred = None
+        if password is not None:
+            for row in rows:
+                try:
+                    if decrypt_credential(row.encrypted_password) == password:
+                        cred = row
+                        break
+                except Exception:
+                    continue
+        if cred is None:
+            cred = rows[0] if rows else None
         if cred is not None:
             cred.last_connected = datetime.now(UTC)
             await db.commit()
@@ -164,7 +175,7 @@ async def connect(
         )
 
     # Update last_connected on any matching saved credential
-    await _update_last_connected(db, user.id, body.server_url, body.username)
+    await _update_last_connected(db, user.id, body.server_url, body.username, body.password)
 
     return _session_to_status(session)
 
@@ -226,7 +237,7 @@ async def reconnect(
             detail=f"Failed to reconnect to Travian server: {exc}",
         )
 
-    await _update_last_connected(db, user.id, server_url, username)
+    await _update_last_connected(db, user.id, server_url, username, password)
 
     return _session_to_status(new_session)
 

--- a/src/travian_api/web/routes/travian_auth.py
+++ b/src/travian_api/web/routes/travian_auth.py
@@ -179,6 +179,11 @@ async def connect(
             detail=f"Failed to connect to Travian server: {exc}",
         )
 
+    # A proven-good explicit login clears any failed-restore backoff, so a
+    # session that vanishes again (restart/worker reload) can auto-restore
+    # immediately instead of waiting out the throttle.
+    reset_restore_backoff(user.id)
+
     # Update last_connected on any matching saved credential
     await _update_last_connected(db, user.id, body.server_url, body.username, body.password)
 
@@ -403,6 +408,9 @@ async def connect_saved_server(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"Failed to connect to Travian server: {exc}",
         )
+
+    # A proven-good login clears any failed-restore backoff (see /connect).
+    reset_restore_backoff(user.id)
 
     # 4. Update last_connected timestamp — best-effort bookkeeping: a DB
     # hiccup here must not report the successful login as a failure.

--- a/src/travian_api/web/routes/users.py
+++ b/src/travian_api/web/routes/users.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from travian_api.web.auth import (
@@ -57,7 +58,17 @@ async def register(body: UserCreate, db: AsyncSession = Depends(get_db)):
         password_hash=hash_password(body.password),
     )
     db.add(user)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        # Two concurrent registrations can both pass the SELECT above; the
+        # unique constraint decides the winner and the loser gets the same
+        # 409 a sequential duplicate would.
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already taken",
+        )
     await db.refresh(user)
 
     token = create_access_token(user.id, user.username)

--- a/src/travian_api/web/routes/users.py
+++ b/src/travian_api/web/routes/users.py
@@ -1,6 +1,8 @@
 """User registration, login, and profile routes."""
 
-from fastapi import APIRouter, Depends, HTTPException, status
+import asyncio
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -13,6 +15,7 @@ from travian_api.web.auth import (
     verify_password,
 )
 from travian_api.web.models.db import User, get_db
+from travian_api.web.rate_limit import auth_limiter
 
 router = APIRouter(prefix="/api/users", tags=["users"])
 
@@ -54,7 +57,12 @@ class TokenResponse(BaseModel):
 
 
 @router.post("/register", response_model=TokenResponse, status_code=status.HTTP_201_CREATED)
-async def register(body: UserCreate, db: AsyncSession = Depends(get_db)):
+async def register(
+    body: UserCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _rate: None = Depends(auth_limiter),
+):
     """Create a new user account and return a JWT."""
     # Check for duplicate username
     result = await db.execute(select(User).where(User.username == body.username))
@@ -64,9 +72,12 @@ async def register(body: UserCreate, db: AsyncSession = Depends(get_db)):
             detail="Username already taken",
         )
 
+    # bcrypt is intentionally slow; run it off the event loop so a burst of
+    # registrations cannot stall unrelated API/WebSocket traffic.
+    password_hash = await asyncio.to_thread(hash_password, body.password)
     user = User(
         username=body.username,
-        password_hash=hash_password(body.password),
+        password_hash=password_hash,
     )
     db.add(user)
     try:
@@ -87,12 +98,22 @@ async def register(body: UserCreate, db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/login", response_model=TokenResponse)
-async def login(body: UserCreate, db: AsyncSession = Depends(get_db)):
+async def login(
+    body: UserCreate,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _rate: None = Depends(auth_limiter),
+):
     """Authenticate an existing user and return a JWT."""
     result = await db.execute(select(User).where(User.username == body.username))
     user = result.scalar_one_or_none()
 
-    if user is None or not verify_password(body.password, user.password_hash):
+    # Offload the bcrypt compare (same DoS/event-loop concern as register). A
+    # missing user still returns 401 without hashing; the per-IP limiter above
+    # is what bounds brute force against a known username.
+    if user is None or not await asyncio.to_thread(
+        verify_password, body.password, user.password_hash
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid username or password",

--- a/src/travian_api/web/routes/users.py
+++ b/src/travian_api/web/routes/users.py
@@ -1,7 +1,7 @@
 """User registration, login, and profile routes."""
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,6 +24,17 @@ router = APIRouter(prefix="/api/users", tags=["users"])
 class UserCreate(BaseModel):
     username: str = Field(..., min_length=3, max_length=32)
     password: str = Field(..., min_length=6)
+
+    @field_validator("password")
+    @classmethod
+    def _within_bcrypt_byte_limit(cls, value: str) -> str:
+        # bcrypt only reads the first 72 BYTES and, from bcrypt 5, raises for
+        # anything longer. Bytes, not characters: an emoji is four. Without
+        # this check a long password passes validation and detonates inside
+        # hash_password(), turning a user mistake into a 500.
+        if len(value.encode("utf-8")) > 72:
+            raise ValueError("password must be at most 72 bytes (UTF-8 encoded)")
+        return value
 
 
 class UserResponse(BaseModel):

--- a/src/travian_api/web/routes/video.py
+++ b/src/travian_api/web/routes/video.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from travian_api.exceptions import TravianError
-from travian_api.web.sessions import TravianSession, get_travian_session
+from travian_api.web.sessions import TravianSession, get_travian_session, require_village_id
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ async def claim_reward(
     session: TravianSession = Depends(get_travian_session),
 ):
     """Claim a single video reward."""
-    village_id = body.village_id or session.active_village_id
+    village_id = require_village_id(body.village_id)
 
     extra_params: dict = {}
     if village_id is not None:
@@ -86,7 +86,7 @@ async def claim_all_production_boosts(
     session: TravianSession = Depends(get_travian_session),
 ):
     """Claim all production boost video rewards."""
-    village_id = (body.village_id if body else None) or session.active_village_id
+    village_id = require_village_id(body.village_id if body else None)
     results = []
 
     for reward_type in _PRODUCTION_BOOST_TYPES:

--- a/src/travian_api/web/routes/video.py
+++ b/src/travian_api/web/routes/video.py
@@ -35,6 +35,12 @@ class VideoClaimRequest(BaseModel):
     building_id: int | None = None
 
 
+class VideoClaimAllRequest(BaseModel):
+    # Village switching is client-side only, so the session default is forever
+    # the login village — the UI passes its own selection.
+    village_id: int | None = None
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -76,10 +82,11 @@ async def claim_reward(
 
 @router.post("/claim-all")
 async def claim_all_production_boosts(
+    body: VideoClaimAllRequest | None = None,
     session: TravianSession = Depends(get_travian_session),
 ):
     """Claim all production boost video rewards."""
-    village_id = session.active_village_id
+    village_id = (body.village_id if body else None) or session.active_village_id
     results = []
 
     for reward_type in _PRODUCTION_BOOST_TYPES:

--- a/src/travian_api/web/routes/villages.py
+++ b/src/travian_api/web/routes/villages.py
@@ -84,14 +84,18 @@ async def switch_village(
     body: SwitchVillageRequest,
     session: TravianSession = Depends(get_travian_session),
 ):
-    """Switch the active village context.
+    """Validate a village selection. Tab-local: does NOT mutate shared state.
 
-    Per-tab isolation lives in the CLIENT: every action route accepts an
-    explicit ``village_id`` and each tab sends its own selection, so tabs
-    cannot interfere through this default. The session field is still updated
-    here because GET /api/villages and /api/travian/status derive
-    ``active_village_id``/``is_active`` from it — leaving it stale would show
-    the old village as active on any status refresh or fresh tab.
+    The active village is a per-tab concept, so this deliberately does not touch
+    ``session.active_village_id``. Persisting it would let one tab (or another
+    logged-in device) silently retarget every other tab's fallback village, and
+    a fallback that hits the wrong village costs a corrective re-fetch — extra
+    Travian traffic and an irregular request fingerprint, which is exactly what
+    the stealth layer exists to avoid.
+
+    This stays safe because every Travian-hitting route and operation carries an
+    explicit ``village_id`` (each tab sends its own selection); the session
+    default is only the stable login village, used as a last-resort fallback.
     """
     village = None
     if session.auth_state:
@@ -113,8 +117,8 @@ async def switch_village(
             detail=f"Village {body.village_id} not found for this player.",
         )
 
-    session.active_village_id = body.village_id
-
+    # The response echoes the caller's choice (its own tab-local truth); the
+    # shared session default is intentionally left untouched.
     return SwitchVillageResponse(
         active_village_id=body.village_id,
         village=village,

--- a/src/travian_api/web/routes/villages.py
+++ b/src/travian_api/web/routes/villages.py
@@ -86,12 +86,13 @@ async def switch_village(
 ):
     """Switch the active village context.
 
-    NOTE: This is now a client-side-only operation. The backend validates that the
-    village belongs to the player but does NOT mutate session.active_village_id.
-    Each browser tab tracks its own active village via sessionStorage. This prevents
-    one tab/browser from affecting another's village context.
+    Per-tab isolation lives in the CLIENT: every action route accepts an
+    explicit ``village_id`` and each tab sends its own selection, so tabs
+    cannot interfere through this default. The session field is still updated
+    here because GET /api/villages and /api/travian/status derive
+    ``active_village_id``/``is_active`` from it — leaving it stale would show
+    the old village as active on any status refresh or fresh tab.
     """
-    # Validate that the village belongs to this player (don't mutate session state)
     village = None
     if session.auth_state:
         for v in session.auth_state.villages:
@@ -111,6 +112,8 @@ async def switch_village(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Village {body.village_id} not found for this player.",
         )
+
+    session.active_village_id = body.village_id
 
     return SwitchVillageResponse(
         active_village_id=body.village_id,

--- a/src/travian_api/web/routes/villages.py
+++ b/src/travian_api/web/routes/villages.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
 from travian_api.web.sessions import TravianSession, get_travian_session
@@ -52,14 +52,31 @@ class SwitchVillageResponse(BaseModel):
 
 @router.get("", response_model=VillageListResponse)
 async def list_villages(
+    active_village_id: int | None = Query(
+        None,
+        description=(
+            "The caller's tab-local active village. Village selection is "
+            "client-side (see /switch), so pass it here to get a consistent "
+            "is_active view; without it the server's login-village default is "
+            "reported."
+        ),
+    ),
     session: TravianSession = Depends(get_travian_session),
 ):
-    """Return all villages for the connected player."""
+    """Return all villages for the connected player.
+
+    ``active_village_id`` reflects the caller's tab-local selection when
+    supplied (and owned by the player), otherwise the session's login-village
+    default — the switch/list pair round-trips for tab-local selection.
+    """
     if session.auth_state is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Session has no auth state. Try reconnecting.",
         )
+
+    owned_ids = {v.id for v in session.auth_state.villages}
+    active = active_village_id if active_village_id in owned_ids else session.active_village_id
 
     villages = [
         VillageInfo(
@@ -68,13 +85,13 @@ async def list_villages(
             x=v.x,
             y=v.y,
             is_main_village=v.is_main_village,
-            is_active=(v.id == session.active_village_id),
+            is_active=(v.id == active),
         )
         for v in session.auth_state.villages
     ]
 
     return VillageListResponse(
-        active_village_id=session.active_village_id,
+        active_village_id=active,
         villages=villages,
     )
 

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -215,6 +215,23 @@ class SessionManager:
     ) -> TravianSession:
         """Create a new session and authenticate to Travian.
 
+        Serialized on the per-user reconnect lock so a logout that returns
+        while this login is in flight cannot be undone when the new session
+        installs. Auto-reconnect paths that already hold that lock call
+        :meth:`_connect_locked` directly instead.
+        """
+        async with self.get_reconnect_lock(user_id):
+            return await self._connect_locked(user_id, server_url, username, password)
+
+    async def _connect_locked(
+        self,
+        user_id: int,
+        server_url: str,
+        username: str,
+        password: str,
+    ) -> TravianSession:
+        """Login + install; the caller holds the per-user reconnect lock.
+
         Any existing session is replaced only AFTER the new login succeeds, so
         a reconnect that hits a transient Travian failure (downtime, captcha)
         cannot destroy a still-working session.
@@ -328,7 +345,8 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
             return None
 
         try:
-            session = await session_manager.connect(
+            # The reconnect lock is already held; go through the locked core.
+            session = await session_manager._connect_locked(
                 user_id=user_id,
                 server_url=server_url,
                 username=username,
@@ -404,21 +422,29 @@ async def get_travian_session(
 
         try:
             password = decrypt_credential(cred.encrypted_password)
-            session = await session_manager.connect(
+            # The reconnect lock is already held; go through the locked core.
+            session = await session_manager._connect_locked(
                 user_id=user.id,
                 server_url=cred.server_url,
                 username=cred.travian_username,
                 password=password,
             )
-            from datetime import datetime
-
-            cred.last_connected = datetime.now(UTC)
-            await db.commit()
-            logger.info("Auto-reconnected user %s to %s", user.id, cred.server_url)
-            return session
         except Exception as exc:
             logger.warning("Auto-reconnect failed for user %s: %s", user.id, exc)
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Auto-reconnect failed: {exc}. Please reconnect manually.",
             )
+
+        # Bookkeeping only: the session is live regardless, and a failed stamp
+        # must not turn a successful login into a 403.
+        try:
+            from datetime import datetime
+
+            cred.last_connected = datetime.now(UTC)
+            await db.commit()
+        except Exception:
+            logger.warning("Auto-reconnected user %s but could not stamp last_connected", user.id)
+
+        logger.info("Auto-reconnected user %s to %s", user.id, cred.server_url)
+        return session

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -455,7 +455,11 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
                 username = cred.travian_username
                 password = decrypt_credential(cred.encrypted_password)
         except Exception as exc:
+            # A corrupt/undecryptable credential or a DB read error fails the
+            # same way a bad login does — back off so reconnecting sockets do
+            # not repeat this restore work on every retry.
             logger.warning("WebSocket auto-reconnect failed for user %s: %s", user_id, exc)
+            _restore_backoff[user_id] = time.monotonic() + _RESTORE_RETRY_SECONDS
             return None
 
         try:

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -376,6 +376,23 @@ def reset_restore_backoff(user_id: int) -> None:
     _restore_backoff.pop(user_id, None)
 
 
+def require_village_id(village_id: Optional[int]) -> int:
+    """A village-specific route must be told which village, explicitly.
+
+    Village selection is client-side (tab-local /switch), so falling back to a
+    shared session default risks acting on the WRONG village — a wasted or
+    wrong Travian request, which the fewer-requests/stealth goals reject. Every
+    first-party caller already sends its own ``village_id``; a missing one is a
+    caller bug and fails loud with 400 rather than silently guessing.
+    """
+    if village_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="village_id is required.",
+        )
+    return village_id
+
+
 def latest_credential_query(user_id: int):
     """The saved credential auto-restore should use: most recently connected,
     with newest-id as the tie-break — timestamps are commonly NULL on freshly

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -208,15 +208,18 @@ class SessionManager:
     ) -> TravianSession:
         """Create a new session and authenticate to Travian.
 
-        If the user already has an active session it is disconnected first.
+        Any existing session is replaced only AFTER the new login succeeds, so
+        a reconnect that hits a transient Travian failure (downtime, captcha)
+        cannot destroy a still-working session.
         """
-        await self.disconnect(user_id)
-
         session = TravianSession(user_id, server_url, username, password)
         await session.connect()
 
         async with self._lock:
+            old = self._sessions.pop(user_id, None)
             self._sessions[user_id] = session
+        if old is not None:
+            await old.disconnect()
 
         logger.info(
             "User %s connected to %s as %s",
@@ -261,6 +264,59 @@ class SessionManager:
 # ---------------------------------------------------------------------------
 
 session_manager = SessionManager()
+
+
+async def try_restore_session(user_id: int) -> Optional[TravianSession]:
+    """Best-effort auto-reconnect from saved credentials, for WebSocket auth.
+
+    HTTP requests restore through :func:`get_travian_session`; sockets have no
+    request-scoped db dependency, so this opens its own session. Returns the
+    live or restored session, or None when nothing is saved or the login fails
+    — WebSocket auth turns None into a policy-violation close, not a 403.
+    """
+    session = session_manager.get(user_id)
+    if session is not None:
+        return session
+
+    reconnect_lock = session_manager.get_reconnect_lock(user_id)
+    async with reconnect_lock:
+        session = session_manager.get(user_id)
+        if session is not None:
+            return session
+
+        from datetime import datetime
+
+        from sqlalchemy import select
+
+        from travian_api.web.auth import decrypt_credential
+        from travian_api.web.models.db import TravianCredential, async_session_factory
+
+        try:
+            async with async_session_factory() as db:
+                result = await db.execute(
+                    select(TravianCredential)
+                    .where(TravianCredential.user_id == user_id)
+                    .order_by(TravianCredential.last_connected.desc().nulls_last())
+                    .limit(1)
+                )
+                cred = result.scalar_one_or_none()
+                if cred is None:
+                    return None
+
+                password = decrypt_credential(cred.encrypted_password)
+                session = await session_manager.connect(
+                    user_id=user_id,
+                    server_url=cred.server_url,
+                    username=cred.travian_username,
+                    password=password,
+                )
+                cred.last_connected = datetime.now(UTC)
+                await db.commit()
+                logger.info("Auto-reconnected user %s for a WebSocket", user_id)
+                return session
+        except Exception as exc:
+            logger.warning("WebSocket auto-reconnect failed for user %s: %s", user_id, exc)
+            return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -6,6 +6,7 @@ so that cookie jars, JWT tokens, and stealth state never leak between users.
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import tempfile
@@ -45,8 +46,16 @@ class TravianSession:
         self.user_id = user_id
         self.server_url = server_url
 
-        # ── Per-user data directory ───────────────────────────────────
-        self._data_dir = _SESSION_DATA_DIR / str(user_id)
+        # ── Per-identity data directory ───────────────────────────────
+        # Keyed by (server, Travian username), not just the web user: the JWT
+        # and cookie caches resume sessions, so a web user who reconnects to
+        # the same world with different credentials must not come up as the
+        # previous player. Same identity keeps its cache — stealth resume of
+        # a still-valid session stays cheap.
+        identity = hashlib.sha256(
+            f"{server_url.rstrip('/')}|{username}".encode()
+        ).hexdigest()[:16]
+        self._data_dir = _SESSION_DATA_DIR / str(user_id) / identity
         self._data_dir.mkdir(parents=True, exist_ok=True)
         try:
             os.chmod(self._data_dir, 0o700)

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -235,7 +235,26 @@ class SessionManager:
         Any existing session is replaced only AFTER the new login succeeds, so
         a reconnect that hits a transient Travian failure (downtime, captcha)
         cannot destroy a still-working session.
+
+        Refused while background operations are running on the session being
+        replaced: those jobs hold the old session's HttpClient, and closing it
+        under them makes every following request in the job fail mid-run.
         """
+        if user_id in self._sessions:
+            from travian_api.operation_manager import operation_manager
+
+            running = sorted(
+                op.label for op in operation_manager.list_for_user(user_id) if not op.task.done()
+            )
+            if running:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"Cannot reconnect while operations are running: "
+                        f"{', '.join(running)}. Stop them first."
+                    ),
+                )
+
         session = TravianSession(user_id, server_url, username, password)
         await session.connect()
 

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -324,6 +324,10 @@ class SessionManager:
         """False after an explicit disconnect, until an explicit connect."""
         return user_id not in self._explicit_disconnects
 
+    def clear_explicit_disconnect(self, user_id: int) -> None:
+        """An explicit reconnect request overrides an earlier explicit disconnect."""
+        self._explicit_disconnects.discard(user_id)
+
     def _running_operation_labels(self, user_id: int) -> list[str]:
         """Labels of the user's background operations that are still running."""
         from travian_api.operation_manager import operation_manager

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -261,7 +261,19 @@ class SessionManager:
                 )
 
         session = TravianSession(user_id, server_url, username, password)
-        await session.connect()
+        try:
+            await session.connect()
+        except BaseException:
+            # Bad credentials, a network error or a captcha leaves a session
+            # that was never installed anywhere -- but its httpx/curl clients
+            # and file-backed state already exist. Abandoning it leaks a
+            # connection pool per failed attempt, and reconnect retries make
+            # that a steady drip. Close it before letting the error out.
+            try:
+                await session.disconnect()
+            except Exception:
+                logger.exception("Cleanup after a failed connect also failed")
+            raise
 
         # Re-check under the install lock: an operation may have started while
         # the login was in flight, and swapping now would close the HttpClient

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -244,14 +244,13 @@ class SessionManager:
 
         Refused while background operations are running on the session being
         replaced: those jobs hold the old session's HttpClient, and closing it
-        under them makes every following request in the job fail mid-run.
+        under them makes every following request in the job fail mid-run. The
+        pre-login check avoids wasting a real login in the common case; the
+        re-check under the install lock closes the race with jobs that start
+        while the login is in flight.
         """
         if user_id in self._sessions:
-            from travian_api.operation_manager import operation_manager
-
-            running = sorted(
-                op.label for op in operation_manager.list_for_user(user_id) if not op.task.done()
-            )
+            running = self._running_operation_labels(user_id)
             if running:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
@@ -264,10 +263,28 @@ class SessionManager:
         session = TravianSession(user_id, server_url, username, password)
         await session.connect()
 
+        # Re-check under the install lock: an operation may have started while
+        # the login was in flight, and swapping now would close the HttpClient
+        # it just captured. No awaits sit between this check and the swap, so
+        # nothing can slip in between.
+        old: Optional[TravianSession] = None
+        conflict: list[str] = []
         async with self._lock:
-            old = self._sessions.pop(user_id, None)
-            self._sessions[user_id] = session
-            self._explicit_disconnects.discard(user_id)
+            if user_id in self._sessions:
+                conflict = self._running_operation_labels(user_id)
+            if not conflict:
+                old = self._sessions.pop(user_id, None)
+                self._sessions[user_id] = session
+                self._explicit_disconnects.discard(user_id)
+        if conflict:
+            await session.disconnect()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Cannot reconnect while operations are running: "
+                    f"{', '.join(conflict)}. Stop them first."
+                ),
+            )
         if old is not None:
             await old.disconnect()
 
@@ -306,6 +323,14 @@ class SessionManager:
     def auto_reconnect_allowed(self, user_id: int) -> bool:
         """False after an explicit disconnect, until an explicit connect."""
         return user_id not in self._explicit_disconnects
+
+    def _running_operation_labels(self, user_id: int) -> list[str]:
+        """Labels of the user's background operations that are still running."""
+        from travian_api.operation_manager import operation_manager
+
+        return sorted(
+            op.label for op in operation_manager.list_for_user(user_id) if not op.task.done()
+        )
 
     def get_reconnect_lock(self, user_id: int) -> asyncio.Lock:
         """Return a per-user lock for serializing auto-reconnect attempts."""
@@ -446,6 +471,16 @@ async def get_travian_session(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Disconnected. Use POST /api/travian/connect to reconnect.",
         )
+    # A page load fans out several protected calls; after a FAILED restore,
+    # each retrying with a real login is the same storm /status avoids.
+    if time.monotonic() < _restore_backoff.get(user.id, 0.0):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Auto-reconnect recently failed and is backing off. "
+                "Use POST /api/travian/connect to reconnect now."
+            ),
+        )
 
     # Serialize reconnect attempts per user — prevents two concurrent requests
     # from both triggering session_manager.connect() simultaneously.
@@ -459,6 +494,14 @@ async def get_travian_session(
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Disconnected. Use POST /api/travian/connect to reconnect.",
+            )
+        if time.monotonic() < _restore_backoff.get(user.id, 0.0):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    "Auto-reconnect recently failed and is backing off. "
+                    "Use POST /api/travian/connect to reconnect now."
+                ),
             )
 
         # Try auto-reconnect from saved credentials
@@ -492,10 +535,13 @@ async def get_travian_session(
             )
         except Exception as exc:
             logger.warning("Auto-reconnect failed for user %s: %s", user.id, exc)
+            _restore_backoff[user.id] = time.monotonic() + _RESTORE_RETRY_SECONDS
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Auto-reconnect failed: {exc}. Please reconnect manually.",
             )
+
+        _restore_backoff.pop(user.id, None)
 
         # Bookkeeping only: the session is live regardless, and a failed stamp
         # must not turn a successful login into a 403.

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -237,12 +237,18 @@ class SessionManager:
         return session
 
     async def disconnect(self, user_id: int) -> None:
-        """Disconnect and remove a user's session (no-op if none exists)."""
-        async with self._lock:
+        """Disconnect and remove a user's session (no-op if none exists).
+
+        Serialized with the per-user reconnect lock: an auto-reconnect holds
+        that lock across its whole login, so a logout arriving mid-login waits
+        for the install and then tears it down — the explicit disconnect stays
+        authoritative instead of being silently undone by the racing login.
+        """
+        reconnect_lock = self.get_reconnect_lock(user_id)
+        async with reconnect_lock, self._lock:
             session = self._sessions.pop(user_id, None)
-            lock = self._reconnect_locks.get(user_id)
-            if lock is not None and not lock.locked():
-                self._reconnect_locks.pop(user_id, None)
+        if not reconnect_lock.locked():
+            self._reconnect_locks.pop(user_id, None)
         if session:
             await session.disconnect()
             logger.info("User %s disconnected from %s", user_id, session.server_url)

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -52,9 +52,7 @@ class TravianSession:
         # the same world with different credentials must not come up as the
         # previous player. Same identity keeps its cache — stealth resume of
         # a still-valid session stays cheap.
-        identity = hashlib.sha256(
-            f"{server_url.rstrip('/')}|{username}".encode()
-        ).hexdigest()[:16]
+        identity = hashlib.sha256(f"{server_url.rstrip('/')}|{username}".encode()).hexdigest()[:16]
         self._data_dir = _SESSION_DATA_DIR / str(user_id) / identity
         self._data_dir.mkdir(parents=True, exist_ok=True)
         try:

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -366,12 +366,21 @@ class SessionManager:
         self._explicit_disconnects.discard(user_id)
 
     def _running_operation_labels(self, user_id: int) -> list[str]:
-        """Labels of the user's background operations that are still running."""
-        from travian_api.operation_manager import operation_manager
+        """Labels of the user's background operations that are still running.
 
-        return sorted(
-            op.label for op in operation_manager.list_for_user(user_id) if not op.task.done()
-        )
+        Two independent registries hold work that pins this session's
+        HttpClient: OperationManager (detached farm/scout/queue/raid tasks)
+        and ActiveOpRegistry (WebSocket-driven work like the raid analyzer,
+        which never becomes an OperationManager task). Both must be consulted
+        — an operation missing from the guard lets disconnect/reconnect close
+        the client underneath it mid-run.
+        """
+        from travian_api.operation_manager import operation_manager
+        from travian_api.web.operation_gate import active_ops
+
+        labels = {op.label for op in operation_manager.list_for_user(user_id) if not op.task.done()}
+        labels.update(active_ops.get_active(user_id))
+        return sorted(labels)
 
     def get_reconnect_lock(self, user_id: int) -> asyncio.Lock:
         """Return a per-user lock for serializing auto-reconnect attempts.

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -463,6 +463,27 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
         return session
 
 
+async def get_live_travian_session(
+    user: User = Depends(get_current_user),
+) -> TravianSession:
+    """The live session only — NO auto-reconnect.
+
+    For endpoints that price their game traffic explicitly (the distribution
+    snapshot): an implicit login would spend unreported requests before the
+    handler even starts. 403 tells the operator to reconnect deliberately.
+    """
+    session = session_manager.get(user.id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Not connected. Reconnect first — this endpoint never spends "
+                "login traffic implicitly."
+            ),
+        )
+    return session
+
+
 # ---------------------------------------------------------------------------
 # FastAPI dependency
 # ---------------------------------------------------------------------------

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -33,6 +33,7 @@ from travian_api.services.target_resolver import TargetResolver
 from travian_api.services.video_reward_service import VideoRewardService
 from travian_api.web.auth import get_current_user
 from travian_api.web.models.db import User, get_db
+from travian_api.web.url_guard import ensure_safe_server_url
 
 logger = logging.getLogger(__name__)
 
@@ -224,8 +225,15 @@ class SessionManager:
         Serialized on the per-user reconnect lock so a logout that returns
         while this login is in flight cannot be undone when the new session
         installs. Auto-reconnect paths that already hold that lock call
-        :meth:`_connect_locked` directly instead.
+        :meth:`_connect_locked` directly instead -- they replay credentials
+        that already passed this guard when they were first connected.
+
+        The URL guard runs before anything else: the backend logs into
+        whatever URL it is given and follows the target's redirects, so an
+        unvalidated URL is an authenticated SSRF primitive (loopback, LAN
+        services) for any registered user.
         """
+        await ensure_safe_server_url(server_url)
         async with self.get_reconnect_lock(user_id):
             return await self._connect_locked(user_id, server_url, username, password)
 
@@ -315,9 +323,26 @@ class SessionManager:
         that lock across its whole login, so a logout arriving mid-login waits
         for the install and then tears it down — the explicit disconnect stays
         authoritative instead of being silently undone by the racing login.
+
+        Refused (409) while background operations are running, exactly like
+        reconnect and for the same reason: the detached job holds this
+        session's HttpClient, and closing it underneath makes every following
+        request in the job fail — loops that treat request failures as
+        nonfatal then fail indefinitely. The check sits under the locks with
+        no await before the pop, so an operation cannot start in between.
         """
         reconnect_lock = self.get_reconnect_lock(user_id)
         async with reconnect_lock, self._lock:
+            if user_id in self._sessions:
+                running = self._running_operation_labels(user_id)
+                if running:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail=(
+                            f"Cannot disconnect while operations are running: "
+                            f"{', '.join(running)}. Stop them first."
+                        ),
+                    )
             session = self._sessions.pop(user_id, None)
             self._explicit_disconnects.add(user_id)
         # The lock entry is deliberately never removed: waiters queued on it

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -247,8 +247,10 @@ class SessionManager:
         reconnect_lock = self.get_reconnect_lock(user_id)
         async with reconnect_lock, self._lock:
             session = self._sessions.pop(user_id, None)
-        if not reconnect_lock.locked():
-            self._reconnect_locks.pop(user_id, None)
+        # The lock entry is deliberately never removed: waiters queued on it
+        # hold a reference, and handing later callers a fresh lock from
+        # get_reconnect_lock() would let two reconnects run concurrently. One
+        # small Lock per user who ever connected is a bounded cost.
         if session:
             await session.disconnect()
             logger.info("User %s disconnected from %s", user_id, session.server_url)
@@ -304,32 +306,52 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
         from travian_api.web.auth import decrypt_credential
         from travian_api.web.models.db import TravianCredential, async_session_factory
 
+        def _latest_credential_query():
+            return (
+                select(TravianCredential)
+                .where(TravianCredential.user_id == user_id)
+                .order_by(TravianCredential.last_connected.desc().nulls_last())
+                .limit(1)
+            )
+
         try:
             async with async_session_factory() as db:
-                result = await db.execute(
-                    select(TravianCredential)
-                    .where(TravianCredential.user_id == user_id)
-                    .order_by(TravianCredential.last_connected.desc().nulls_last())
-                    .limit(1)
-                )
+                result = await db.execute(_latest_credential_query())
                 cred = result.scalar_one_or_none()
                 if cred is None:
                     return None
-
+                server_url = cred.server_url
+                username = cred.travian_username
                 password = decrypt_credential(cred.encrypted_password)
-                session = await session_manager.connect(
-                    user_id=user_id,
-                    server_url=cred.server_url,
-                    username=cred.travian_username,
-                    password=password,
-                )
-                cred.last_connected = datetime.now(UTC)
-                await db.commit()
-                logger.info("Auto-reconnected user %s for a WebSocket", user_id)
-                return session
         except Exception as exc:
             logger.warning("WebSocket auto-reconnect failed for user %s: %s", user_id, exc)
             return None
+
+        try:
+            session = await session_manager.connect(
+                user_id=user_id,
+                server_url=server_url,
+                username=username,
+                password=password,
+            )
+        except Exception as exc:
+            logger.warning("WebSocket auto-reconnect failed for user %s: %s", user_id, exc)
+            return None
+
+        # Bookkeeping only: the session is live regardless, and a failed stamp
+        # must not make the caller report a login failure.
+        try:
+            async with async_session_factory() as db:
+                result = await db.execute(_latest_credential_query())
+                cred = result.scalar_one_or_none()
+                if cred is not None:
+                    cred.last_connected = datetime.now(UTC)
+                    await db.commit()
+        except Exception:
+            logger.warning("Auto-reconnected user %s but could not stamp last_connected", user_id)
+
+        logger.info("Auto-reconnected user %s for a WebSocket", user_id)
+        return session
 
 
 # ---------------------------------------------------------------------------

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -201,6 +201,11 @@ class SessionManager:
         self._sessions: dict[int, TravianSession] = {}
         self._lock = asyncio.Lock()
         self._reconnect_locks: dict[int, asyncio.Lock] = {}
+        # Users who explicitly disconnected. Auto-restore exists for crashes
+        # and restarts, not to override the user: the flag suppresses it until
+        # an explicit connect. In-memory on purpose — a process restart clears
+        # it, which is exactly when seamless recovery is wanted.
+        self._explicit_disconnects: set[int] = set()
 
     # ------------------------------------------------------------------
     # Public API
@@ -261,6 +266,7 @@ class SessionManager:
         async with self._lock:
             old = self._sessions.pop(user_id, None)
             self._sessions[user_id] = session
+            self._explicit_disconnects.discard(user_id)
         if old is not None:
             await old.disconnect()
 
@@ -283,6 +289,7 @@ class SessionManager:
         reconnect_lock = self.get_reconnect_lock(user_id)
         async with reconnect_lock, self._lock:
             session = self._sessions.pop(user_id, None)
+            self._explicit_disconnects.add(user_id)
         # The lock entry is deliberately never removed: waiters queued on it
         # hold a reference, and handing later callers a fresh lock from
         # get_reconnect_lock() would let two reconnects run concurrently. One
@@ -294,6 +301,10 @@ class SessionManager:
     def get(self, user_id: int) -> Optional[TravianSession]:
         """Return an active session for *user_id*, or ``None``."""
         return self._sessions.get(user_id)
+
+    def auto_reconnect_allowed(self, user_id: int) -> bool:
+        """False after an explicit disconnect, until an explicit connect."""
+        return user_id not in self._explicit_disconnects
 
     def get_reconnect_lock(self, user_id: int) -> asyncio.Lock:
         """Return a per-user lock for serializing auto-reconnect attempts."""
@@ -328,12 +339,17 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
     session = session_manager.get(user_id)
     if session is not None:
         return session
+    if not session_manager.auto_reconnect_allowed(user_id):
+        # The user explicitly disconnected; restoring would override them.
+        return None
 
     reconnect_lock = session_manager.get_reconnect_lock(user_id)
     async with reconnect_lock:
         session = session_manager.get(user_id)
         if session is not None:
             return session
+        if not session_manager.auto_reconnect_allowed(user_id):
+            return None
 
         from datetime import datetime
 
@@ -403,12 +419,18 @@ async def get_travian_session(
     """FastAPI dependency returning the caller's active Travian session.
 
     If no session exists but the user has saved credentials, attempts to
-    auto-reconnect using the most recently connected saved credential.
-    Raises HTTP 403 only if reconnection fails or no credentials are saved.
+    auto-reconnect using the most recently connected saved credential — unless
+    the user explicitly disconnected, which stands until an explicit connect.
+    Raises HTTP 403 if reconnection fails, is suppressed, or nothing is saved.
     """
     session = session_manager.get(user.id)
     if session is not None:
         return session
+    if not session_manager.auto_reconnect_allowed(user.id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Disconnected. Use POST /api/travian/connect to reconnect.",
+        )
 
     # Serialize reconnect attempts per user — prevents two concurrent requests
     # from both triggering session_manager.connect() simultaneously.
@@ -418,6 +440,11 @@ async def get_travian_session(
         session = session_manager.get(user.id)
         if session is not None:
             return session
+        if not session_manager.auto_reconnect_allowed(user.id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Disconnected. Use POST /api/travian/connect to reconnect.",
+            )
 
         # Try auto-reconnect from saved credentials
         from sqlalchemy import select

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -333,10 +333,12 @@ class SessionManager:
         )
 
     def get_reconnect_lock(self, user_id: int) -> asyncio.Lock:
-        """Return a per-user lock for serializing auto-reconnect attempts."""
-        if user_id not in self._reconnect_locks:
-            self._reconnect_locks[user_id] = asyncio.Lock()
-        return self._reconnect_locks[user_id]
+        """Return a per-user lock for serializing auto-reconnect attempts.
+
+        setdefault keeps creation atomic at the dict level, so concurrent
+        first-use callers can never end up holding two different locks.
+        """
+        return self._reconnect_locks.setdefault(user_id, asyncio.Lock())
 
     async def disconnect_all(self) -> None:
         """Disconnect every session (call during application shutdown)."""
@@ -359,6 +361,26 @@ session_manager = SessionManager()
 # bot-detection pressure. Keyed by user id, monotonic deadline.
 _RESTORE_RETRY_SECONDS = 60.0
 _restore_backoff: dict[int, float] = {}
+
+
+def latest_credential_query(user_id: int):
+    """The saved credential auto-restore should use: most recently connected,
+    with newest-id as the tie-break — timestamps are commonly NULL on freshly
+    saved rows and legacy duplicates, and without the tie-break SQLite may
+    pick an older row with an outdated password."""
+    from sqlalchemy import select
+
+    from travian_api.web.models.db import TravianCredential
+
+    return (
+        select(TravianCredential)
+        .where(TravianCredential.user_id == user_id)
+        .order_by(
+            TravianCredential.last_connected.desc().nulls_last(),
+            TravianCredential.id.desc(),
+        )
+        .limit(1)
+    )
 
 
 async def try_restore_session(user_id: int) -> Optional[TravianSession]:
@@ -390,22 +412,12 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
 
         from datetime import datetime
 
-        from sqlalchemy import select
-
         from travian_api.web.auth import decrypt_credential
-        from travian_api.web.models.db import TravianCredential, async_session_factory
-
-        def _latest_credential_query():
-            return (
-                select(TravianCredential)
-                .where(TravianCredential.user_id == user_id)
-                .order_by(TravianCredential.last_connected.desc().nulls_last())
-                .limit(1)
-            )
+        from travian_api.web.models.db import async_session_factory
 
         try:
             async with async_session_factory() as db:
-                result = await db.execute(_latest_credential_query())
+                result = await db.execute(latest_credential_query(user_id))
                 cred = result.scalar_one_or_none()
                 if cred is None:
                     return None
@@ -435,7 +447,7 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
         # must not make the caller report a login failure.
         try:
             async with async_session_factory() as db:
-                result = await db.execute(_latest_credential_query())
+                result = await db.execute(latest_credential_query(user_id))
                 cred = result.scalar_one_or_none()
                 if cred is not None:
                     cred.last_connected = datetime.now(UTC)
@@ -505,17 +517,9 @@ async def get_travian_session(
             )
 
         # Try auto-reconnect from saved credentials
-        from sqlalchemy import select
-
         from travian_api.web.auth import decrypt_credential
-        from travian_api.web.models.db import TravianCredential
 
-        result = await db.execute(
-            select(TravianCredential)
-            .where(TravianCredential.user_id == user.id)
-            .order_by(TravianCredential.last_connected.desc().nulls_last())
-            .limit(1)
-        )
+        result = await db.execute(latest_credential_query(user.id))
         cred = result.scalar_one_or_none()
 
         if cred is None:

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -367,6 +367,15 @@ _RESTORE_RETRY_SECONDS = 60.0
 _restore_backoff: dict[int, float] = {}
 
 
+def reset_restore_backoff(user_id: int) -> None:
+    """Drop the failed-restore backoff for a user.
+
+    Called when the user EXPLICITLY reconnects: the backoff exists to stop
+    per-request auto-reconnect storms, not to block an intentional retry.
+    """
+    _restore_backoff.pop(user_id, None)
+
+
 def latest_credential_query(user_id: int):
     """The saved credential auto-restore should use: most recently connected,
     with newest-id as the tie-break — timestamps are commonly NULL on freshly

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -225,15 +225,9 @@ class SessionManager:
         Serialized on the per-user reconnect lock so a logout that returns
         while this login is in flight cannot be undone when the new session
         installs. Auto-reconnect paths that already hold that lock call
-        :meth:`_connect_locked` directly instead -- they replay credentials
-        that already passed this guard when they were first connected.
-
-        The URL guard runs before anything else: the backend logs into
-        whatever URL it is given and follows the target's redirects, so an
-        unvalidated URL is an authenticated SSRF primitive (loopback, LAN
-        services) for any registered user.
+        :meth:`_connect_locked` directly -- the URL guard lives there so those
+        paths are validated too.
         """
-        await ensure_safe_server_url(server_url)
         async with self.get_reconnect_lock(user_id):
             return await self._connect_locked(user_id, server_url, username, password)
 
@@ -256,7 +250,14 @@ class SessionManager:
         pre-login check avoids wasting a real login in the common case; the
         re-check under the install lock closes the race with jobs that start
         while the login is in flight.
+
+        The SSRF guard runs here, the single choke point every path funnels
+        through -- foreground connect AND the auto-restore paths that replay a
+        saved URL. A saved host whose DNS has since moved to a private address,
+        or a legacy row from before the guard existed, is caught at connection
+        time rather than trusted because it was once accepted.
         """
+        await ensure_safe_server_url(server_url)
         if user_id in self._sessions:
             running = self._running_operation_labels(user_id)
             if running:

--- a/src/travian_api/web/sessions.py
+++ b/src/travian_api/web/sessions.py
@@ -10,6 +10,7 @@ import hashlib
 import logging
 import os
 import tempfile
+import time
 from datetime import UTC
 from pathlib import Path
 from typing import Optional
@@ -327,6 +328,13 @@ class SessionManager:
 
 session_manager = SessionManager()
 
+# After a FAILED background restore, do not retry for this long. The /status
+# health poll calls try_restore_session on every tick; with stale credentials
+# or a downed world, retrying each poll is unbounded login traffic and
+# bot-detection pressure. Keyed by user id, monotonic deadline.
+_RESTORE_RETRY_SECONDS = 60.0
+_restore_backoff: dict[int, float] = {}
+
 
 async def try_restore_session(user_id: int) -> Optional[TravianSession]:
     """Best-effort auto-reconnect from saved credentials, for WebSocket auth.
@@ -342,6 +350,8 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
     if not session_manager.auto_reconnect_allowed(user_id):
         # The user explicitly disconnected; restoring would override them.
         return None
+    if time.monotonic() < _restore_backoff.get(user_id, 0.0):
+        return None
 
     reconnect_lock = session_manager.get_reconnect_lock(user_id)
     async with reconnect_lock:
@@ -349,6 +359,8 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
         if session is not None:
             return session
         if not session_manager.auto_reconnect_allowed(user_id):
+            return None
+        if time.monotonic() < _restore_backoff.get(user_id, 0.0):
             return None
 
         from datetime import datetime
@@ -389,7 +401,10 @@ async def try_restore_session(user_id: int) -> Optional[TravianSession]:
             )
         except Exception as exc:
             logger.warning("WebSocket auto-reconnect failed for user %s: %s", user_id, exc)
+            _restore_backoff[user_id] = time.monotonic() + _RESTORE_RETRY_SECONDS
             return None
+
+        _restore_backoff.pop(user_id, None)
 
         # Bookkeeping only: the session is live regardless, and a failed stamp
         # must not make the caller report a login failure.

--- a/src/travian_api/web/url_guard.py
+++ b/src/travian_api/web/url_guard.py
@@ -1,0 +1,72 @@
+"""Guard for user-supplied Travian server URLs.
+
+Any registered user can point the backend at a URL, and the backend then sends
+a login POST and follows the target's authentication redirect. On a shared or
+LAN deployment that is an authenticated SSRF primitive: a loopback or
+private-network service can be probed with the server's own network position.
+
+The rules are deliberately those of a real Travian world and nothing wider:
+https on the default port, a resolvable public hostname, never a bare IP.
+Every resolved address must be globally routable -- a public DNS name pointed
+at 127.0.0.1 is rejected the same as a literal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+from fastapi import HTTPException, status
+
+
+async def _resolve_host(host: str) -> list[str]:
+    """All addresses *host* resolves to. Split out so tests can stub DNS."""
+    loop = asyncio.get_running_loop()
+    infos = await loop.getaddrinfo(host, 443, type=socket.SOCK_STREAM)
+    return [info[4][0] for info in infos]
+
+
+async def ensure_safe_server_url(server_url: str) -> None:
+    """Raise a 400 unless *server_url* is a plausible public Travian server."""
+
+    def _reject(reason: str) -> None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"server_url {reason}",
+        )
+
+    try:
+        parsed = urlsplit(server_url)
+    except ValueError:
+        _reject("is not a valid URL")
+    if parsed.scheme != "https":
+        _reject("must use https")
+    host = parsed.hostname
+    if not host:
+        _reject("has no hostname")
+    if parsed.username or parsed.password:
+        _reject("must not embed credentials")
+    try:
+        if parsed.port not in (None, 443):
+            _reject("must use the default https port")
+    except ValueError:
+        _reject("has an invalid port")
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass  # a hostname, as expected
+    else:
+        _reject("must be a hostname, not an IP address")
+
+    try:
+        addresses = await _resolve_host(host)
+    except socket.gaierror:
+        _reject("could not be resolved")
+    for address in addresses:
+        # IPv6 addresses may carry a zone index ("%eth0"); the address part
+        # is what routes.
+        ip = ipaddress.ip_address(address.split("%")[0])
+        if not ip.is_global:
+            _reject("resolves to a private or local address")

--- a/src/travian_api/web/url_guard.py
+++ b/src/travian_api/web/url_guard.py
@@ -20,6 +20,8 @@ from urllib.parse import urlsplit
 
 from fastapi import HTTPException, status
 
+from travian_api.config import settings
+
 
 async def _resolve_host(host: str) -> list[str]:
     """All addresses *host* resolves to. Split out so tests can stub DNS."""
@@ -59,6 +61,13 @@ async def ensure_safe_server_url(server_url: str) -> None:
         pass  # a hostname, as expected
     else:
         _reject("must be a hostname, not an IP address")
+
+    # Allowlist BEFORE DNS: a publicly resolvable phishing host must never
+    # receive a login attempt just because its address is routable.
+    host_l = host.lower()
+    allowed = [s.strip().lower() for s in settings.allowed_server_hosts.split(",") if s.strip()]
+    if not any(host_l == suffix or host_l.endswith("." + suffix) for suffix in allowed):
+        _reject(f"is not an allowed Travian host (allowed: {', '.join(allowed)})")
 
     try:
         addresses = await _resolve_host(host)

--- a/src/travian_api/web/ws/analyzer_ws.py
+++ b/src/travian_api/web/ws/analyzer_ws.py
@@ -101,8 +101,18 @@ async def ws_analyze_reports(websocket: WebSocket):
 
         from travian_api.models.raid_analyzer import AnalyzerSettings
 
+        # The analysis is the heaviest read operation; running it against a
+        # guessed village would waste a large batch of Travian requests, so the
+        # source village must be explicit (the client always sends it).
+        analysis_village_id = msg.get("village_id")
+        if not analysis_village_id:
+            await tracked_send(
+                {"type": "error", "message": "village_id is required", "fatal": True}
+            )
+            return
+
         settings = AnalyzerSettings(
-            village_id=msg.get("village_id") or session.active_village_id,
+            village_id=analysis_village_id,
             min_resources=msg.get("min_resources", 200),
             max_report_age_hours=msg.get("max_report_age_hours", 24),
             max_pages=msg.get("max_pages", 3),

--- a/src/travian_api/web/ws/analyzer_ws.py
+++ b/src/travian_api/web/ws/analyzer_ws.py
@@ -62,6 +62,10 @@ async def ws_analyze_reports(websocket: WebSocket):
         await websocket.close(code=4009, reason="Raid analysis already running")
         return
 
+    # Bound before the try so the finally can reference it even if setup
+    # (ws_manager.connect / a client disconnect) fails before it is created —
+    # otherwise cleanup raises UnboundLocalError and masks the real error.
+    exec_session = None
     try:
         active_ops.register(user_id, op_type)
         await ws_manager.connect(websocket, user_id, CHANNEL)
@@ -225,5 +229,6 @@ async def ws_analyze_reports(websocket: WebSocket):
             pass
     finally:
         active_ops.unregister(user_id, op_type)
-        exec_session_manager.mark_disconnected(exec_session.id)
+        if exec_session is not None:
+            exec_session_manager.mark_disconnected(exec_session.id)
         await ws_manager.disconnect(user_id, CHANNEL, websocket)

--- a/src/travian_api/web/ws/manager.py
+++ b/src/travian_api/web/ws/manager.py
@@ -8,7 +8,7 @@ import jwt
 from fastapi import WebSocket, status
 
 from travian_api.web.auth import decode_access_token
-from travian_api.web.sessions import session_manager
+from travian_api.web.sessions import session_manager, try_restore_session
 
 logger = logging.getLogger(__name__)
 
@@ -60,13 +60,17 @@ class ConnectionManager:
 
         user_id = payload["user_id"]
 
-        # Verify user has active Travian session (when required)
+        # Verify user has active Travian session (when required). HTTP routes
+        # auto-reconnect from saved credentials, so give sockets the same
+        # chance before rejecting — otherwise a backend restart leaves every
+        # live page broken until the user reconnects by hand.
         if require_travian_session and session_manager.get(user_id) is None:
-            await websocket.accept()
-            await websocket.close(
-                code=status.WS_1008_POLICY_VIOLATION, reason="No active Travian session"
-            )
-            return None
+            if await try_restore_session(user_id) is None:
+                await websocket.accept()
+                await websocket.close(
+                    code=status.WS_1008_POLICY_VIOLATION, reason="No active Travian session"
+                )
+                return None
 
         return user_id
 

--- a/src/travian_api/web/ws/manager.py
+++ b/src/travian_api/web/ws/manager.py
@@ -12,6 +12,27 @@ from travian_api.web.sessions import session_manager, try_restore_session
 
 logger = logging.getLogger(__name__)
 
+# The subprotocol marker the frontend sends before the token:
+# `Sec-WebSocket-Protocol: travian-jwt, <JWT>`.
+_JWT_SUBPROTOCOL = "travian-jwt"
+
+
+def _token_from_subprotocol(websocket: WebSocket) -> Optional[str]:
+    """Extract the JWT carried as `travian-jwt, <token>` subprotocols.
+
+    The header is a comma-separated offer list; the value right after the
+    marker is the token. Returns None when the marker is absent so the caller
+    can fall back to the legacy query param.
+    """
+    header = websocket.headers.get("sec-websocket-protocol")
+    if not header:
+        return None
+    protocols = [p.strip() for p in header.split(",") if p.strip()]
+    for index, proto in enumerate(protocols):
+        if proto == _JWT_SUBPROTOCOL and index + 1 < len(protocols):
+            return protocols[index + 1]
+    return None
+
 
 class ConnectionManager:
     """Manages WebSocket connections keyed by user_id.
@@ -33,9 +54,15 @@ class ConnectionManager:
         *,
         require_travian_session: bool = True,
     ) -> Optional[int]:
-        """Authenticate a WebSocket connection via query parameter token.
+        """Authenticate a WebSocket connection.
 
-        Expected URL: ws://host/ws/path?token=<JWT>
+        The token is read from the ``travian-jwt`` WebSocket subprotocol
+        (``Sec-WebSocket-Protocol: travian-jwt, <JWT>``). It is deliberately
+        NOT read from the query string by default: uvicorn logs request paths
+        (with query) at INFO, which would write a reusable bearer token into
+        server logs. A legacy ``?token=`` query param is still accepted as a
+        fallback so older clients keep working.
+
         Returns user_id on success, None on failure.
         Must accept() before close() per ASGI spec.
 
@@ -45,7 +72,7 @@ class ConnectionManager:
                 when the user has no active Travian session.  Set to False for
                 endpoints like /ws/logs and /ws/sessions that only need JWT auth.
         """
-        token = websocket.query_params.get("token")
+        token = _token_from_subprotocol(websocket) or websocket.query_params.get("token")
         if not token:
             await websocket.accept()
             await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason="Missing token")

--- a/src/travian_api/web/ws/queue_ws.py
+++ b/src/travian_api/web/ws/queue_ws.py
@@ -329,8 +329,20 @@ async def queue_run_ws(websocket: WebSocket) -> None:
         await websocket.close(code=4002)
         return
 
-    if not plan.village_id and session.active_village_id:
-        plan.village_id = session.active_village_id
+    # The plan must name its village explicitly. Falling back to the session
+    # default (pinned to the login village since selection became tab-local)
+    # would run the build queue against the wrong village — a wasted, wrong
+    # sequence of Travian requests. Fail fast instead.
+    if not plan.village_id:
+        await websocket.send_json(
+            {
+                "type": "error",
+                "message": "Build plan is missing village_id.",
+                "fatal": True,
+            }
+        )
+        await websocket.close(code=4002)
+        return
 
     op_label = f"queue:{plan.village_id}"
     if op_label in active_ops.get_active(user_id):

--- a/src/travian_api/web/ws/scout_ws.py
+++ b/src/travian_api/web/ws/scout_ws.py
@@ -224,7 +224,10 @@ def _build_auto_scout_coro(config: dict):
         delay_min = config.get("delay_min", config.get("delay", 2.0))
         delay_max = config.get("delay_max", delay_min + 2.0)
         start_index = config.get("start_index", 0)
-        village_id = config.get("village_id") or session.active_village_id
+        village_id = config.get("village_id")
+        if not village_id:
+            ctx.push({"type": "error", "message": "village_id is required", "fatal": True})
+            return
         targets_from_ui = config.get("targets")
         # Recon (background) account toggle — applies only to the
         # read portion of this sweep (the prep scan / target list
@@ -773,7 +776,10 @@ def _build_scout_scan_coro(config: dict):
     async def coro(ctx: OperationContext) -> None:
         session: TravianSession = ctx.session
         radius = config.get("radius", 10)
-        village_id = config.get("village_id") or session.active_village_id
+        village_id = config.get("village_id")
+        if not village_id:
+            ctx.push({"type": "error", "message": "village_id is required", "fatal": True})
+            return
         min_pop = config.get("min_pop")
         max_pop = config.get("max_pop")
         max_player_pop = config.get("max_player_pop")

--- a/start.bat
+++ b/start.bat
@@ -19,7 +19,16 @@ if errorlevel 1 (
 )
 where npm >nul 2>&1
 if errorlevel 1 (
-    echo ERROR: 'npm' is not on PATH. Install Node.js 18+ from https://nodejs.org/
+    echo ERROR: 'npm' is not on PATH. Install Node.js 20.19+ or 22.12+ from https://nodejs.org/
+    goto :fail
+)
+:: Vite 8 (the locked frontend toolchain) requires Node ^20.19.0 or >=22.12.0.
+:: Checking only that npm exists let Node 18 pass preflight and then fail
+:: halfway through the frontend build.
+for /f "tokens=1 delims=." %%v in ('node -v') do set NODE_MAJOR=%%v
+set NODE_MAJOR=%NODE_MAJOR:v=%
+if %NODE_MAJOR% LSS 20 (
+    echo ERROR: Node %NODE_MAJOR% is too old. The frontend build needs Node 20.19+ or 22.12+.
     goto :fail
 )
 

--- a/start.bat
+++ b/start.bat
@@ -22,13 +22,29 @@ if errorlevel 1 (
     echo ERROR: 'npm' is not on PATH. Install Node.js 20.19+ or 22.12+ from https://nodejs.org/
     goto :fail
 )
+where node >nul 2>&1
+if errorlevel 1 (
+    echo ERROR: 'node' is not on PATH. Install Node.js 20.19+ or 22.12+ from https://nodejs.org/
+    goto :fail
+)
 :: Vite 8 (the locked frontend toolchain) requires Node ^20.19.0 or >=22.12.0.
-:: Checking only that npm exists let Node 18 pass preflight and then fail
-:: halfway through the frontend build.
-for /f "tokens=1 delims=." %%v in ('node -v') do set NODE_MAJOR=%%v
-set NODE_MAJOR=%NODE_MAJOR:v=%
-if %NODE_MAJOR% LSS 20 (
-    echo ERROR: Node %NODE_MAJOR% is too old. The frontend build needs Node 20.19+ or 22.12+.
+:: The check must match that range exactly: a major-only check let Node
+:: 20.0-20.18 and Node 21 pass preflight and then fail halfway through the
+:: frontend build.
+set NODE_MAJOR=
+set NODE_MINOR=
+for /f "tokens=1,2 delims=v." %%a in ('node -v') do (set NODE_MAJOR=%%a& set NODE_MINOR=%%b)
+if "%NODE_MAJOR%"=="" (
+    echo ERROR: could not read the Node version from 'node -v'.
+    goto :fail
+)
+set NODE_OK=1
+if %NODE_MAJOR% LSS 20 set NODE_OK=0
+if %NODE_MAJOR% EQU 20 if %NODE_MINOR% LSS 19 set NODE_OK=0
+if %NODE_MAJOR% EQU 21 set NODE_OK=0
+if %NODE_MAJOR% EQU 22 if %NODE_MINOR% LSS 12 set NODE_OK=0
+if %NODE_OK% EQU 0 (
+    echo ERROR: Node %NODE_MAJOR%.%NODE_MINOR% cannot build the frontend. It needs Node 20.19+ or 22.12+.
     goto :fail
 )
 

--- a/start.bat
+++ b/start.bat
@@ -53,14 +53,15 @@ if errorlevel 1 (
     echo ERROR: frontend directory not found.
     goto :fail
 )
-if not exist node_modules (
-    echo        Installing npm packages...
-    call npm install
-    if errorlevel 1 (
-        popd
-        echo ERROR: npm install failed.
-        goto :fail
-    )
+:: Always sync npm packages: after a pull, an existing node_modules can be
+:: stale against the new package-lock.json, and npm install is fast when
+:: everything is already current.
+echo        Installing npm packages...
+call npm install
+if errorlevel 1 (
+    popd
+    echo ERROR: npm install failed.
+    goto :fail
 )
 call npm run build
 if errorlevel 1 (

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env sh
+# Travian Auto Player - one-click setup and start (Linux/Mac)
+# Usage: ./start.sh from the project root
+set -e
+
+cd "$(dirname "$0")"
+
+echo ""
+echo " ============================================"
+echo "  Travian Auto Player - Setup & Start"
+echo " ============================================"
+echo ""
+
+# Preflight: require Python and Node on PATH
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: 'python3' is not on PATH. Install Python 3.11+ from https://www.python.org/downloads/"
+    exit 1
+fi
+if ! command -v npm >/dev/null 2>&1 || ! command -v node >/dev/null 2>&1; then
+    echo "ERROR: Node.js is not on PATH. Install Node.js 20.19+ or 22.12+ from https://nodejs.org/"
+    exit 1
+fi
+
+# Vite 8 (the locked frontend toolchain) requires Node ^20.19.0 or >=22.12.0.
+# The check must match that range exactly: a major-only check lets Node
+# 20.0-20.18 and Node 21 pass preflight and then fail halfway through the
+# frontend build.
+NODE_VERSION=$(node -v | sed 's/^v//')
+NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+NODE_MINOR=$(echo "$NODE_VERSION" | cut -d. -f2)
+NODE_OK=1
+[ "$NODE_MAJOR" -lt 20 ] && NODE_OK=0
+[ "$NODE_MAJOR" -eq 20 ] && [ "$NODE_MINOR" -lt 19 ] && NODE_OK=0
+[ "$NODE_MAJOR" -eq 21 ] && NODE_OK=0
+[ "$NODE_MAJOR" -eq 22 ] && [ "$NODE_MINOR" -lt 12 ] && NODE_OK=0
+if [ "$NODE_OK" -eq 0 ]; then
+    echo "ERROR: Node $NODE_VERSION cannot build the frontend. It needs Node 20.19+ or 22.12+."
+    exit 1
+fi
+
+# 1. Create/activate venv and install Python dependencies
+echo "[1/3] Installing Python dependencies..."
+if [ ! -x ".venv/bin/python" ]; then
+    echo "       Creating virtual environment at .venv ..."
+    python3 -m venv .venv
+fi
+. .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e ".[web]"
+echo "       Done."
+
+# 2. Build frontend
+echo "[2/3] Building frontend..."
+cd frontend
+# Always sync npm packages: after a pull, an existing node_modules can be
+# stale against the new package-lock.json, and npm install is fast when
+# everything is already current.
+echo "       Installing npm packages..."
+npm install
+npm run build
+cd ..
+echo "       Done."
+
+# 3. Start server
+echo "[3/3] Starting server on http://localhost:8001"
+echo ""
+echo " ============================================"
+echo "  Open http://localhost:8001 in your browser"
+echo " ============================================"
+echo ""
+python -m uvicorn travian_api.web.app:app --host 0.0.0.0 --port 8001

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared test plumbing.
+
+The URL guard resolves hostnames through real DNS in production. Tests must
+never depend on the network, so DNS is stubbed here to "resolves publicly"
+for every test; guard-specific tests override the stub per-case to exercise
+private/loopback/unresolvable outcomes.
+"""
+
+import pytest
+
+import travian_api.web.url_guard as url_guard
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch):
+    async def resolves_public(host: str) -> list[str]:
+        return ["8.8.8.8"]
+
+    monkeypatch.setattr(url_guard, "_resolve_host", resolves_public)

--- a/tests/fixtures/distribution_account.json
+++ b/tests/fixtures/distribution_account.json
@@ -1,0 +1,802 @@
+{
+ "snapshot": [
+  {
+   "village_id": 1001,
+   "name": "Capital",
+   "x": 0,
+   "y": 0,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 9800.0,
+   "clay_per_hour": 9800.0,
+   "iron_per_hour": 8200.0,
+   "crop_per_hour": 74000.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1002,
+   "name": "Hammer",
+   "x": -6,
+   "y": 4,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1800.0,
+   "clay_per_hour": 1800.0,
+   "iron_per_hour": 1800.0,
+   "crop_per_hour": -7200.0,
+   "crop_stock": 40000,
+   "crop_draining": true
+  },
+  {
+   "village_id": 1003,
+   "name": "Anvil",
+   "x": 3,
+   "y": -5,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 2900.0,
+   "clay_per_hour": 3600.0,
+   "iron_per_hour": 2200.0,
+   "crop_per_hour": -1900.0,
+   "crop_stock": 40000,
+   "crop_draining": true
+  },
+  {
+   "village_id": 1004,
+   "name": "Oakfield",
+   "x": 9,
+   "y": 2,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 2100.0,
+   "clay_per_hour": 2100.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 160.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1005,
+   "name": "Clayrun",
+   "x": -8,
+   "y": -7,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1575.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 1120.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1006,
+   "name": "Ironhold",
+   "x": 14,
+   "y": -3,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 1313.0,
+   "crop_per_hour": 1930.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1007,
+   "name": "Millbrook",
+   "x": 19,
+   "y": 6,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 2100.0,
+   "crop_per_hour": 1570.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1008,
+   "name": "Stonegate",
+   "x": 5,
+   "y": 9,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 2420.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1009,
+   "name": "Westmoor",
+   "x": -15,
+   "y": 3,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 2100.0,
+   "crop_per_hour": 2680.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1010,
+   "name": "Eastvale",
+   "x": 22,
+   "y": -8,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 525.0,
+   "clay_per_hour": 350.0,
+   "iron_per_hour": 525.0,
+   "crop_per_hour": 9380.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1011,
+   "name": "Northrun",
+   "x": -4,
+   "y": 14,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 2100.0,
+   "crop_per_hour": 2910.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1012,
+   "name": "Southbay",
+   "x": 7,
+   "y": -13,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 2100.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 2900.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1013,
+   "name": "Fernwick",
+   "x": -18,
+   "y": -11,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 2100.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 2900.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1014,
+   "name": "Harrow",
+   "x": 26,
+   "y": 11,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1313.0,
+   "clay_per_hour": 2100.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 4550.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1015,
+   "name": "Larkspur",
+   "x": -23,
+   "y": 16,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 3060.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 1313.0,
+   "crop_per_hour": 3030.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1016,
+   "name": "Duskmere",
+   "x": 31,
+   "y": -6,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 2100.0,
+   "clay_per_hour": 2100.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 3250.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1017,
+   "name": "Ravenholt",
+   "x": -9,
+   "y": -21,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 2180.0,
+   "iron_per_hour": 1313.0,
+   "crop_per_hour": 3360.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1018,
+   "name": "Thornfield",
+   "x": 17,
+   "y": 24,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 1313.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 3490.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1019,
+   "name": "Emberlyn",
+   "x": -27,
+   "y": -4,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 2100.0,
+   "iron_per_hour": 1750.0,
+   "crop_per_hour": 2840.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1020,
+   "name": "Glasswood",
+   "x": 35,
+   "y": 18,
+   "merchants_total": 19,
+   "merchants_free": 19,
+   "lumber_per_hour": 1750.0,
+   "clay_per_hour": 1750.0,
+   "iron_per_hour": 1313.0,
+   "crop_per_hour": 4750.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1021,
+   "name": "Farhaven",
+   "x": 118,
+   "y": -47,
+   "merchants_total": 20,
+   "merchants_free": 20,
+   "lumber_per_hour": 438.0,
+   "clay_per_hour": 350.0,
+   "iron_per_hour": 175.0,
+   "crop_per_hour": 10400.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1022,
+   "name": "Saltmarsh",
+   "x": -52,
+   "y": 128,
+   "merchants_total": 15,
+   "merchants_free": 15,
+   "lumber_per_hour": 266.0,
+   "clay_per_hour": 266.0,
+   "iron_per_hour": 266.0,
+   "crop_per_hour": 5670.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  },
+  {
+   "village_id": 1023,
+   "name": "Windrest",
+   "x": 40,
+   "y": 152,
+   "merchants_total": 19,
+   "merchants_free": 19,
+   "lumber_per_hour": 254.0,
+   "clay_per_hour": 254.0,
+   "iron_per_hour": 254.0,
+   "crop_per_hour": 5600.0,
+   "crop_stock": 40000,
+   "crop_draining": false
+  }
+ ],
+ "config": [
+  {
+   "village_id": 1001,
+   "trade_office_level": 18
+  },
+  {
+   "village_id": 1002,
+   "trade_office_level": 6
+  },
+  {
+   "village_id": 1003,
+   "trade_office_level": 0
+  },
+  {
+   "village_id": 1004,
+   "trade_office_level": 12
+  },
+  {
+   "village_id": 1005,
+   "trade_office_level": 8
+  },
+  {
+   "village_id": 1006,
+   "trade_office_level": 8
+  },
+  {
+   "village_id": 1007,
+   "trade_office_level": 9
+  },
+  {
+   "village_id": 1008,
+   "trade_office_level": 11
+  },
+  {
+   "village_id": 1009,
+   "trade_office_level": 5
+  },
+  {
+   "village_id": 1010,
+   "trade_office_level": 13
+  },
+  {
+   "village_id": 1011,
+   "trade_office_level": 5
+  },
+  {
+   "village_id": 1012,
+   "trade_office_level": 7
+  },
+  {
+   "village_id": 1013,
+   "trade_office_level": 5
+  },
+  {
+   "village_id": 1014,
+   "trade_office_level": 14
+  },
+  {
+   "village_id": 1015,
+   "trade_office_level": 14
+  },
+  {
+   "village_id": 1016,
+   "trade_office_level": 11
+  },
+  {
+   "village_id": 1017,
+   "trade_office_level": 7
+  },
+  {
+   "village_id": 1018,
+   "trade_office_level": 13
+  },
+  {
+   "village_id": 1019,
+   "trade_office_level": 9
+  },
+  {
+   "village_id": 1020,
+   "trade_office_level": 11
+  },
+  {
+   "village_id": 1021,
+   "trade_office_level": 14
+  },
+  {
+   "village_id": 1022,
+   "trade_office_level": 0
+  },
+  {
+   "village_id": 1023,
+   "trade_office_level": 11
+  }
+ ],
+ "allocations": {
+  "lumber": {
+   "1001": {
+    "mode": "remainder",
+    "value": 0
+   },
+   "1002": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1003": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1004": {
+    "mode": "absolute",
+    "value": 7559
+   },
+   "1005": {
+    "mode": "absolute",
+    "value": 7559
+   },
+   "1006": {
+    "mode": "absolute",
+    "value": 7559
+   },
+   "1007": {
+    "mode": "absolute",
+    "value": 7559
+   },
+   "1008": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1009": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1010": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1011": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1012": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1013": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1014": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1015": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1016": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1017": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1018": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1019": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1020": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1021": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1022": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1023": {
+    "mode": "absolute",
+    "value": 827
+   }
+  },
+  "clay": {
+   "1001": {
+    "mode": "remainder",
+    "value": 0
+   },
+   "1002": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1003": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1004": {
+    "mode": "absolute",
+    "value": 4664
+   },
+   "1005": {
+    "mode": "absolute",
+    "value": 4664
+   },
+   "1006": {
+    "mode": "absolute",
+    "value": 4664
+   },
+   "1007": {
+    "mode": "absolute",
+    "value": 4664
+   },
+   "1008": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1009": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1010": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1011": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1012": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1013": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1014": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1015": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1016": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1017": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1018": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1019": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1020": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1021": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1022": {
+    "mode": "absolute",
+    "value": 926
+   },
+   "1023": {
+    "mode": "absolute",
+    "value": 926
+   }
+  },
+  "iron": {
+   "1001": {
+    "mode": "remainder",
+    "value": 0
+   },
+   "1002": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1003": {
+    "mode": "absolute",
+    "value": 827
+   },
+   "1004": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1005": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1006": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1007": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1008": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1009": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1010": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1011": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1012": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1013": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1014": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1015": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1016": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1017": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1018": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1019": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1020": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1021": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1022": {
+    "mode": "absolute",
+    "value": 891
+   },
+   "1023": {
+    "mode": "absolute",
+    "value": 891
+   }
+  },
+  "crop": {
+   "1001": {
+    "mode": "remainder",
+    "value": 0
+   },
+   "1002": {
+    "mode": "sustain",
+    "value": 3
+   },
+   "1003": {
+    "mode": "sustain",
+    "value": 3
+   },
+   "1004": {
+    "mode": "absolute",
+    "value": 1785
+   },
+   "1005": {
+    "mode": "absolute",
+    "value": 1785
+   },
+   "1006": {
+    "mode": "absolute",
+    "value": 1785
+   },
+   "1007": {
+    "mode": "absolute",
+    "value": 1785
+   },
+   "1008": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1009": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1010": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1011": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1012": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1013": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1014": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1015": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1016": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1017": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1018": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1019": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1020": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1021": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1022": {
+    "mode": "absolute",
+    "value": 187
+   },
+   "1023": {
+    "mode": "absolute",
+    "value": 187
+   }
+  }
+ },
+ "map_span": 401,
+ "speed_fields_per_hour": 12,
+ "merchant_base_capacity": 2200,
+ "trade_office_bonus_per_level": 0.2
+}

--- a/tests/test_auth_redirect_ssrf.py
+++ b/tests/test_auth_redirect_ssrf.py
@@ -1,0 +1,64 @@
+"""The post-login redirect must stay on the server the user connected to.
+
+AuthService.login follows the login host's `redirectTo` through get_html,
+which accepts absolute URLs. A malicious or compromised server could point it
+at a loopback or private service, making authenticated login an SSRF vector
+past the connect-time URL guard. These tests pin that off-host redirects are
+refused and same-host / relative ones pass through.
+"""
+
+import pytest
+
+from travian_api.config import Settings
+from travian_api.exceptions import AuthError
+from travian_api.services.auth_service import AuthService
+
+
+class _StubClient:
+    """Enough of HttpClient for AuthService.__init__; never called otherwise."""
+
+    def set_auth_callback(self, _cb) -> None:
+        pass
+
+
+def _service() -> AuthService:
+    settings = Settings(
+        base_url="https://ts20.x2.europe.travian.com",
+        username="u@example.com",
+        password="pw",
+    )
+    # No network happens in _safe_login_redirect; the client is never touched.
+    return AuthService(http_client=_StubClient(), settings=settings)
+
+
+class TestRedirectGuard:
+    def test_a_loopback_redirect_is_refused(self):
+        svc = _service()
+        with pytest.raises(AuthError, match="off-server"):
+            svc._safe_login_redirect("http://127.0.0.1:8000/steal")
+
+    def test_a_private_host_redirect_is_refused(self):
+        svc = _service()
+        with pytest.raises(AuthError, match="off-server"):
+            svc._safe_login_redirect("https://192.168.1.10/admin")
+
+    def test_a_different_public_host_is_refused(self):
+        svc = _service()
+        with pytest.raises(AuthError, match="off-server"):
+            svc._safe_login_redirect("https://evil.example.com/x")
+
+    def test_plain_http_same_host_is_refused(self):
+        svc = _service()
+        with pytest.raises(AuthError, match="off-server"):
+            svc._safe_login_redirect("http://ts20.x2.europe.travian.com/x")
+
+    def test_same_host_https_passes(self):
+        svc = _service()
+        url = "https://ts20.x2.europe.travian.com/api/v1/auth/redirect?code=abc"
+        assert svc._safe_login_redirect(url) == url
+
+    def test_a_relative_redirect_passes(self):
+        svc = _service()
+        assert svc._safe_login_redirect("/api/v1/auth/redirect?code=abc") == (
+            "/api/v1/auth/redirect?code=abc"
+        )

--- a/tests/test_build_queue_idle_wait.py
+++ b/tests/test_build_queue_idle_wait.py
@@ -78,14 +78,20 @@ def test_resource_short_clamp_boundaries(monkeypatch):
 
     monkeypatch.setattr(bq.HumanTiming, "delay", staticmethod(lambda *a, **k: 5.0))
     _, low = bq._resolve_idle_wait(
-        any_no_checksum=False, any_resource_short=True, next_prio=1,
-        poll_interval_s=30.0, stealth_enabled=True,
+        any_no_checksum=False,
+        any_resource_short=True,
+        next_prio=1,
+        poll_interval_s=30.0,
+        stealth_enabled=True,
     )
     assert low == 120.0  # tiny draw clamps up
 
     monkeypatch.setattr(bq.HumanTiming, "delay", staticmethod(lambda *a, **k: 5000.0))
     _, high = bq._resolve_idle_wait(
-        any_no_checksum=False, any_resource_short=True, next_prio=1,
-        poll_interval_s=30.0, stealth_enabled=True,
+        any_no_checksum=False,
+        any_resource_short=True,
+        next_prio=1,
+        poll_interval_s=30.0,
+        stealth_enabled=True,
     )
     assert high == 600.0  # huge draw clamps down

--- a/tests/test_crop_balance.py
+++ b/tests/test_crop_balance.py
@@ -188,21 +188,22 @@ class TestAccountWideFetch:
         assert balances[20003].draining is True
         assert balances[20011].net_per_hour > 0
 
-    def test_costs_two_requests_when_capacity_is_cached(self):
-        """Granary capacity changes only on upgrade, so it caches."""
+    def test_still_fetches_capacity_for_storage_safety_even_when_granary_cached(self):
+        """A cached granary map seeds crop derivation, but the capacity page is
+        still read: its WAREHOUSE figures are the planner's only source for
+        lumber/clay/iron overflow safety, and skipping the page would silently
+        disable those checks."""
         http = _StatsHttp()
 
-        balances, _caps, requests_spent = asyncio.run(
+        balances, caps, requests_spent = asyncio.run(
             BuildingService(http).get_all_villages_net_crop(
                 granary_capacity={20003: 240000, 20011: 160000}
             )
         )
 
-        assert http.urls == [
-            "/village/statistics/resources",
-            "/village/statistics/resources/warehouse",
-        ]
-        assert requests_spent == 2
+        assert "/village/statistics/resources/capacity" in http.urls
+        assert requests_spent == 3
+        assert caps and all("warehouse" in c for c in caps.values())
         assert balances[20011].net_per_hour > 0
 
     def test_a_village_with_no_stock_reading_is_underived_not_zero(self):
@@ -224,14 +225,20 @@ class TestAccountWideFetch:
         assert balances[20003].net_per_hour is None
         assert balances[20003].draining is True
 
-    def test_an_all_draining_account_never_fetches_capacity(self):
-        """Capacity only matters for filling villages."""
+    def test_an_all_draining_account_still_fetches_capacity_for_storage_safety(self):
+        """Regression for the silent-overflow bug: even when every granary is
+        draining (so crop derivation needs no capacity), the capacity page must
+        still be fetched — its warehouse figures are the only source for storage
+        overflow safety, and gating it on crop direction disabled those checks."""
         http = _StatsHttp()
         http.get_html = _only_draining(http)
 
-        asyncio.run(BuildingService(http).get_all_villages_net_crop())
+        _balances, caps, _spent = asyncio.run(BuildingService(http).get_all_villages_net_crop())
 
-        assert not any("capacity" in url for url in http.urls)
+        assert any("capacity" in url for url in http.urls), (
+            "storage safety needs the capacity page even on an all-draining account"
+        )
+        assert caps and all("warehouse" in c for c in caps.values())
 
 
 def _only_draining(http: _StatsHttp):
@@ -245,7 +252,7 @@ def _only_draining(http: _StatsHttp):
         if url.endswith("/warehouse"):
             return draining_only
         if url.endswith("/capacity"):
-            raise AssertionError("capacity must not be fetched when nothing is filling")
+            return CAPACITY_HTML
         return RESOURCES_HTML
 
     return get_html

--- a/tests/test_crop_balance.py
+++ b/tests/test_crop_balance.py
@@ -62,6 +62,44 @@ CAPACITY_HTML = """
 """
 
 
+# Markup captured from the live account (Europe 2). The draining granary marks
+# the countdown with a leading `crit` minus span, and the timer span carries a
+# DUPLICATE class attribute (`class="timer crit" class="timer"`) — BeautifulSoup
+# keeps the second, dropping `crit`, so the draining flag can NOT be read off the
+# timer span. The non-draining row has a plain timer span and no crit anywhere.
+REAL_WAREHOUSE_HTML = """
+<table id="warehouse"><tbody>
+    <tr class="hover">
+        <td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+        <td class="lum">28%</td><td class="clay">28%</td><td class="iron">28%</td>
+        <td class="max123"><span class="timer" counting="down" value="72065">20:01:05</span></td>
+        <td class="crop">28%</td>
+        <td class="max4 lc"><span class="crit">&minus;</span>&nbsp;<span class="timer crit" class="timer" counting="down" value="32701">9:05:01</span></td>
+    </tr>
+    <tr class="hover">
+        <td class="vil fc"><a href="/dorf1.php?newdid=20002">02</a></td>
+        <td class="lum">86%</td><td class="clay">86%</td><td class="iron">86%</td>
+        <td class="max123"><span class="timer" counting="down" value="60000">16:40:00</span></td>
+        <td class="crop">86%</td>
+        <td class="max4 lc"><span  class="timer" counting="down" value="4996">1:23:16</span></td>
+    </tr>
+</tbody></table>
+"""
+
+
+class TestRealDrainingMarkup:
+    def test_draining_is_detected_despite_the_duplicate_timer_class(self):
+        """Regression: every village came back draining=False because the flag
+        was read off the timer span, whose duplicate class attribute drops
+        `crit`. The leading crit minus span is the reliable signal."""
+        out = parse_village_stats_warehouse(REAL_WAREHOUSE_HTML)
+
+        assert out[20003]["crop_draining"] is True
+        assert out[20003]["crop_seconds"] == 32701
+        assert out[20002]["crop_draining"] is False
+        assert out[20002]["crop_seconds"] == 4996
+
+
 class TestWarehouseParser:
     def test_reads_raw_seconds_and_direction(self):
         out = parse_village_stats_warehouse(WAREHOUSE_HTML)

--- a/tests/test_crop_balance.py
+++ b/tests/test_crop_balance.py
@@ -163,6 +163,25 @@ class TestAccountWideFetch:
         ]
         assert balances[20011].net_per_hour > 0
 
+    def test_a_village_with_no_stock_reading_is_underived_not_zero(self):
+        """Defaulting the stock to 0 makes a draining village derive to exactly
+        0/h, which is indistinguishable from healthy."""
+        http = _StatsHttp()
+        original = http.get_html
+
+        async def missing_stock(url: str, skip_reauth: bool = True) -> str:
+            html = await original(url, skip_reauth)
+            if url.endswith("/resources"):
+                # Drop village 03 from the stocks table only.
+                return RESOURCES_HTML.replace("20003", "99999")
+            return html
+
+        http.get_html = missing_stock
+        balances = asyncio.run(BuildingService(http).get_all_villages_net_crop())
+
+        assert balances[20003].net_per_hour is None
+        assert balances[20003].draining is True
+
     def test_an_all_draining_account_never_fetches_capacity(self):
         """Capacity only matters for filling villages."""
         http = _StatsHttp()

--- a/tests/test_crop_balance.py
+++ b/tests/test_crop_balance.py
@@ -174,7 +174,9 @@ class TestAccountWideFetch:
     def test_costs_three_requests_when_capacity_is_unknown(self):
         http = _StatsHttp()
 
-        balances, requests_spent = asyncio.run(BuildingService(http).get_all_villages_net_crop())
+        balances, _caps, requests_spent = asyncio.run(
+            BuildingService(http).get_all_villages_net_crop()
+        )
 
         assert http.urls == [
             "/village/statistics/resources",
@@ -190,7 +192,7 @@ class TestAccountWideFetch:
         """Granary capacity changes only on upgrade, so it caches."""
         http = _StatsHttp()
 
-        balances, requests_spent = asyncio.run(
+        balances, _caps, requests_spent = asyncio.run(
             BuildingService(http).get_all_villages_net_crop(
                 granary_capacity={20003: 240000, 20011: 160000}
             )
@@ -217,7 +219,7 @@ class TestAccountWideFetch:
             return html
 
         http.get_html = missing_stock
-        balances, _ = asyncio.run(BuildingService(http).get_all_villages_net_crop())
+        balances, _caps, _spent = asyncio.run(BuildingService(http).get_all_villages_net_crop())
 
         assert balances[20003].net_per_hour is None
         assert balances[20003].draining is True

--- a/tests/test_crop_balance.py
+++ b/tests/test_crop_balance.py
@@ -136,13 +136,14 @@ class TestAccountWideFetch:
     def test_costs_three_requests_when_capacity_is_unknown(self):
         http = _StatsHttp()
 
-        balances = asyncio.run(BuildingService(http).get_all_villages_net_crop())
+        balances, requests_spent = asyncio.run(BuildingService(http).get_all_villages_net_crop())
 
         assert http.urls == [
             "/village/statistics/resources",
             "/village/statistics/resources/warehouse",
             "/village/statistics/resources/capacity",
         ]
+        assert requests_spent == 3
         assert balances[20003].net_per_hour == pytest.approx(-5527, rel=1e-3)
         assert balances[20003].draining is True
         assert balances[20011].net_per_hour > 0
@@ -151,7 +152,7 @@ class TestAccountWideFetch:
         """Granary capacity changes only on upgrade, so it caches."""
         http = _StatsHttp()
 
-        balances = asyncio.run(
+        balances, requests_spent = asyncio.run(
             BuildingService(http).get_all_villages_net_crop(
                 granary_capacity={20003: 240000, 20011: 160000}
             )
@@ -161,6 +162,7 @@ class TestAccountWideFetch:
             "/village/statistics/resources",
             "/village/statistics/resources/warehouse",
         ]
+        assert requests_spent == 2
         assert balances[20011].net_per_hour > 0
 
     def test_a_village_with_no_stock_reading_is_underived_not_zero(self):
@@ -177,7 +179,7 @@ class TestAccountWideFetch:
             return html
 
         http.get_html = missing_stock
-        balances = asyncio.run(BuildingService(http).get_all_villages_net_crop())
+        balances, _ = asyncio.run(BuildingService(http).get_all_villages_net_crop())
 
         assert balances[20003].net_per_hour is None
         assert balances[20003].draining is True

--- a/tests/test_crop_balance.py
+++ b/tests/test_crop_balance.py
@@ -1,0 +1,190 @@
+"""Net crop for the whole account from the granary countdown.
+
+Markup is trimmed from a real /village/statistics/resources/warehouse capture.
+Inverting the countdown avoids the upkeep model entirely, which matters because
+consumption is charged where troops *stand*: a village's own army may be
+reinforcing elsewhere while foreign troops eat its crop, so no arithmetic over
+"own troops" can produce the right answer.
+"""
+
+import asyncio
+
+import pytest
+
+from travian_api.parsers.html_parser import parse_village_stats_warehouse
+from travian_api.services.building_service import BuildingService, derive_net_crop_per_hour
+
+WAREHOUSE_HTML = """
+<table cellpadding="1" cellspacing="1" id="warehouse">
+    <thead><tr>
+        <td onclick="sortByColumnOrder('sortIndex')">Village</td>
+        <td><i class="r1"></i></td><td><i class="r2"></i></td><td><i class="r3"></i></td>
+        <td><img class="clock" alt="Duration"></td>
+        <td><i class="r4"></i></td>
+        <td><img class="clock" alt="Duration"></td>
+    </tr></thead>
+    <tbody>
+    <tr class="hover" "="">
+        <td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+        <td class="lum">‭‭55‬%‬</td><td class="clay">‭‭53‬%‬</td><td class="iron">‭‭58‬%‬</td>
+        <td class="max123"><span class="timer" counting="down" value="72065" data-value="72065">20:01:05</span></td>
+        <td class="crop">‭‭28‬%‬</td>
+        <td class="max4 lc"><span class="crit">−</span>&nbsp;<span class="timer crit" counting="down" value="43899" data-value="43899">12:11:39</span></td>
+    </tr><tr class="hover" "="">
+        <td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+        <td class="lum">‭‭18‬%‬</td><td class="clay">‭‭35‬%‬</td><td class="iron">‭‭0‬%‬</td>
+        <td class="max123"><span class="timer" counting="down" value="88017" data-value="88017">24:26:57</span></td>
+        <td class="crop">‭‭56‬%‬</td>
+        <td class="max4 lc"><span class="timer" counting="down" value="211328" data-value="211328">58:42:08</span></td>
+    </tr>
+    </tbody>
+</table>
+"""
+
+RESOURCES_HTML = """
+<table id="ressources"><tbody>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+        <td class="lum">‭1‬</td><td class="clay">‭1‬</td><td class="iron">‭1‬</td>
+        <td class="crop">‭67,397‬</td><td class="tra lc"><a href="#">‭20‬/‭20‬</a></td></tr>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+        <td class="lum">‭1‬</td><td class="clay">‭1‬</td><td class="iron">‭1‬</td>
+        <td class="crop">‭89,600‬</td><td class="tra lc"><a href="#">‭20‬/‭20‬</a></td></tr>
+</tbody></table>
+"""
+
+CAPACITY_HTML = """
+<table id="capacity"><tbody>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+        <td class="max123">‭160,000‬</td><td class="max4">‭240,000‬</td></tr>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+        <td class="max123">‭160,000‬</td><td class="max4">‭160,000‬</td></tr>
+</tbody></table>
+"""
+
+
+class TestWarehouseParser:
+    def test_reads_raw_seconds_and_direction(self):
+        out = parse_village_stats_warehouse(WAREHOUSE_HTML)
+
+        assert out[20003]["crop_seconds"] == 43899
+        assert out[20003]["crop_draining"] is True
+        assert out[20011]["crop_seconds"] == 211328
+        assert out[20011]["crop_draining"] is False
+
+    def test_reads_percentages_and_the_warehouse_timer(self):
+        out = parse_village_stats_warehouse(WAREHOUSE_HTML)
+
+        assert out[20003]["crop_percent"] == 28
+        assert out[20003]["warehouse_seconds"] == 72065
+
+    def test_tolerates_the_malformed_row_markup(self):
+        """Real rows are emitted as `<tr class="hover" "="">`."""
+        assert set(parse_village_stats_warehouse(WAREHOUSE_HTML)) == {20003, 20011}
+
+    def test_missing_table_yields_nothing(self):
+        assert parse_village_stats_warehouse("<html>nope</html>") == {}
+
+
+class TestDerivation:
+    def test_draining_village_matches_the_rate_the_game_reports(self):
+        """V03: 67,397 crop draining at -5,556/h empties in 43,670s.
+
+        Cross-checked against that village's own dorf1 blob, which reports
+        production.l4 = -5556.
+        """
+        net = derive_net_crop_per_hour(stock=67397, seconds_remaining=43670, draining=True)
+
+        assert net == pytest.approx(-5556, rel=1e-3)
+
+    def test_draining_village_needs_no_granary_capacity(self):
+        """Which is why a starving-village report costs only two requests."""
+        assert derive_net_crop_per_hour(67397, 43899, draining=True) is not None
+
+    def test_filling_village_uses_headroom(self):
+        net = derive_net_crop_per_hour(
+            stock=89600, seconds_remaining=211328, draining=False, granary_capacity=160000
+        )
+
+        assert net == pytest.approx((160000 - 89600) / (211328 / 3600))
+        assert net > 0
+
+    def test_filling_village_without_capacity_returns_none_not_zero(self):
+        """A silent zero reads as a healthy village. This codebase has shipped
+        that bug three times; do not add a fourth."""
+        assert derive_net_crop_per_hour(89600, 211328, draining=False) is None
+
+    def test_a_stopped_countdown_is_underivable(self):
+        assert derive_net_crop_per_hour(1000, 0, draining=True) is None
+
+
+class _StatsHttp:
+    """Serves the three statistics tables and records what was requested."""
+
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    async def get_html(self, url: str, skip_reauth: bool = True) -> str:
+        self.urls.append(url)
+        if url.endswith("/warehouse"):
+            return WAREHOUSE_HTML
+        if url.endswith("/capacity"):
+            return CAPACITY_HTML
+        return RESOURCES_HTML
+
+
+class TestAccountWideFetch:
+    def test_costs_three_requests_when_capacity_is_unknown(self):
+        http = _StatsHttp()
+
+        balances = asyncio.run(BuildingService(http).get_all_villages_net_crop())
+
+        assert http.urls == [
+            "/village/statistics/resources",
+            "/village/statistics/resources/warehouse",
+            "/village/statistics/resources/capacity",
+        ]
+        assert balances[20003].net_per_hour == pytest.approx(-5527, rel=1e-3)
+        assert balances[20003].draining is True
+        assert balances[20011].net_per_hour > 0
+
+    def test_costs_two_requests_when_capacity_is_cached(self):
+        """Granary capacity changes only on upgrade, so it caches."""
+        http = _StatsHttp()
+
+        balances = asyncio.run(
+            BuildingService(http).get_all_villages_net_crop(
+                granary_capacity={20003: 240000, 20011: 160000}
+            )
+        )
+
+        assert http.urls == [
+            "/village/statistics/resources",
+            "/village/statistics/resources/warehouse",
+        ]
+        assert balances[20011].net_per_hour > 0
+
+    def test_an_all_draining_account_never_fetches_capacity(self):
+        """Capacity only matters for filling villages."""
+        http = _StatsHttp()
+        http.get_html = _only_draining(http)
+
+        asyncio.run(BuildingService(http).get_all_villages_net_crop())
+
+        assert not any("capacity" in url for url in http.urls)
+
+
+def _only_draining(http: _StatsHttp):
+    draining_only = WAREHOUSE_HTML.replace(
+        '<span class="timer" counting="down" value="211328" data-value="211328">',
+        '<span class="timer crit" counting="down" value="211328" data-value="211328">',
+    )
+
+    async def get_html(url: str, skip_reauth: bool = True) -> str:
+        http.urls.append(url)
+        if url.endswith("/warehouse"):
+            return draining_only
+        if url.endswith("/capacity"):
+            raise AssertionError("capacity must not be fetched when nothing is filling")
+        return RESOURCES_HTML
+
+    return get_html

--- a/tests/test_defense_cache.py
+++ b/tests/test_defense_cache.py
@@ -1,0 +1,52 @@
+"""Defense-cache isolation: entries belong to one server+account, never shared.
+
+The cache key used to be bare coordinates. Two users on different worlds (or
+two accounts on one world) scanning the same (x, y) would read each other's
+defense reports -- and raid decisions made from another account's report are
+unsafe. These tests pin that every path (L1, L2, in-flight coalescing) is
+scoped.
+"""
+
+import asyncio
+
+from travian_api.services.defense_cache import TieredDefenseCache
+
+SCOPE_A = "https://ts20.x2.europe.travian.com|Attacker"
+SCOPE_B = "https://ts6.x1.america.travian.com|OtherPlayer"
+
+
+class TestScopedKeys:
+    def test_another_scope_never_sees_the_entry(self, tmp_path):
+        cache = TieredDefenseCache(disk_dir=tmp_path)
+        cache.put(SCOPE_A, 12, 120, last_raid_time=1_000, defense_data={"defender_total": 55})
+
+        assert cache.get(SCOPE_A, 12, 120, last_raid_time=1_000) is not None
+        assert cache.get(SCOPE_B, 12, 120, last_raid_time=1_000) is None, (
+            "same coordinates on another world/account must be a miss"
+        )
+
+    def test_another_scope_misses_even_after_l1_expiry(self, tmp_path):
+        """The L2 (disk) path is a separate lookup; it must be scoped too."""
+        cache = TieredDefenseCache(disk_dir=tmp_path)
+        cache.put(SCOPE_A, 12, 120, last_raid_time=1_000, defense_data={"defender_total": 55})
+        cache._l1.clear()  # force the read down to disk
+
+        assert cache.get(SCOPE_B, 12, 120, last_raid_time=1_000) is None
+        assert cache.get(SCOPE_A, 12, 120, last_raid_time=1_000) is not None
+
+    def test_inflight_coalescing_is_scoped(self, tmp_path):
+        """A fetch in flight for one account must not hand its future -- and
+        with it, that account's defense report -- to another account asking
+        about the same coordinates."""
+
+        async def scenario():
+            cache = TieredDefenseCache(disk_dir=tmp_path)
+            cache.set_inflight(SCOPE_A, 12, 120)
+            try:
+                assert cache.get_inflight(SCOPE_B, 12, 120) is None
+                assert cache.get_inflight(SCOPE_A, 12, 120) is not None
+            finally:
+                cache.clear_inflight(SCOPE_A, 12, 120)
+            assert cache.get_inflight(SCOPE_A, 12, 120) is None
+
+        asyncio.run(scenario())

--- a/tests/test_distribution_allocation.py
+++ b/tests/test_distribution_allocation.py
@@ -173,16 +173,17 @@ class TestDefaultsAndValidation:
         with pytest.raises(AllocationError):
             Allocation(AllocationMode.PERCENTAGE, value)
 
-    def test_percentage_against_a_crop_negative_account_warns(self):
-        """30% of a net -4,000/h account is a target of -1,200, which reads as
-        an instruction to ship crop out of a starving village."""
-        plan = resolve_resource(
-            Resource.CROP,
-            productions={1: -5000, 2: 1000},
-            allocations={2: pct(30)},
-        )
-
-        assert any("negative" in w for w in plan.warnings)
+    def test_percentage_against_a_crop_negative_account_is_rejected(self):
+        """30% of a net -4,000/h account is a target of -1,200 — an instruction
+        to ship crop out of a starving village. A warning is not enough: the
+        resolved routes are wrong, not merely noisy, so the plan must not
+        resolve at all."""
+        with pytest.raises(AllocationError, match="negative"):
+            resolve_resource(
+                Resource.CROP,
+                productions={1: -5000, 2: 1000},
+                allocations={2: pct(30)},
+            )
 
     def test_negative_total_production_still_resolves(self):
         """An account can be crop-negative overall; the planner must not break."""

--- a/tests/test_distribution_allocation.py
+++ b/tests/test_distribution_allocation.py
@@ -173,6 +173,17 @@ class TestDefaultsAndValidation:
         with pytest.raises(AllocationError):
             Allocation(AllocationMode.PERCENTAGE, value)
 
+    def test_percentage_against_a_crop_negative_account_warns(self):
+        """30% of a net -4,000/h account is a target of -1,200, which reads as
+        an instruction to ship crop out of a starving village."""
+        plan = resolve_resource(
+            Resource.CROP,
+            productions={1: -5000, 2: 1000},
+            allocations={2: pct(30)},
+        )
+
+        assert any("negative" in w for w in plan.warnings)
+
     def test_negative_total_production_still_resolves(self):
         """An account can be crop-negative overall; the planner must not break."""
         plan = resolve_resource(

--- a/tests/test_distribution_allocation.py
+++ b/tests/test_distribution_allocation.py
@@ -1,0 +1,185 @@
+"""Allocation resolution.
+
+Known issue #1 — shipping the target instead of the gap — is the error this
+module exists to prevent, so it gets the most direct tests.
+"""
+
+import pytest
+
+from travian_api.services.distribution.allocation import (
+    Allocation,
+    AllocationError,
+    AllocationMode,
+    Resource,
+    resolve_resource,
+)
+
+KEEP = Allocation(AllocationMode.KEEP)
+
+
+def pct(value: float) -> Allocation:
+    return Allocation(AllocationMode.PERCENTAGE, value)
+
+
+class TestShipVersusTarget:
+    def test_ship_is_the_gap_not_the_target(self):
+        """Known issue #1. A village producing 400 that should hold 1,000
+        receives 600 -- not 1,000."""
+        plan = resolve_resource(
+            Resource.IRON,
+            productions={1: 400, 2: 600},
+            allocations={1: Allocation(AllocationMode.ABSOLUTE, 1000), 2: KEEP},
+        )
+        village = next(v for v in plan.villages if v.village_id == 1)
+
+        assert village.target_per_hour == 1000
+        assert village.ship_per_hour == 600
+
+    def test_a_village_keeping_exactly_what_it_makes_ships_nothing(self):
+        plan = resolve_resource(
+            Resource.LUMBER,
+            productions={1: 500},
+            allocations={1: Allocation(AllocationMode.ABSOLUTE, 500)},
+        )
+
+        assert plan.villages[0].ship_per_hour == 0
+        assert not plan.villages[0].is_receiver
+        assert not plan.villages[0].is_sender
+
+    def test_a_village_below_its_own_production_becomes_a_sender(self):
+        plan = resolve_resource(
+            Resource.CLAY,
+            productions={1: 900},
+            allocations={1: Allocation(AllocationMode.ABSOLUTE, 200)},
+        )
+
+        assert plan.villages[0].ship_per_hour == -700
+        assert plan.villages[0].is_sender
+
+
+class TestConservation:
+    def test_shipping_nets_to_zero_with_a_remainder_village(self):
+        """Nothing is created or destroyed in transit."""
+        plan = resolve_resource(
+            Resource.IRON,
+            productions={1: 1000, 2: 2000, 3: 3000},
+            allocations={
+                1: pct(50),
+                2: Allocation(AllocationMode.ABSOLUTE, 500),
+                3: Allocation(AllocationMode.REMAINDER),
+            },
+        )
+
+        assert plan.is_conserved
+        assert sum(v.ship_per_hour for v in plan.receivers) == pytest.approx(
+            -sum(v.ship_per_hour for v in plan.senders)
+        )
+
+    def test_remainder_absorbs_the_slack_from_partial_percentages(self):
+        """Known issue #9: percentages summing to 96% left 4% unassigned."""
+        plan = resolve_resource(
+            Resource.LUMBER,
+            productions={1: 5000, 2: 3000, 3: 2000},
+            allocations={1: pct(60), 2: pct(36), 3: Allocation(AllocationMode.REMAINDER)},
+        )
+        remainder = next(v for v in plan.villages if v.village_id == 3)
+
+        assert plan.unallocated == pytest.approx(400)  # 4% of 10,000
+        assert remainder.target_per_hour == pytest.approx(400)
+        assert plan.is_conserved
+
+
+class TestRemainderRules:
+    def test_two_remainder_villages_are_rejected(self):
+        with pytest.raises(AllocationError, match="exactly one remainder"):
+            resolve_resource(
+                Resource.CROP,
+                productions={1: 100, 2: 100},
+                allocations={
+                    1: Allocation(AllocationMode.REMAINDER),
+                    2: Allocation(AllocationMode.REMAINDER),
+                },
+            )
+
+    def test_unassigned_slack_without_a_remainder_warns(self):
+        plan = resolve_resource(
+            Resource.LUMBER,
+            productions={1: 5000, 2: 5000},
+            allocations={1: pct(60), 2: pct(36)},
+        )
+
+        assert not plan.is_conserved
+        assert any("unallocated" in w for w in plan.warnings)
+
+    def test_over_allocation_warns_about_the_remainder_going_negative(self):
+        """No single percentage may exceed 100, but a set of them can."""
+        plan = resolve_resource(
+            Resource.IRON,
+            productions={1: 1000, 2: 1000, 3: 1000},
+            allocations={1: pct(80), 2: pct(60), 3: Allocation(AllocationMode.REMAINDER)},
+        )
+
+        assert plan.unallocated == pytest.approx(-1200)  # 140% of 3,000
+        assert any("exceed production" in w for w in plan.warnings)
+
+
+class TestSustainMode:
+    def test_sustain_covers_the_deficit_plus_headroom(self):
+        """Real figures: village 03 drains 5,556 crop/h. At 13% headroom it
+        must receive 6,278/h and ends up 722/h positive."""
+        plan = resolve_resource(
+            Resource.CROP,
+            productions={20003: -5556, 2: 20000},
+            allocations={
+                20003: Allocation(AllocationMode.SUSTAIN, 13),
+                2: Allocation(AllocationMode.REMAINDER),
+            },
+        )
+        army = next(v for v in plan.villages if v.village_id == 20003)
+
+        assert army.ship_per_hour == pytest.approx(6278.28)
+        assert army.target_per_hour == pytest.approx(722.28)
+        assert plan.is_conserved
+
+    def test_sustain_on_a_healthy_village_ships_nothing_and_warns(self):
+        """Sustain is a floor, not a top-up; a positive village needs no crop."""
+        plan = resolve_resource(
+            Resource.CROP,
+            productions={1: 4000},
+            allocations={1: Allocation(AllocationMode.SUSTAIN, 13)},
+        )
+
+        assert plan.villages[0].ship_per_hour == 0
+        assert any("nothing to sustain" in w for w in plan.warnings)
+
+    def test_negative_headroom_is_rejected(self):
+        with pytest.raises(AllocationError):
+            Allocation(AllocationMode.SUSTAIN, -5)
+
+
+class TestDefaultsAndValidation:
+    def test_unlisted_villages_keep_their_own_production(self):
+        plan = resolve_resource(Resource.IRON, productions={1: 700, 2: 300}, allocations={})
+
+        assert all(v.ship_per_hour == 0 for v in plan.villages)
+        assert plan.is_conserved
+
+    def test_allocation_for_an_unknown_village_is_rejected(self):
+        with pytest.raises(AllocationError, match="no production"):
+            resolve_resource(Resource.IRON, productions={1: 100}, allocations={99: pct(50)})
+
+    @pytest.mark.parametrize("value", [-1, 101])
+    def test_percentage_outside_range_is_rejected(self, value):
+        with pytest.raises(AllocationError):
+            Allocation(AllocationMode.PERCENTAGE, value)
+
+    def test_negative_total_production_still_resolves(self):
+        """An account can be crop-negative overall; the planner must not break."""
+        plan = resolve_resource(
+            Resource.CROP,
+            productions={1: -5000, 2: 1000},
+            allocations={2: Allocation(AllocationMode.REMAINDER)},
+        )
+
+        assert plan.total_production == -4000
+        assert plan.is_conserved

--- a/tests/test_distribution_day_check.py
+++ b/tests/test_distribution_day_check.py
@@ -110,6 +110,49 @@ class TestSimulateProfileCycle:
         # reading as "stable" about a village overflowing daily.
         assert crop.daily_net == pytest.approx(60_000, rel=0.01)
 
+    def test_a_store_already_above_its_alert_reports_standing_not_crossing(self):
+        """A draining store that starts above the ceiling never crosses it
+        upward. Claiming "crosses at 00:00" would be factually inverted -- the
+        standing condition is its own kind, reported once."""
+        segment = ProfileSegment(
+            name="Day",
+            start_minute=0,
+            end_minute=720,
+            ship_rates={},
+        )
+
+        _, breaches = simulate_profile_cycle(
+            [segment],
+            own_rates={1: {Resource.CROP: -500.0}},
+            stocks={1: {Resource.CROP: 90_000}},
+            capacities={1: {Resource.CROP: 240_000}},
+            ceilings={1: 50_000.0},
+        )
+
+        kinds = {b.kind for b in breaches}
+        assert "above" in kinds, f"the standing condition must be reported: {breaches}"
+        assert "ceiling" not in kinds, "a store draining from above never crosses upward"
+        above = next(b for b in breaches if b.kind == "above")
+        assert (above.day, above.minute) == (0, 0)
+
+    def test_a_ceiling_misconfigured_above_the_cap_never_fires(self):
+        """The ceiling is checked on the post-clamp level: the store physically
+        cannot exceed its cap, so an alert set above it must stay silent."""
+        segment = ProfileSegment(name="Day", start_minute=0, end_minute=720, ship_rates={})
+
+        _, breaches = simulate_profile_cycle(
+            [segment],
+            own_rates={1: {Resource.CROP: 4_000.0}},
+            stocks={1: {Resource.CROP: 79_000}},
+            capacities={1: {Resource.CROP: 80_000}},
+            ceilings={1: 90_000.0},
+        )
+
+        kinds = {b.kind for b in breaches}
+        assert "capacity" in kinds
+        assert "ceiling" not in kinds, "90k is unreachable behind an 80k cap"
+        assert "above" not in kinds
+
 
 class TestDayCheckEndpoint:
     def _village(self, vid, name, crop, crop_stock, granary):
@@ -174,6 +217,111 @@ class TestDayCheckEndpoint:
         capital = next(v for v in res.villages if v.village_id == 1 and v.resource is Resource.CROP)
         assert capital.village_name == "02"
         assert capital.daily_net > 0
+
+    def test_a_foreign_tribute_drains_the_day_it_would_otherwise_flatter(self):
+        """The backend reviewer's measured failure: a hub producing 3,000/h
+        owing a 4,000/h tribute showed +72,000/day when reality is net
+        -1,000/h and dry in ~50 hours. The tribute must drain the composite
+        exactly as POST /plan ships it."""
+        body = DayCheckRequest.model_validate(
+            {
+                "snapshot": [
+                    self._village(1, "02", crop=3_000, crop_stock=50_000, granary=200_000)
+                ],
+                "segments": [
+                    {
+                        "name": "All day",
+                        "window": [0, 1439],
+                        "allocations": {"crop": {"1": {"mode": "remainder"}}},
+                    }
+                ],
+                "foreign_targets": [
+                    {"name": "Ally capital", "x": 10, "y": 10, "crop_per_hour": 4_000}
+                ],
+            }
+        )
+
+        res = asyncio.run(post_day_check(body, SimpleNamespace(id=1)))
+
+        hub = next(v for v in res.villages if v.village_id == 1 and v.resource is Resource.CROP)
+        assert hub.daily_net == pytest.approx(-24_000, rel=0.02), (
+            "own 3,000/h minus a 4,000/h tribute is net -1,000/h, not +3,000/h"
+        )
+        dry = [w for w in res.warnings if "runs dry" in w]
+        assert dry and dry[0].startswith("02:"), f"the starvation must be warned: {res.warnings}"
+        assert all(v.village_id > 0 for v in res.villages), (
+            "the sink has no trajectory of its own; its drain lives in the senders"
+        )
+
+    def test_a_profile_without_a_remainder_leaves_the_tribute_unpaid_and_says_so(self):
+        """No remainder village means nothing funds the sink's absolute target:
+        resolve leaves every real village at its own rate. Modeling that
+        silently would just move the optimism, so it must be said out loud."""
+        body = DayCheckRequest.model_validate(
+            {
+                "snapshot": [
+                    self._village(1, "02", crop=3_000, crop_stock=50_000, granary=200_000)
+                ],
+                "segments": [{"name": "Night", "window": [0, 1439], "allocations": {}}],
+                "foreign_targets": [
+                    {"name": "Ally capital", "x": 10, "y": 10, "crop_per_hour": 4_000}
+                ],
+            }
+        )
+
+        res = asyncio.run(post_day_check(body, SimpleNamespace(id=1)))
+
+        unpaid = [w for w in res.warnings if "nothing funds the tribute" in w]
+        assert unpaid and unpaid[0].startswith("Night:"), f"warnings: {res.warnings}"
+        hub = next(v for v in res.villages if v.resource is Resource.CROP)
+        assert hub.daily_net == pytest.approx(72_000, rel=0.02), (
+            "unpaid means unpaid: the hub keeps its own production"
+        )
+
+    def test_an_unreadable_crop_rate_is_reported_not_silently_dropped(self):
+        """A crop_per_hour=None village sits the check out -- allocations
+        dropped, no crop row, its alert level ignored. The response must say
+        so instead of merely looking complete."""
+        body = DayCheckRequest.model_validate(
+            {
+                "snapshot": [
+                    self._village(1, "02", crop=5_000, crop_stock=10_000, granary=800_000),
+                    self._village(2, "05", crop=None, crop_stock=79_000, granary=80_000),
+                ],
+                "segments": [{"name": "Day", "window": [0, 1439], "allocations": {}}],
+                "crop_ceilings": {"2": 79_500},
+            }
+        )
+
+        res = asyncio.run(post_day_check(body, SimpleNamespace(id=1)))
+
+        note = [w for w in res.warnings if "no rate could be read" in w]
+        assert note, f"warnings: {res.warnings}"
+        assert "05" in note[0], "the sidelined village must be named"
+        assert "crop alert levels included" in note[0], (
+            "its ignored ceiling is the dangerous part -- 1,000 under the cap"
+        )
+        assert not any(v.village_id == 2 and v.resource is Resource.CROP for v in res.villages)
+
+    def test_a_stock_already_above_its_alert_is_worded_as_standing(self):
+        body = DayCheckRequest.model_validate(
+            {
+                "snapshot": [
+                    self._village(1, "02", crop=-2_000, crop_stock=373_000, granary=800_000)
+                ],
+                "segments": [{"name": "Day", "window": [0, 1439], "allocations": {}}],
+                "crop_ceilings": {"1": 90_000},
+            }
+        )
+
+        res = asyncio.run(post_day_check(body, SimpleNamespace(id=1)))
+
+        alert = [w for w in res.warnings if "alert" in w]
+        assert alert, f"warnings: {res.warnings}"
+        assert "already above its 90,000 alert level" in alert[0]
+        assert not any("crosses" in w for w in res.warnings), (
+            "a draining store above the alert never crosses it upward"
+        )
 
     def test_overlapping_windows_are_rejected(self):
         body = DayCheckRequest.model_validate(

--- a/tests/test_distribution_day_check.py
+++ b/tests/test_distribution_day_check.py
@@ -278,6 +278,33 @@ class TestDayCheckEndpoint:
             "unpaid means unpaid: the hub keeps its own production"
         )
 
+    def test_a_nonconserved_profile_cannot_report_a_green_all_clear(self):
+        """An absolute receiver target with no remainder to source it is not
+        conserved: resolve_resource hands back inflow no route supplies. The
+        day check must surface that warning rather than credit crop from
+        nothing and fall through to 'all clear'."""
+        body = DayCheckRequest.model_validate(
+            {
+                "snapshot": [
+                    self._village(1, "02", crop=1_000, crop_stock=50_000, granary=800_000),
+                    self._village(2, "03", crop=1_000, crop_stock=50_000, granary=800_000),
+                ],
+                "segments": [
+                    {
+                        # 02 is told to hold 50,000/h with nobody assigned to send it.
+                        "name": "Day",
+                        "window": [0, 1439],
+                        "allocations": {"crop": {"1": {"mode": "absolute", "value": 50_000}}},
+                    }
+                ],
+            }
+        )
+
+        res = asyncio.run(post_day_check(body, SimpleNamespace(id=1)))
+
+        assert res.warnings, "a non-conserved profile must not be silently accepted"
+        assert any("unallocated" in w and w.startswith("Day:") for w in res.warnings)
+
     def test_an_unreadable_crop_rate_is_reported_not_silently_dropped(self):
         """A crop_per_hour=None village sits the check out -- allocations
         dropped, no crop row, its alert level ignored. The response must say

--- a/tests/test_distribution_day_check.py
+++ b/tests/test_distribution_day_check.py
@@ -1,0 +1,201 @@
+"""The full-day check: every profile in its own hours, one stock trajectory.
+
+Profiles are planned in isolation, but the account lives through all of them
+every day. What the day profile ships decides the stock the night profile
+starts from, so "does the capital cross 90k during the night?" is unanswerable
+per-profile -- it needs the composite, and these tests pin that the composite
+answers it with an hour and a profile name attached.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from travian_api.services.distribution.allocation import Resource
+from travian_api.services.distribution.storage import ProfileSegment, simulate_profile_cycle
+from travian_api.web.routes.distribution import DayCheckRequest, post_day_check
+
+
+class TestSimulateProfileCycle:
+    def test_the_night_profile_inherits_the_day_profiles_stock(self):
+        """The user's scenario. The capital receives heavily by day (its own
+        +5,000/h plus +10,000/h shipped in, 07:00-23:00) and receives almost
+        nothing by night. Whether it crosses a 90,000 alert at night depends
+        entirely on where the DAY profile left the stock -- which is exactly
+        what per-profile planning cannot see."""
+        day = ProfileSegment(
+            name="Day",
+            start_minute=7 * 60,
+            end_minute=23 * 60,
+            ship_rates={1: {Resource.CROP: 10_000.0}},
+        )
+        night = ProfileSegment(
+            name="Night",
+            start_minute=23 * 60,
+            end_minute=7 * 60,
+            ship_rates={1: {Resource.CROP: 500.0}},
+        )
+
+        trajectories, breaches = simulate_profile_cycle(
+            [day, night],
+            own_rates={1: {Resource.CROP: 5_000.0}},
+            stocks={1: {Resource.CROP: 10_000}},
+            capacities={1: {Resource.CROP: 800_000}},
+            ceilings={1: 90_000.0},
+        )
+
+        ceiling_hits = [b for b in breaches if b.kind == "ceiling"]
+        assert ceiling_hits, "the stock climbs 284k/day; the 90k alert must fire"
+        first = ceiling_hits[0]
+        # +15,000/h from 07:00 on 10,000 opening stock crosses 90,000 within
+        # day one's Day window -- and the breach must say so by name.
+        assert first.day == 0
+        assert first.segment == "Day"
+        assert 7 * 60 <= first.minute < 23 * 60
+
+    def test_a_balanced_pair_settles_and_reports_its_swing(self):
+        """Night keeps crop home (+4,000/h net), day ships hard (-2,000/h net):
+        the day drains what the night banked. The composite must settle into a
+        repeating day and report the low/high swing rather than drift."""
+        day = ProfileSegment(
+            name="Day",
+            start_minute=8 * 60,
+            end_minute=20 * 60,  # 12h at -2,000/h net = -24,000
+            ship_rates={1: {Resource.CROP: -6_000.0}},
+        )
+        night = ProfileSegment(
+            name="Night",
+            start_minute=20 * 60,
+            end_minute=8 * 60,  # 12h at +2,000/h net = +24,000
+            ship_rates={1: {Resource.CROP: -2_000.0}},
+        )
+
+        trajectories, breaches = simulate_profile_cycle(
+            [day, night],
+            own_rates={1: {Resource.CROP: 4_000.0}},
+            stocks={1: {Resource.CROP: 50_000}},
+            capacities={1: {Resource.CROP: 800_000}},
+        )
+
+        (crop,) = [t for t in trajectories if t.resource is Resource.CROP]
+        assert crop.settled, "a zero-daily-net pair must reach a repeating day"
+        assert abs(crop.daily_net) < 1.0
+        # The swing is 24,000 wide: banked by night, spent by day.
+        assert crop.high - crop.low == pytest.approx(24_000, rel=0.02)
+        assert not breaches
+
+    def test_hours_with_no_profile_run_on_production_alone(self):
+        """A gap between windows means no routes exist then -- production
+        continues, shipping stops. The gap must not inherit either profile."""
+        only_day = ProfileSegment(
+            name="Day",
+            start_minute=6 * 60,
+            end_minute=18 * 60,
+            ship_rates={1: {Resource.CROP: -5_000.0}},
+        )
+
+        trajectories, _ = simulate_profile_cycle(
+            [only_day],
+            own_rates={1: {Resource.CROP: 5_000.0}},
+            stocks={1: {Resource.CROP: 100_000}},
+            capacities={1: {Resource.CROP: 800_000}},
+        )
+
+        (crop,) = trajectories
+        # 12h of net zero (day) + 12h of +5,000/h (gap) = +60,000/day. The
+        # nominal drift must survive the store clamping at its cap -- measured
+        # off simulated levels it would collapse to zero once pinned there,
+        # reading as "stable" about a village overflowing daily.
+        assert crop.daily_net == pytest.approx(60_000, rel=0.01)
+
+
+class TestDayCheckEndpoint:
+    def _village(self, vid, name, crop, crop_stock, granary):
+        return {
+            "village_id": vid,
+            "name": name,
+            "x": 0,
+            "y": vid,
+            "merchants_total": 20,
+            "merchants_free": 20,
+            "lumber_per_hour": 0,
+            "clay_per_hour": 0,
+            "iron_per_hour": 0,
+            "crop_per_hour": crop,
+            "crop_stock": crop_stock,
+            "granary_capacity": granary,
+            "warehouse_capacity": 400_000,
+        }
+
+    def test_the_ceiling_breach_names_the_village_the_hour_and_the_profile(self):
+        body = DayCheckRequest.model_validate(
+            {
+                "snapshot": [
+                    self._village(1, "02", crop=20_000, crop_stock=60_000, granary=800_000),
+                    self._village(2, "03", crop=-2_000, crop_stock=90_000, granary=240_000),
+                ],
+                "segments": [
+                    {
+                        # By day everything flows to the capital.
+                        "name": "Day",
+                        "window": [420, 1380],
+                        "allocations": {
+                            "crop": {
+                                "1": {"mode": "remainder"},
+                                "2": {"mode": "sustain", "value": 5},
+                            }
+                        },
+                    },
+                    {
+                        # By night villages keep their crop; nothing moves.
+                        "name": "Night",
+                        "window": [1380, 420],
+                        "allocations": {},
+                    },
+                ],
+                "crop_ceilings": {"1": 90_000},
+            }
+        )
+
+        res = asyncio.run(post_day_check(body, SimpleNamespace(id=1)))
+
+        alert = [w for w in res.warnings if "90,000 alert" in w]
+        assert alert, f"no ceiling warning in {res.warnings}"
+        assert alert[0].startswith("02:"), "the warning must name the village"
+        # The composite's whole point: the breach happens at NIGHT, not by day.
+        # By day the capital actually SENDS (remainder absorbs a negative
+        # residue), but at night no routes run and its own 20,000/h keeps
+        # flowing -- 60,000 stock crosses 90,000 at 01:30 during Night. A
+        # per-profile view could never have said that.
+        assert "during Night" in alert[0], "the warning must name the profile running"
+        assert "01:30" in alert[0], "the warning must carry the hour"
+        capital = next(v for v in res.villages if v.village_id == 1 and v.resource is Resource.CROP)
+        assert capital.village_name == "02"
+        assert capital.daily_net > 0
+
+    def test_overlapping_windows_are_rejected(self):
+        body = DayCheckRequest.model_validate(
+            {
+                "snapshot": [self._village(1, "02", 1000, 0, 80_000)],
+                "segments": [
+                    {"name": "Day", "window": [0, 720], "allocations": {}},
+                    {"name": "Night", "window": [600, 1439], "allocations": {}},
+                ],
+            }
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(post_day_check(body, SimpleNamespace(id=1)))
+
+        assert exc.value.status_code == 400
+        assert "overlap" in exc.value.detail
+
+    def test_costs_no_game_requests(self):
+        import inspect
+
+        from travian_api.web.sessions import get_travian_session
+
+        for parameter in inspect.signature(post_day_check).parameters.values():
+            assert getattr(parameter.default, "dependency", None) is not get_travian_session

--- a/tests/test_distribution_geometry.py
+++ b/tests/test_distribution_geometry.py
@@ -1,0 +1,66 @@
+"""Toroidal map geometry.
+
+The wrap matters: on a 401-wide map the two far edges are adjacent, so a naive
+Euclidean distance overstates the trip for villages near opposite borders --
+and an overstated trip inflates the merchant pool for exactly the routes that
+are already expensive.
+"""
+
+import math
+
+import pytest
+
+from travian_api.services.distribution.geometry import MapGeometry
+
+# Europe-style map: coordinates -200..+200.
+EUROPE = MapGeometry(span=401, speed_fields_per_hour=12.0)
+
+
+class TestDistance:
+    def test_same_village_is_zero(self):
+        assert EUROPE.distance((15, 91), (15, 91)) == 0.0
+
+    def test_plain_euclidean_when_the_wrap_is_not_shorter(self):
+        assert EUROPE.distance((0, 0), (3, 4)) == pytest.approx(5.0)
+
+    def test_shortest_path_crosses_the_map_edge(self):
+        """x=-198 and x=198 are 5 fields apart on a 401-wide map, not 396."""
+        assert EUROPE.distance((-198, 0), (198, 0)) == pytest.approx(5.0)
+
+    def test_wrap_applies_on_both_axes_at_once(self):
+        assert EUROPE.distance((-199, -199), (199, 199)) == pytest.approx(math.hypot(3, 3))
+
+    def test_distance_is_symmetric(self):
+        a, b = (42, 17), (-64, 116)
+
+        assert EUROPE.distance(a, b) == pytest.approx(EUROPE.distance(b, a))
+
+    def test_no_pair_exceeds_half_the_map_on_an_axis(self):
+        """A wrapped axis separation can never exceed span/2."""
+        for x in range(-200, 201, 37):
+            assert EUROPE._axis_delta(0, x) <= EUROPE.span / 2
+
+
+class TestTravelTime:
+    def test_one_way_minutes_from_speed(self):
+        """12 fields at 12 fields/hour is one hour."""
+        assert EUROPE.one_way_minutes((0, 0), (12, 0)) == pytest.approx(60.0)
+
+    def test_round_trip_is_twice_one_way(self):
+        origin, target = (0, 0), (30, 40)
+
+        assert EUROPE.round_trip_minutes(origin, target) == pytest.approx(
+            2 * EUROPE.one_way_minutes(origin, target)
+        )
+
+    def test_faster_tribe_travels_the_same_distance_sooner(self):
+        gaul = MapGeometry(span=401, speed_fields_per_hour=24.0)
+
+        assert gaul.one_way_minutes((0, 0), (12, 0)) == pytest.approx(30.0)
+
+
+class TestValidation:
+    @pytest.mark.parametrize("span,speed", [(0, 12.0), (-1, 12.0), (401, 0), (401, -3.0)])
+    def test_invalid_geometry_is_rejected(self, span, speed):
+        with pytest.raises(ValueError):
+            MapGeometry(span=span, speed_fields_per_hour=speed)

--- a/tests/test_distribution_geometry.py
+++ b/tests/test_distribution_geometry.py
@@ -36,9 +36,9 @@ class TestDistance:
         assert EUROPE.distance(a, b) == pytest.approx(EUROPE.distance(b, a))
 
     def test_no_pair_exceeds_half_the_map_on_an_axis(self):
-        """A wrapped axis separation can never exceed span/2."""
+        """A wrapped separation can never exceed half the map."""
         for x in range(-200, 201, 37):
-            assert EUROPE._axis_delta(0, x) <= EUROPE.span / 2
+            assert EUROPE.distance((0, 0), (x, 0)) <= EUROPE.span / 2
 
 
 class TestTravelTime:

--- a/tests/test_distribution_golden.py
+++ b/tests/test_distribution_golden.py
@@ -58,8 +58,12 @@ SEED_TOTAL_MERCHANTS = 233
 # Ratchet on the merchant-minimal plan (latency pass off): the optimizer must do
 # at least this well. Tighten these when an improvement lands; never loosen them
 # without saying why.
-MAX_TOTAL_MERCHANTS = 210
-MAX_OVER_BUDGET_EXCESS = 62
+# The ratchet is on the objective the search actually optimises, in its own
+# order: excess first, merchants second. Relay buys the 62 -> 44 excess drop with
+# one extra merchant, which is an improvement even though the merchant count
+# rose -- bounding merchants alone would have rejected it.
+MAX_OVER_BUDGET_EXCESS = 44
+MAX_TOTAL_MERCHANTS = 211
 
 # Villages whose surplus cannot be shipped within their merchant budget on this
 # snapshot. They are NOT interchangeable, and the distinction is the point:
@@ -158,8 +162,10 @@ def test_the_optimizer_holds_its_ratchet():
 
     plan = build_plan(villages, plans, geometry, model, max_latency_hours=None)
 
-    assert plan.total_merchants <= MAX_TOTAL_MERCHANTS
-    assert sum(o.excess for o in plan.over_budget) <= MAX_OVER_BUDGET_EXCESS
+    assert (sum(o.excess for o in plan.over_budget), plan.total_merchants) <= (
+        MAX_OVER_BUDGET_EXCESS,
+        MAX_TOTAL_MERCHANTS,
+    )
     assert not plan.shortfalls
     # A finished search, so the over-budget figures below are trustworthy.
     assert not [w for w in plan.warnings if "improvement passes" in w]
@@ -222,27 +228,37 @@ def test_golden_plan_respects_the_structural_invariants():
 
     plan = build_plan(villages, plans, geometry, model)
 
-    # No two-way pair and no relay of the same resource (issues #2 and the
-    # no-waterfall rule), checked on the real account rather than only on
-    # generated ones.
+    # No two-way pair (issue #2), and no relay of a MATERIAL: the no-waterfall
+    # rule is W/C/I only. Crop relay is permitted (profile 3.5) and is how the
+    # optimizer lifts load off villages that cannot staff their own haul.
+    materials = {Resource.LUMBER, Resource.CLAY, Resource.IRON}
     sends: dict[int, set] = {}
     receives: dict[int, set] = {}
     carried: dict[tuple[int, int], set] = {}
     for route in plan.routes:
         carried[(route.origin, route.destination)] = set(route.cargo_per_hour)
-        sends.setdefault(route.origin, set()).update(route.cargo_per_hour)
-        receives.setdefault(route.destination, set()).update(route.cargo_per_hour)
+        material_cargo = set(route.cargo_per_hour) & materials
+        sends.setdefault(route.origin, set()).update(material_cargo)
+        receives.setdefault(route.destination, set()).update(material_cargo)
     for (origin, destination), resources in carried.items():
         assert not (resources & carried.get((destination, origin), set()))
     for vid in villages:
         assert not (sends.get(vid, set()) & receives.get(vid, set()))
 
-    # Conservation: no village ships more of a resource than its surplus.
+    # Conservation: inflow minus outflow equals what each village's allocation
+    # asked for. Stated on the net so a relay hub -- which forwards cargo it did
+    # not grow -- is covered by the same rule as everyone else.
     for resource, resource_plan in plans.items():
-        surplus = {v.village_id: -v.ship_per_hour for v in resource_plan.senders}
-        sent: dict[int, float] = {}
+        inflow: dict[int, float] = {}
+        outflow: dict[int, float] = {}
         for route in plan.routes:
-            if resource in route.cargo_per_hour:
-                sent[route.origin] = sent.get(route.origin, 0.0) + route.cargo_per_hour[resource]
-        for vid, amount in sent.items():
-            assert amount <= surplus.get(vid, 0.0) + 1e-6
+            amount = route.cargo_per_hour.get(resource)
+            if amount:
+                outflow[route.origin] = outflow.get(route.origin, 0.0) + amount
+                inflow[route.destination] = inflow.get(route.destination, 0.0) + amount
+        for village in resource_plan.villages:
+            net = inflow.get(village.village_id, 0.0) - outflow.get(village.village_id, 0.0)
+            assert abs(net - village.ship_per_hour) < 1e-6, (
+                f"village {village.village_id} nets {net:+.1f}/h of {resource.value} "
+                f"against an allocation of {village.ship_per_hour:+.1f}/h"
+            )

--- a/tests/test_distribution_golden.py
+++ b/tests/test_distribution_golden.py
@@ -1,13 +1,20 @@
-"""Golden regression for the flow optimizer, frozen on a real 22-village account.
+"""Golden regression for the flow optimizer, frozen on a synthetic 23-village account.
 
 Profile Appendix A asks for exactly this: a frozen snapshot — production, coords,
 Trade Office levels and allocation targets in; route set and per-village merchant
 pool out — that pins the optimizer against silent regressions. It is deliberately
-*not* a live read (the account has already gone 20 -> 22 -> 23 villages; a golden
-test that reads current state stops being a regression test), and it captures the
-case that motivated the merchant-aware improvement pass: two geographically
-stranded villages (15 at 121|52, 21 at 7|35) whose crop surplus cannot be shipped
-within their merchant budget at any Trade Office level.
+*not* a live read: an account grows and every figure moves between runs, so a
+golden test that reads current state stops being a regression test.
+
+The fixture is **invented, not captured**. Village ids, names, coordinates and
+rates are made up. A real snapshot would be operational reconnaissance about a
+live account — map positions, which villages are starving, how many merchants
+each can field — and this repository is public, so no real account state belongs
+in it. What the fixture reproduces is the *structure* that makes the case
+interesting: a capital hub absorbing the remainder, two army villages eating more
+crop than they grow, a spread of Trade Office levels, sub-20-merchant villages,
+and three villages that cannot ship their surplus within budget — one bound by
+distance (no upgrade helps) and two bound by capacity (an upgrade does).
 
 On the assertions: the merchant-minimal figures are upper *bounds* (``<=``), not
 equalities, so a genuine search improvement passes rather than failing as a
@@ -42,27 +49,27 @@ from travian_api.services.distribution.optimizer import (
     build_plan,
 )
 
-FIXTURE = Path(__file__).parent / "fixtures" / "distribution_real_account.json"
+FIXTURE = Path(__file__).parent / "fixtures" / "distribution_account.json"
 
-# The greedy seed's numbers on this account, measured before the improvement pass
-# existed. The improved optimizer must never do worse than these.
-SEED_TOTAL_MERCHANTS = 163
+# What the greedy seed alone commits on this account. The improved optimizer must
+# never do worse than this.
+SEED_TOTAL_MERCHANTS = 233
 
 # Ratchet on the merchant-minimal plan (latency pass off): the optimizer must do
 # at least this well. Tighten these when an improvement lands; never loosen them
 # without saying why.
-MAX_TOTAL_MERCHANTS = 152
-MAX_OVER_BUDGET_EXCESS = 17
+MAX_TOTAL_MERCHANTS = 210
+MAX_OVER_BUDGET_EXCESS = 62
 
-# Villages whose crop cannot be shipped within their merchant budget on this
+# Villages whose surplus cannot be shipped within their merchant budget on this
 # snapshot. They are NOT interchangeable, and the distinction is the point:
-#   20015 ("15", 121|52) is distance-bound -- 100+ fields from everything, so no
-#       Trade Office level shrinks the haul and the report says so.
-#   81449 ("21", 7|35) is capacity-bound -- it has a concrete TO+7 fix, so a
-#       future improvement may legitimately route it within budget.
-# Hence a subset assertion for the set and an exact assertion only for 20015.
-DISTANCE_BOUND_VILLAGE = 20015
-CAPACITY_BOUND_VILLAGE = 81449
+#   "Farhaven" is distance-bound -- 120+ fields from everything, so the trip
+#       rather than the load is the cost and no Trade Office level shrinks it.
+#   "Saltmarsh" is capacity-bound -- a Trade Office would fix it, so a future
+#       improvement may legitimately route it within budget.
+# Hence an exact assertion only for the distance-bound one.
+DISTANCE_BOUND_VILLAGE = 1021
+CAPACITY_BOUND_VILLAGE = 1022
 
 
 def _median_latency(plan):

--- a/tests/test_distribution_golden.py
+++ b/tests/test_distribution_golden.py
@@ -14,6 +14,7 @@ improvement does better is expected — raising them is a regression.
 """
 
 import json
+import statistics
 from pathlib import Path
 
 from travian_api.services.distribution.allocation import (
@@ -38,12 +39,19 @@ FIXTURE = Path(__file__).parent / "fixtures" / "distribution_real_account.json"
 SEED_TOTAL_MERCHANTS = 163
 SEED_OVER_BUDGET_EXCESS = 22
 
-# What the current merchant-aware optimizer achieves. Pinned so an accidental
+# The merchant-minimal plan (latency pass off). Pinned so an accidental
 # regression is caught; expected to only ever drop.
 EXPECTED_TOTAL_MERCHANTS = 152
 EXPECTED_OVER_BUDGET_EXCESS = 17
+# With the latency pass on (the default), idle merchants are spent on speed, so
+# the count rises within budget while travel time falls.
+EXPECTED_LATENCY_MERCHANTS = 163
 # Both remote and crop-heavy; no Trade Office upgrade shrinks village 15's haul.
 STRANDED_VILLAGES = {20015, 81449}
+
+
+def _median_latency(plan):
+    return statistics.median(route.latency_hours for route in plan.routes)
 
 
 def _load_case():
@@ -116,7 +124,8 @@ def test_the_improved_plan_never_costs_more_than_the_greedy_seed():
     villages, plans, geometry, model = _load_case()
 
     seed = _seed_total_merchants(villages, plans, geometry, model)
-    plan = build_plan(villages, plans, geometry, model)
+    # Latency pass off: this property is about the merchant-minimal stage.
+    plan = build_plan(villages, plans, geometry, model, max_latency_hours=None)
 
     assert seed == SEED_TOTAL_MERCHANTS
     assert plan.total_merchants <= seed
@@ -125,12 +134,28 @@ def test_the_improved_plan_never_costs_more_than_the_greedy_seed():
 def test_golden_totals_are_pinned():
     villages, plans, geometry, model = _load_case()
 
-    plan = build_plan(villages, plans, geometry, model)
+    plan = build_plan(villages, plans, geometry, model, max_latency_hours=None)
 
     assert plan.total_merchants == EXPECTED_TOTAL_MERCHANTS
     assert sum(o.excess for o in plan.over_budget) == EXPECTED_OVER_BUDGET_EXCESS
     assert sum(o.excess for o in plan.over_budget) <= SEED_OVER_BUDGET_EXCESS
     assert not plan.shortfalls
+
+
+def test_the_latency_pass_trades_idle_merchants_for_speed():
+    """With a latency target, otherwise-idle merchants shorten cycles: the count
+    rises within budget while median travel time falls, and no village that was
+    within budget is pushed over it."""
+    villages, plans, geometry, model = _load_case()
+
+    minimal = build_plan(villages, plans, geometry, model, max_latency_hours=None)
+    fast = build_plan(villages, plans, geometry, model, max_latency_hours=2.0)
+
+    assert fast.total_merchants == EXPECTED_LATENCY_MERCHANTS
+    assert fast.total_merchants > minimal.total_merchants
+    assert _median_latency(fast) < _median_latency(minimal)
+    # Feasibility is unchanged: the same villages are over budget, no more.
+    assert {o.village_id for o in fast.over_budget} == {o.village_id for o in minimal.over_budget}
 
 
 def test_the_stranded_villages_are_reported_not_hidden():

--- a/tests/test_distribution_golden.py
+++ b/tests/test_distribution_golden.py
@@ -9,8 +9,18 @@ case that motivated the merchant-aware improvement pass: two geographically
 stranded villages (15 at 121|52, 21 at 7|35) whose crop surplus cannot be shipped
 within their merchant budget at any Trade Office level.
 
-The pinned totals track the current optimizer. Lowering them when a future search
-improvement does better is expected — raising them is a regression.
+On the assertions: the merchant-minimal figures are upper *bounds* (``<=``), not
+equalities, so a genuine search improvement passes rather than failing as a
+"regression". Equalities were tried first and were actively harmful — they made
+these two integers the only coverage for the fill floor, the pass cap and
+cross-resource bundling, so any legitimate re-baselining would have silently
+deleted that coverage. Those behaviours are now pinned directly in
+``test_distribution_optimizer.py``; what remains here is the ratchet.
+
+The latency plan is deliberately NOT bounded above by merchants: that pass exists
+to spend idle merchants on speed, so a better one may legitimately spend more.
+It is bounded by the properties that must hold instead — within budget, faster
+than the merchant-minimal plan, no new over-budget village.
 """
 
 import json
@@ -37,17 +47,22 @@ FIXTURE = Path(__file__).parent / "fixtures" / "distribution_real_account.json"
 # The greedy seed's numbers on this account, measured before the improvement pass
 # existed. The improved optimizer must never do worse than these.
 SEED_TOTAL_MERCHANTS = 163
-SEED_OVER_BUDGET_EXCESS = 22
 
-# The merchant-minimal plan (latency pass off). Pinned so an accidental
-# regression is caught; expected to only ever drop.
-EXPECTED_TOTAL_MERCHANTS = 152
-EXPECTED_OVER_BUDGET_EXCESS = 17
-# With the latency pass on (the default), idle merchants are spent on speed, so
-# the count rises within budget while travel time falls.
-EXPECTED_LATENCY_MERCHANTS = 163
-# Both remote and crop-heavy; no Trade Office upgrade shrinks village 15's haul.
-STRANDED_VILLAGES = {20015, 81449}
+# Ratchet on the merchant-minimal plan (latency pass off): the optimizer must do
+# at least this well. Tighten these when an improvement lands; never loosen them
+# without saying why.
+MAX_TOTAL_MERCHANTS = 152
+MAX_OVER_BUDGET_EXCESS = 17
+
+# Villages whose crop cannot be shipped within their merchant budget on this
+# snapshot. They are NOT interchangeable, and the distinction is the point:
+#   20015 ("15", 121|52) is distance-bound -- 100+ fields from everything, so no
+#       Trade Office level shrinks the haul and the report says so.
+#   81449 ("21", 7|35) is capacity-bound -- it has a concrete TO+7 fix, so a
+#       future improvement may legitimately route it within budget.
+# Hence a subset assertion for the set and an exact assertion only for 20015.
+DISTANCE_BOUND_VILLAGE = 20015
+CAPACITY_BOUND_VILLAGE = 81449
 
 
 def _median_latency(plan):
@@ -131,43 +146,58 @@ def test_the_improved_plan_never_costs_more_than_the_greedy_seed():
     assert plan.total_merchants <= seed
 
 
-def test_golden_totals_are_pinned():
+def test_the_optimizer_holds_its_ratchet():
     villages, plans, geometry, model = _load_case()
 
     plan = build_plan(villages, plans, geometry, model, max_latency_hours=None)
 
-    assert plan.total_merchants == EXPECTED_TOTAL_MERCHANTS
-    assert sum(o.excess for o in plan.over_budget) == EXPECTED_OVER_BUDGET_EXCESS
-    assert sum(o.excess for o in plan.over_budget) <= SEED_OVER_BUDGET_EXCESS
+    assert plan.total_merchants <= MAX_TOTAL_MERCHANTS
+    assert sum(o.excess for o in plan.over_budget) <= MAX_OVER_BUDGET_EXCESS
     assert not plan.shortfalls
+    # A finished search, so the over-budget figures below are trustworthy.
+    assert not [w for w in plan.warnings if "improvement passes" in w]
 
 
 def test_the_latency_pass_trades_idle_merchants_for_speed():
-    """With a latency target, otherwise-idle merchants shorten cycles: the count
-    rises within budget while median travel time falls, and no village that was
-    within budget is pushed over it."""
+    """With a latency target, otherwise-idle merchants shorten cycles: travel
+    time falls, spending stays inside every village's budget, and no village that
+    was within budget is pushed over it.
+
+    Deliberately no upper bound on merchants here -- see the module docstring.
+    """
     villages, plans, geometry, model = _load_case()
 
     minimal = build_plan(villages, plans, geometry, model, max_latency_hours=None)
     fast = build_plan(villages, plans, geometry, model, max_latency_hours=2.0)
 
-    assert fast.total_merchants == EXPECTED_LATENCY_MERCHANTS
-    assert fast.total_merchants > minimal.total_merchants
     assert _median_latency(fast) < _median_latency(minimal)
-    # Feasibility is unchanged: the same villages are over budget, no more.
-    assert {o.village_id for o in fast.over_budget} == {o.village_id for o in minimal.over_budget}
+    # Feasibility is unchanged: no village that was within budget is pushed over.
+    minimal_over = {o.village_id for o in minimal.over_budget}
+    assert {o.village_id for o in fast.over_budget} <= minimal_over
+    for vid, used in fast.merchants_committed.items():
+        if vid not in minimal_over:
+            assert used <= villages[vid].spare_merchants()
 
 
-def test_the_stranded_villages_are_reported_not_hidden():
-    """15 and 21 cannot ship their crop within budget; that must surface as an
-    honest over-budget report, and village 15 as unfixable by any upgrade."""
+def test_an_unroutable_village_is_reported_not_hidden():
+    """Village 15 cannot ship its crop within budget at any Trade Office level;
+    that must surface as an honest over-budget report saying no upgrade helps,
+    never as a silently trimmed plan."""
     villages, plans, geometry, model = _load_case()
 
     plan = build_plan(villages, plans, geometry, model)
 
-    assert {o.village_id for o in plan.over_budget} == STRANDED_VILLAGES
-    fifteen = next(o for o in plan.over_budget if o.village_id == 20015)
-    assert fifteen.trade_office_levels_needed is None  # 100+ fields out; distance-bound
+    over = {o.village_id: o for o in plan.over_budget}
+    assert DISTANCE_BOUND_VILLAGE in over
+    assert over[DISTANCE_BOUND_VILLAGE].excess > 0
+    # 100+ fields from everything: the trip, not the load, is the cost.
+    assert over[DISTANCE_BOUND_VILLAGE].trade_office_levels_needed is None
+
+    # The capacity-bound village may or may not still be over budget -- a better
+    # search could route it -- but while it is, it must carry its concrete fix.
+    capacity_bound = over.get(CAPACITY_BOUND_VILLAGE)
+    if capacity_bound is not None:
+        assert capacity_bound.trade_office_levels_needed is not None
 
 
 def test_golden_plan_is_deterministic():

--- a/tests/test_distribution_golden.py
+++ b/tests/test_distribution_golden.py
@@ -1,0 +1,186 @@
+"""Golden regression for the flow optimizer, frozen on a real 22-village account.
+
+Profile Appendix A asks for exactly this: a frozen snapshot — production, coords,
+Trade Office levels and allocation targets in; route set and per-village merchant
+pool out — that pins the optimizer against silent regressions. It is deliberately
+*not* a live read (the account has already gone 20 -> 22 -> 23 villages; a golden
+test that reads current state stops being a regression test), and it captures the
+case that motivated the merchant-aware improvement pass: two geographically
+stranded villages (15 at 121|52, 21 at 7|35) whose crop surplus cannot be shipped
+within their merchant budget at any Trade Office level.
+
+The pinned totals track the current optimizer. Lowering them when a future search
+improvement does better is expected — raising them is a regression.
+"""
+
+import json
+from pathlib import Path
+
+from travian_api.services.distribution.allocation import (
+    Allocation,
+    AllocationMode,
+    Resource,
+    resolve_resource,
+)
+from travian_api.services.distribution.geometry import MapGeometry
+from travian_api.services.distribution.merchants import DAILY_BEAT_CYCLES, MerchantModel
+from travian_api.services.distribution.optimizer import (
+    VillageState,
+    _flows_for_resource,
+    _route_for_pair,
+    build_plan,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "distribution_real_account.json"
+
+# The greedy seed's numbers on this account, measured before the improvement pass
+# existed. The improved optimizer must never do worse than these.
+SEED_TOTAL_MERCHANTS = 163
+SEED_OVER_BUDGET_EXCESS = 22
+
+# What the current merchant-aware optimizer achieves. Pinned so an accidental
+# regression is caught; expected to only ever drop.
+EXPECTED_TOTAL_MERCHANTS = 152
+EXPECTED_OVER_BUDGET_EXCESS = 17
+# Both remote and crop-heavy; no Trade Office upgrade shrinks village 15's haul.
+STRANDED_VILLAGES = {20015, 81449}
+
+
+def _load_case():
+    body = json.loads(FIXTURE.read_text())
+    snap = body["snapshot"]
+    trade_office = {c["village_id"]: c["trade_office_level"] for c in body["config"]}
+    villages = {
+        v["village_id"]: VillageState(
+            village_id=v["village_id"],
+            x=v["x"],
+            y=v["y"],
+            merchant_count=v["merchants_total"],
+            trade_office_level=trade_office.get(v["village_id"], 0),
+            name=v["name"],
+        )
+        for v in snap
+    }
+    rate_field = {
+        Resource.LUMBER: "lumber_per_hour",
+        Resource.CLAY: "clay_per_hour",
+        Resource.IRON: "iron_per_hour",
+        Resource.CROP: "crop_per_hour",
+    }
+    productions = {}
+    for resource, field_name in rate_field.items():
+        rates = {
+            v["village_id"]: float(v[field_name]) for v in snap if v.get(field_name) is not None
+        }
+        if rates:
+            productions[resource] = rates
+    allocations = {
+        Resource(res): {
+            int(vid): Allocation(mode=AllocationMode(item["mode"]), value=item["value"])
+            for vid, item in per.items()
+            if item["mode"] != "keep"
+        }
+        for res, per in body["allocations"].items()
+    }
+    plans = {
+        res: resolve_resource(res, productions[res], allocations.get(res, {}))
+        for res in productions
+    }
+    geometry = MapGeometry(
+        span=body["map_span"], speed_fields_per_hour=body["speed_fields_per_hour"]
+    )
+    model = MerchantModel(
+        base_capacity=body["merchant_base_capacity"],
+        bonus_per_trade_office_level=body["trade_office_bonus_per_level"],
+    )
+    return villages, plans, geometry, model
+
+
+def _seed_total_merchants(villages, plans, geometry, model):
+    """Merchants the greedy seed alone would commit — the number to beat."""
+    pair: dict[tuple[int, int], dict[Resource, float]] = {}
+    for resource, resource_plan in plans.items():
+        flows, _ = _flows_for_resource(resource_plan, villages, geometry)
+        for key, amount in flows.items():
+            pair.setdefault(key, {})[resource] = amount
+    total = 0
+    for (origin, destination), cargo in pair.items():
+        route = _route_for_pair(
+            origin, destination, cargo, villages, geometry, model, DAILY_BEAT_CYCLES
+        )
+        total += route.merchants_committed
+    return total
+
+
+def test_the_improved_plan_never_costs_more_than_the_greedy_seed():
+    villages, plans, geometry, model = _load_case()
+
+    seed = _seed_total_merchants(villages, plans, geometry, model)
+    plan = build_plan(villages, plans, geometry, model)
+
+    assert seed == SEED_TOTAL_MERCHANTS
+    assert plan.total_merchants <= seed
+
+
+def test_golden_totals_are_pinned():
+    villages, plans, geometry, model = _load_case()
+
+    plan = build_plan(villages, plans, geometry, model)
+
+    assert plan.total_merchants == EXPECTED_TOTAL_MERCHANTS
+    assert sum(o.excess for o in plan.over_budget) == EXPECTED_OVER_BUDGET_EXCESS
+    assert sum(o.excess for o in plan.over_budget) <= SEED_OVER_BUDGET_EXCESS
+    assert not plan.shortfalls
+
+
+def test_the_stranded_villages_are_reported_not_hidden():
+    """15 and 21 cannot ship their crop within budget; that must surface as an
+    honest over-budget report, and village 15 as unfixable by any upgrade."""
+    villages, plans, geometry, model = _load_case()
+
+    plan = build_plan(villages, plans, geometry, model)
+
+    assert {o.village_id for o in plan.over_budget} == STRANDED_VILLAGES
+    fifteen = next(o for o in plan.over_budget if o.village_id == 20015)
+    assert fifteen.trade_office_levels_needed is None  # 100+ fields out; distance-bound
+
+
+def test_golden_plan_is_deterministic():
+    villages, plans, geometry, model = _load_case()
+
+    first = build_plan(villages, plans, geometry, model)
+    second = build_plan(villages, plans, geometry, model)
+
+    assert first.routes == second.routes
+    assert first.merchants_committed == second.merchants_committed
+
+
+def test_golden_plan_respects_the_structural_invariants():
+    villages, plans, geometry, model = _load_case()
+
+    plan = build_plan(villages, plans, geometry, model)
+
+    # No two-way pair and no relay of the same resource (issues #2 and the
+    # no-waterfall rule), checked on the real account rather than only on
+    # generated ones.
+    sends: dict[int, set] = {}
+    receives: dict[int, set] = {}
+    carried: dict[tuple[int, int], set] = {}
+    for route in plan.routes:
+        carried[(route.origin, route.destination)] = set(route.cargo_per_hour)
+        sends.setdefault(route.origin, set()).update(route.cargo_per_hour)
+        receives.setdefault(route.destination, set()).update(route.cargo_per_hour)
+    for (origin, destination), resources in carried.items():
+        assert not (resources & carried.get((destination, origin), set()))
+    for vid in villages:
+        assert not (sends.get(vid, set()) & receives.get(vid, set()))
+
+    # Conservation: no village ships more of a resource than its surplus.
+    for resource, resource_plan in plans.items():
+        surplus = {v.village_id: -v.ship_per_hour for v in resource_plan.senders}
+        sent: dict[int, float] = {}
+        for route in plan.routes:
+            if resource in route.cargo_per_hour:
+                sent[route.origin] = sent.get(route.origin, 0.0) + route.cargo_per_hour[resource]
+        for vid, amount in sent.items():
+            assert amount <= surplus.get(vid, 0.0) + 1e-6

--- a/tests/test_distribution_golden.py
+++ b/tests/test_distribution_golden.py
@@ -59,10 +59,20 @@ SEED_TOTAL_MERCHANTS = 233
 # at least this well. Tighten these when an improvement lands; never loosen them
 # without saying why.
 # The ratchet is on the objective the search actually optimises, in its own
-# order: excess first, merchants second. Relay buys the 62 -> 44 excess drop with
-# one extra merchant, which is an improvement even though the merchant count
-# rose -- bounding merchants alone would have rejected it.
-MAX_OVER_BUDGET_EXCESS = 44
+# order: excess first, merchants second. Relay buys the excess down from the
+# greedy seed's 62 at the cost of a merchant or two, which is an improvement even
+# though the merchant count rose -- bounding merchants alone would have rejected
+# it.
+#
+# Loosened once, deliberately, from 44 to 52. Relay was originally allowed to
+# build chains (A -> B -> C -> D) and two-way pairs, and those bought some of the
+# 44. They are not schedulable: the beat has to place a hub's outbound after its
+# inbound, which a 2-cycle makes unsatisfiable at both ends at once, so those
+# plans only looked better on paper. Constraining relay to genuine single hops
+# gives 52, and 52 that can actually be executed beats 44 that cannot. This is
+# the only loosening in this file and it should not be repeated without the same
+# kind of reason.
+MAX_OVER_BUDGET_EXCESS = 52
 MAX_TOTAL_MERCHANTS = 211
 
 # Villages whose surplus cannot be shipped within their merchant budget on this

--- a/tests/test_distribution_merchants.py
+++ b/tests/test_distribution_merchants.py
@@ -11,6 +11,7 @@ import pytest
 from travian_api.services.distribution.merchants import (
     ALL_CYCLES,
     DAILY_BEAT_CYCLES,
+    EUROPE2_TEUTON,
     STOCK_TEUTON,
     CalibrationError,
     CapacityObservation,
@@ -29,7 +30,7 @@ V10_CAPACITY = 5720
 
 class TestCapacity:
     def test_capacity_scales_with_trade_office_level(self):
-        model = MerchantModel(1000, 0.10, 12.0)
+        model = MerchantModel(1000, 0.10)
 
         assert model.capacity(0) == 1000
         assert model.capacity(10) == 2000
@@ -38,7 +39,7 @@ class TestCapacity:
     def test_capacity_rounds_down(self):
         """Understating capacity over-provisions (safe); overstating breaches
         the merchant budget invisibly (unsafe). Only round the safe way."""
-        model = MerchantModel(1000, 0.13, 12.0)
+        model = MerchantModel(1000, 0.13)
 
         assert model.capacity(1) == 1130
         assert model.capacity(3) == 1390  # 1390.0000000000002 must not become 1391
@@ -54,7 +55,6 @@ class TestCalibration:
     def test_two_observations_recover_base_and_bonus(self):
         model = calibrate(
             [CapacityObservation(0, 1000), CapacityObservation(10, 2000)],
-            speed_fields_per_hour=12.0,
         )
 
         assert model.base_capacity == 1000
@@ -64,25 +64,33 @@ class TestCalibration:
         """The two villages to hand may both have a Trade Office."""
         model = calibrate(
             [CapacityObservation(4, 1400), CapacityObservation(11, 2100)],
-            speed_fields_per_hour=12.0,
         )
 
         assert model.base_capacity == 1000
         assert model.bonus_per_trade_office_level == pytest.approx(0.10)
 
-    def test_calibration_distinguishes_the_two_disputed_models(self):
-        """The whole point of R1: which model the account actually follows.
+    def test_calibration_distinguishes_rival_models(self):
+        """Why one reading settles R1: the candidates are nowhere near.
 
-        A TO-11 village reading 2,100 is base 1000 / +10%. Reading 7,040 it is
-        base 2200 / +20%. One observation pair settles it.
+        A TO-11 village reading 2,100 is base 1000 / +10%; reading 7,040 it is
+        base 2200 / +20% -- a 3.35x difference in how many merchants every route
+        needs.
         """
-        teuton = calibrate([CapacityObservation(0, 1000), CapacityObservation(11, 2100)], 12.0)
-        doc_model = calibrate([CapacityObservation(0, 2200), CapacityObservation(11, 7040)], 12.0)
+        stock = calibrate([CapacityObservation(0, 1000), CapacityObservation(11, 2100)])
+        measured = calibrate([CapacityObservation(0, 2200), CapacityObservation(11, 7040)])
 
-        assert teuton.capacity(11) == 2100
-        assert doc_model.capacity(11) == 7040
-        # A 3.35x difference in how many merchants every route needs.
-        assert doc_model.capacity(11) / teuton.capacity(11) == pytest.approx(3.35, abs=0.01)
+        assert stock.capacity(11) == 2100
+        assert measured.capacity(11) == 7040
+        assert measured.capacity(11) / stock.capacity(11) == pytest.approx(3.35, abs=0.01)
+
+    def test_the_measured_europe2_model_matches_the_live_reading(self):
+        """R1 resolved: a TO 13 village on Europe 2 carries 7,920 per merchant.
+
+        2200 * (1 + 0.2 * 13) == 7920 exactly. Stock Teuton predicts 2,300, so
+        this server is not stock and the review's objection was wrong.
+        """
+        assert EUROPE2_TEUTON.capacity(13) == 7920
+        assert STOCK_TEUTON.capacity(13) == 2300
 
     def test_inconsistent_observations_raise_rather_than_average(self):
         """Per-village variation means a Trade artifact, not a fitting problem."""
@@ -93,7 +101,6 @@ class TestCalibration:
                     CapacityObservation(10, 2000),
                     CapacityObservation(5, 3000),  # doubled: artifact village
                 ],
-                speed_fields_per_hour=12.0,
             )
 
     def test_adjacent_trade_office_levels_are_refused(self):
@@ -105,22 +112,22 @@ class TestCalibration:
         that silently breaches a village's merchant budget.
         """
         with pytest.raises(CalibrationError, match="apart"):
-            calibrate([CapacityObservation(7, 1350), CapacityObservation(8, 1400)], 12.0)
+            calibrate([CapacityObservation(7, 1350), CapacityObservation(8, 1400)])
 
     def test_a_trade_office_free_village_needs_no_separation(self):
         """base is read directly, so TO 0 paired with TO 1 is still exact."""
-        model = calibrate([CapacityObservation(0, 1000), CapacityObservation(1, 1100)], 12.0)
+        model = calibrate([CapacityObservation(0, 1000), CapacityObservation(1, 1100)])
 
         assert model.base_capacity == 1000
         assert model.bonus_per_trade_office_level == pytest.approx(0.10)
 
     def test_single_trade_office_level_cannot_solve_two_unknowns(self):
         with pytest.raises(CalibrationError, match="two different"):
-            calibrate([CapacityObservation(5, 1500), CapacityObservation(5, 1500)], 12.0)
+            calibrate([CapacityObservation(5, 1500), CapacityObservation(5, 1500)])
 
     def test_one_observation_is_rejected(self):
         with pytest.raises(CalibrationError, match="at least two"):
-            calibrate([CapacityObservation(0, 1000)], 12.0)
+            calibrate([CapacityObservation(0, 1000)])
 
 
 class TestRouteCost:
@@ -198,6 +205,21 @@ class TestCycleSelection:
         assert {c.merchants_committed for c in costs} == {1}
 
         assert cheapest_cycle(1, 60.0, 10_000, cycles=(3, 2, 1)).cycle_hours == 1
+
+    def test_the_cheapest_cycle_is_also_the_most_affordable_one(self):
+        """Why cheapest_cycle takes no budget parameter.
+
+        Minimising merchants already yields the cycle most likely to fit, so a
+        budget filter could never change the answer: if the minimum does not
+        fit, nothing does. Feasibility stays the caller's check.
+        """
+        costs = cycle_sweep(V10_CARGO, V10_ROUND_TRIP, V10_CAPACITY)
+        best = cheapest_cycle(V10_CARGO, V10_ROUND_TRIP, V10_CAPACITY)
+
+        assert best.merchants_committed == min(c.merchants_committed for c in costs)
+        for budget in range(40):
+            fits = [c for c in costs if c.merchants_committed <= budget]
+            assert not fits or best in fits
 
     def test_empty_cycle_set_is_rejected(self):
         with pytest.raises(ValueError):

--- a/tests/test_distribution_merchants.py
+++ b/tests/test_distribution_merchants.py
@@ -96,6 +96,24 @@ class TestCalibration:
                 speed_fields_per_hour=12.0,
             )
 
+    def test_adjacent_trade_office_levels_are_refused(self):
+        """Found by simulation, not by these tests originally.
+
+        The game floors reported capacity, so adjacent levels make the solve
+        ill-conditioned: across 570 synthetic models it mis-predicted capacity
+        at TO 20 by up to 19 and overstated it in 8% of cases -- the direction
+        that silently breaches a village's merchant budget.
+        """
+        with pytest.raises(CalibrationError, match="apart"):
+            calibrate([CapacityObservation(7, 1350), CapacityObservation(8, 1400)], 12.0)
+
+    def test_a_trade_office_free_village_needs_no_separation(self):
+        """base is read directly, so TO 0 paired with TO 1 is still exact."""
+        model = calibrate([CapacityObservation(0, 1000), CapacityObservation(1, 1100)], 12.0)
+
+        assert model.base_capacity == 1000
+        assert model.bonus_per_trade_office_level == pytest.approx(0.10)
+
     def test_single_trade_office_level_cannot_solve_two_unknowns(self):
         with pytest.raises(CalibrationError, match="two different"):
             calibrate([CapacityObservation(5, 1500), CapacityObservation(5, 1500)], 12.0)

--- a/tests/test_distribution_merchants.py
+++ b/tests/test_distribution_merchants.py
@@ -1,0 +1,186 @@
+"""Merchant capacity model and route cost.
+
+The V10 -> V02 case is the operator's own hand-computed route from
+docs/25-resource-distribution-planner.md. It is the golden case because it was
+produced independently of this code and exhibits the non-monotonicity that makes
+the cycle choice non-obvious.
+"""
+
+import pytest
+
+from travian_api.services.distribution.merchants import (
+    ALL_CYCLES,
+    DAILY_BEAT_CYCLES,
+    STOCK_TEUTON,
+    CalibrationError,
+    CapacityObservation,
+    MerchantModel,
+    calibrate,
+    cheapest_cycle,
+    cycle_sweep,
+    route_cost,
+)
+
+# V10 -> V02: 9,323/h of cargo, 532 min round trip, 5,720 per merchant.
+V10_CARGO = 9323
+V10_ROUND_TRIP = 532.0
+V10_CAPACITY = 5720
+
+
+class TestCapacity:
+    def test_capacity_scales_with_trade_office_level(self):
+        model = MerchantModel(1000, 0.10, 12.0)
+
+        assert model.capacity(0) == 1000
+        assert model.capacity(10) == 2000
+        assert model.capacity(20) == 3000
+
+    def test_capacity_rounds_down(self):
+        """Understating capacity over-provisions (safe); overstating breaches
+        the merchant budget invisibly (unsafe). Only round the safe way."""
+        model = MerchantModel(1000, 0.13, 12.0)
+
+        assert model.capacity(1) == 1130
+        assert model.capacity(3) == 1390  # 1390.0000000000002 must not become 1391
+
+    def test_negative_trade_office_level_is_rejected(self):
+        with pytest.raises(ValueError):
+            STOCK_TEUTON.capacity(-1)
+
+
+class TestCalibration:
+    """Resolves R1 without trusting any published constant."""
+
+    def test_two_observations_recover_base_and_bonus(self):
+        model = calibrate(
+            [CapacityObservation(0, 1000), CapacityObservation(10, 2000)],
+            speed_fields_per_hour=12.0,
+        )
+
+        assert model.base_capacity == 1000
+        assert model.bonus_per_trade_office_level == pytest.approx(0.10)
+
+    def test_calibration_works_without_a_zero_level_sample(self):
+        """The two villages to hand may both have a Trade Office."""
+        model = calibrate(
+            [CapacityObservation(4, 1400), CapacityObservation(11, 2100)],
+            speed_fields_per_hour=12.0,
+        )
+
+        assert model.base_capacity == 1000
+        assert model.bonus_per_trade_office_level == pytest.approx(0.10)
+
+    def test_calibration_distinguishes_the_two_disputed_models(self):
+        """The whole point of R1: which model the account actually follows.
+
+        A TO-11 village reading 2,100 is base 1000 / +10%. Reading 7,040 it is
+        base 2200 / +20%. One observation pair settles it.
+        """
+        teuton = calibrate([CapacityObservation(0, 1000), CapacityObservation(11, 2100)], 12.0)
+        doc_model = calibrate([CapacityObservation(0, 2200), CapacityObservation(11, 7040)], 12.0)
+
+        assert teuton.capacity(11) == 2100
+        assert doc_model.capacity(11) == 7040
+        # A 3.35x difference in how many merchants every route needs.
+        assert doc_model.capacity(11) / teuton.capacity(11) == pytest.approx(3.35, abs=0.01)
+
+    def test_inconsistent_observations_raise_rather_than_average(self):
+        """Per-village variation means a Trade artifact, not a fitting problem."""
+        with pytest.raises(CalibrationError, match="Trade artifact"):
+            calibrate(
+                [
+                    CapacityObservation(0, 1000),
+                    CapacityObservation(10, 2000),
+                    CapacityObservation(5, 3000),  # doubled: artifact village
+                ],
+                speed_fields_per_hour=12.0,
+            )
+
+    def test_single_trade_office_level_cannot_solve_two_unknowns(self):
+        with pytest.raises(CalibrationError, match="two different"):
+            calibrate([CapacityObservation(5, 1500), CapacityObservation(5, 1500)], 12.0)
+
+    def test_one_observation_is_rejected(self):
+        with pytest.raises(CalibrationError, match="at least two"):
+            calibrate([CapacityObservation(0, 1000)], 12.0)
+
+
+class TestRouteCost:
+    def test_reproduces_the_hand_computed_route(self):
+        """Independently derived by the operator; must reproduce exactly."""
+        expected = {
+            1: (2, 9, 18),
+            2: (4, 5, 20),
+            3: (5, 3, 15),
+            4: (7, 3, 21),
+        }
+
+        for cycle, (send, sets, pool) in expected.items():
+            cost = route_cost(V10_CARGO, cycle, V10_ROUND_TRIP, V10_CAPACITY)
+            assert (cost.merchants_per_send, cost.sets_in_flight) == (send, sets), cycle
+            assert cost.merchants_committed == pool, cycle
+
+    def test_merchant_cost_is_not_monotonic_in_cycle_length(self):
+        """Why the optimizer must sweep instead of hill-climbing."""
+        pools = [
+            route_cost(V10_CARGO, cycle, V10_ROUND_TRIP, V10_CAPACITY).merchants_committed
+            for cycle in (1, 2, 3, 4)
+        ]
+
+        assert pools == [18, 20, 15, 21]
+        assert pools[1] > pools[0] and pools[2] < pools[1] and pools[3] > pools[2]
+
+    def test_sets_in_flight_at_an_exact_multiple_of_the_cycle(self):
+        """Round trip 360 min on a 3h cycle: the first set lands exactly as the
+        third send is due, so two sets suffice."""
+        cost = route_cost(1000, 3, 360.0, 10_000)
+
+        assert cost.sets_in_flight == 2
+
+    def test_a_trip_shorter_than_the_cycle_needs_one_set(self):
+        cost = route_cost(1000, 4, 90.0, 10_000)
+
+        assert cost.sets_in_flight == 1
+
+    def test_zero_cargo_commits_no_merchants(self):
+        cost = route_cost(0, 3, V10_ROUND_TRIP, V10_CAPACITY)
+
+        assert cost.merchants_committed == 0
+
+    @pytest.mark.parametrize(
+        "cargo,cycle,capacity",
+        [(100, 0, 1000), (100, -1, 1000), (100, 3, 0), (-1, 3, 1000)],
+    )
+    def test_invalid_inputs_are_rejected(self, cargo, cycle, capacity):
+        with pytest.raises(ValueError):
+            route_cost(cargo, cycle, 100.0, capacity)
+
+
+class TestCycleSelection:
+    def test_picks_the_cheapest_cycle(self):
+        best = cheapest_cycle(V10_CARGO, V10_ROUND_TRIP, V10_CAPACITY)
+
+        assert best.cycle_hours == 3
+        assert best.merchants_committed == 15
+
+    def test_default_cycles_all_divide_a_day(self):
+        """R5: a schedule is only expressible as a daily beat if they do."""
+        assert all(24 % cycle == 0 for cycle in DAILY_BEAT_CYCLES)
+
+    def test_the_wider_sweep_is_available_to_price_the_restriction(self):
+        """The daily-beat restriction must be measurable, not hidden."""
+        restricted = cheapest_cycle(V10_CARGO, V10_ROUND_TRIP, V10_CAPACITY)
+        unrestricted = cheapest_cycle(V10_CARGO, V10_ROUND_TRIP, V10_CAPACITY, ALL_CYCLES)
+
+        assert unrestricted.merchants_committed <= restricted.merchants_committed
+
+    def test_ties_resolve_to_the_shorter_cycle(self):
+        """Equal merchants, sooner delivery -- objective 2."""
+        costs = cycle_sweep(1, 60.0, 10_000, cycles=(1, 2, 3))
+        assert {c.merchants_committed for c in costs} == {1}
+
+        assert cheapest_cycle(1, 60.0, 10_000, cycles=(3, 2, 1)).cycle_hours == 1
+
+    def test_empty_cycle_set_is_rejected(self):
+        with pytest.raises(ValueError):
+            cheapest_cycle(V10_CARGO, V10_ROUND_TRIP, V10_CAPACITY, cycles=())

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -283,14 +283,34 @@ def _greedy_seed_merchants(villages, plans):
 class TestImprovementNeverRegresses:
     @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
     def test_improved_plan_is_never_worse_than_the_greedy_seed(self, village_count):
-        """The local search only accepts strictly-improving swaps, so the plan it
-        returns must commit no more merchants than the seed it started from."""
+        """The local search only accepts strictly-improving swaps, so the
+        merchant-minimal plan commits no more merchants than the seed it started
+        from. Measured with the latency pass off (``max_latency_hours=None``),
+        which is the stage this property is about — the latency pass then spends
+        idle merchants on speed, deliberately raising the count within budget."""
         villages = make_account(village_count, seed=village_count + 91)
         plans, _ = make_plans(villages, seed=village_count + 91)
 
-        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+        plan = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
 
         assert plan.total_merchants <= _greedy_seed_merchants(villages, plans)
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_latency_pass_never_pushes_a_village_over_budget(self, village_count):
+        """Idle-merchant spending is gated by the per-village budget, so a plan
+        that was feasible without it stays feasible with it, and villages already
+        over budget (no spare) are left untouched."""
+        villages = make_account(village_count, seed=village_count + 91)
+        plans, _ = make_plans(villages, seed=village_count + 91)
+
+        minimal = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+        with_latency = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=2.0)
+
+        minimal_over = {o.village_id for o in minimal.over_budget}
+        assert {o.village_id for o in with_latency.over_budget} == minimal_over
+        for vid, used in with_latency.merchants_committed.items():
+            if vid not in minimal_over:
+                assert used <= villages[vid].spare_merchants()
 
 
 class TestDeterminism:

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -30,6 +30,7 @@ from travian_api.services.distribution.optimizer import (
     VillageState,
     _flows_for_resource,
     _route_for_pair,
+    breakpoint_candidates,
     build_plan,
 )
 
@@ -712,6 +713,56 @@ class TestRelayGraphStaysShallow:
                 f"village {hub} forwards crop on to another hub {downstream & hubs}; "
                 f"that is a relay chain, not a single hop"
             )
+
+
+class TestBreakpointCandidates:
+    """Transfer sizes must include boundaries from SHRINKING pairs too.
+
+    Codex review counterexample (capacity 1,000): a pair carrying 200/h over a
+    1,800-minute round trip costs 8 merchants; at the 166.67/h boundary of a 6h
+    cycle it costs 5. With growing legs at 600/1,200-minute round trips, the
+    transfer t=33.33 that lands on that boundary saves a net merchant while the
+    full transfer t=100 costs a net merchant. The first implementation only
+    generated boundaries where a GROWING pair's batch crossed a capacity
+    multiple, so the one improving move was never tried and the search declared
+    convergence with an improvement still available.
+    """
+
+    def test_shrinking_pair_boundaries_are_generated(self):
+        ts = breakpoint_candidates(
+            grows=[(0.0, 1_000), (0.0, 1_000)],
+            shrinks=[(100.0, 1_000), (200.0, 1_000)],
+            t_full=100.0,
+            cycles=DAILY_BEAT_CYCLES,
+        )
+
+        assert any(abs(t - 100.0 / 3) < 0.01 for t in ts), (
+            f"the 166.67/h boundary of the shrinking 200/h pair (t=33.33) is "
+            f"missing: {[round(t, 2) for t in ts]}"
+        )
+
+    def test_the_full_transfer_is_always_first(self):
+        """The vertex move must never be silently dropped by the cap: it is the
+        one candidate the pre-refinement search already relies on."""
+        ts = breakpoint_candidates(
+            grows=[(950.0, 1_000), (990.0, 1_000)],
+            shrinks=[(970.0, 1_000), (960.0, 1_000)],
+            t_full=500.0,
+            cycles=DAILY_BEAT_CYCLES,
+        )
+
+        assert ts[0] == 500.0
+        assert len(ts) <= 12
+
+    def test_candidates_stay_inside_the_open_interval(self):
+        ts = breakpoint_candidates(
+            grows=[(123.0, 1_000)],
+            shrinks=[(456.0, 1_000)],
+            t_full=77.7,
+            cycles=DAILY_BEAT_CYCLES,
+        )
+
+        assert all(0 < t <= 77.7 for t in ts)
 
 
 class TestCrossResourceBundling:

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -594,6 +594,47 @@ class TestCropRelay:
         )
 
 
+class TestRelayGraphStaysShallow:
+    """Relay must produce single hops, not a waterfall or a loop.
+
+    The beat's collect-then-ship ordering assumes it can place a hub's inbound
+    before its outbound. A longer chain makes that a topological problem, and a
+    two-way pair makes it unsatisfiable outright -- each end would have to ship
+    after the other. Guarding only the relayed flow's ORIGIN was not enough:
+    relaying a leg that ended at an existing hub extended the chain.
+    """
+
+    @pytest.mark.parametrize("village_count", [5, 12, 22, 40])
+    def test_crop_never_forms_a_chain_or_a_two_way_pair(self, village_count):
+        villages = make_account(village_count, seed=village_count + 301)
+        plans, _ = make_plans(villages, seed=village_count + 301)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+
+        edges = {
+            (r.origin, r.destination) for r in plan.routes if Resource.CROP in r.cargo_per_hour
+        }
+        for origin, destination in edges:
+            assert (destination, origin) not in edges, (
+                f"crop ships both ways between {origin} and {destination}; "
+                f"collect-then-ship cannot be satisfied at either end"
+            )
+        senders = {o for o, _ in edges}
+        receivers = {d for _, d in edges}
+        hubs = senders & receivers
+        for hub in hubs:
+            upstream = {o for o, d in edges if d == hub}
+            downstream = {d for o, d in edges if o == hub}
+            assert not (upstream & hubs), (
+                f"village {hub} forwards crop it received from another hub {upstream & hubs}; "
+                f"that is a relay chain, not a single hop"
+            )
+            assert not (downstream & hubs), (
+                f"village {hub} forwards crop on to another hub {downstream & hubs}; "
+                f"that is a relay chain, not a single hop"
+            )
+
+
 class TestCrossResourceBundling:
     def test_cargo_riding_an_existing_pair_is_preferred_to_opening_a_new_one(self):
         """Merchant cost is charged on the MERGED pair cargo, so moving a

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -18,8 +18,17 @@ from travian_api.services.distribution.allocation import (
     resolve_resource,
 )
 from travian_api.services.distribution.geometry import MapGeometry
-from travian_api.services.distribution.merchants import EUROPE2_TEUTON, route_cost
-from travian_api.services.distribution.optimizer import VillageState, build_plan
+from travian_api.services.distribution.merchants import (
+    DAILY_BEAT_CYCLES,
+    EUROPE2_TEUTON,
+    route_cost,
+)
+from travian_api.services.distribution.optimizer import (
+    VillageState,
+    _flows_for_resource,
+    _route_for_pair,
+    build_plan,
+)
 
 GEOMETRY = MapGeometry(span=401, speed_fields_per_hour=12.0)
 MODEL = EUROPE2_TEUTON
@@ -253,6 +262,35 @@ class TestBudgetIsReportedNotHidden:
         village = VillageState(village_id=1, x=0, y=0, merchant_count=2)
 
         assert village.spare_merchants(reserve=2) == 0
+
+
+def _greedy_seed_merchants(villages, plans):
+    """Total merchants the greedy seed alone commits, before local search."""
+    pair: dict[tuple[int, int], dict[Resource, float]] = {}
+    for resource, resource_plan in plans.items():
+        flows, _ = _flows_for_resource(resource_plan, villages, GEOMETRY)
+        for key, amount in flows.items():
+            pair.setdefault(key, {})[resource] = amount
+    total = 0
+    for (origin, destination), cargo in pair.items():
+        route = _route_for_pair(
+            origin, destination, cargo, villages, GEOMETRY, MODEL, DAILY_BEAT_CYCLES
+        )
+        total += route.merchants_committed
+    return total
+
+
+class TestImprovementNeverRegresses:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_improved_plan_is_never_worse_than_the_greedy_seed(self, village_count):
+        """The local search only accepts strictly-improving swaps, so the plan it
+        returns must commit no more merchants than the seed it started from."""
+        villages = make_account(village_count, seed=village_count + 91)
+        plans, _ = make_plans(villages, seed=village_count + 91)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        assert plan.total_merchants <= _greedy_seed_merchants(villages, plans)
 
 
 class TestDeterminism:

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -22,6 +22,7 @@ from travian_api.services.distribution.geometry import MapGeometry
 from travian_api.services.distribution.merchants import (
     DAILY_BEAT_CYCLES,
     EUROPE2_TEUTON,
+    MerchantModel,
     route_cost,
 )
 from travian_api.services.distribution.optimizer import (
@@ -486,14 +487,54 @@ class TestLatencyPassRespectsTheFillFloor:
 
 
 class TestCropRelay:
-    """Relay exists to buy feasibility, never to save merchants.
+    """Relay buys feasibility, and in one regime it genuinely saves merchants.
 
-    Merchant cost is essentially cargo x round_trip / capacity -- linear in both
-    -- so consolidating n shipments into one long haul costs the same on the long
-    leg and adds the collection legs on top. Measured across every cluster
-    geometry, relay is at best break-even on total merchants. Its real use is to
-    move commitment off a village that cannot staff its own haul.
+    The first version of this docstring claimed it could NEVER save merchants,
+    from a linearity argument (cost ~ cargo x round_trip / capacity) -- and a
+    sweep that happened to sample only the large-batch regime "confirmed" it.
+    External review produced the counterexample: cost is really
+    ceil(batch/capacity) x sets_in_flight, so each send's partial-vehicle waste
+    is multiplied by every set in flight, and POOLING part-loads onto one trunk
+    removes that waste. Five 900/h flows over a 1,200-minute round trip at
+    capacity 1,000: 100 vehicles direct, 95 pooled.
+
+    Its primary use remains moving commitment off a village that cannot staff
+    its own haul (feasibility, the first objective key).
     """
+
+    def test_pooling_part_loads_can_genuinely_save_merchants(self):
+        """The ceiling-waste counterexample, end to end. Also pins the honest
+        limitation: single-flow relay moves harvest the pooling win only
+        PARTIALLY -- fully pooling all five senders needs a compound move whose
+        individual steps are break-even, which first-improvement cannot cross.
+        So this asserts only that relay ON strictly beats relay OFF, not that
+        the full theoretical saving is captured."""
+        model = MerchantModel(base_capacity=1_000, bonus_per_trade_office_level=0.0)
+        villages = {1: VillageState(1, 0, 0, merchant_count=200, trade_office_level=0)}
+        prod = {1: 0.0}
+        alloc = {1: Allocation(AllocationMode.REMAINDER)}
+        for i, vid in enumerate((2, 3, 4, 5, 6)):
+            villages[vid] = VillageState(vid, 120, i, merchant_count=25, trade_office_level=0)
+            prod[vid] = 900.0
+            alloc[vid] = Allocation(AllocationMode.ABSOLUTE, 0.0)
+        # The hub sits beside the cluster and already carries crop.
+        villages[7] = VillageState(7, 114, 2, merchant_count=200, trade_office_level=0)
+        prod[7] = 100.0
+        alloc[7] = Allocation(AllocationMode.ABSOLUTE, 0.0)
+        plans = {Resource.CROP: resolve_resource(Resource.CROP, prod, alloc)}
+
+        direct = build_plan(
+            villages, plans, GEOMETRY, model, max_latency_hours=None, max_relay_hops=0
+        )
+        relayed = build_plan(villages, plans, GEOMETRY, model, max_latency_hours=None)
+
+        assert not direct.over_budget and not relayed.over_budget, (
+            "budgets are deliberately huge; any excess means the fixture drifted"
+        )
+        assert relayed.total_merchants < direct.total_merchants, (
+            f"pooling saved nothing ({relayed.total_merchants} vs "
+            f"{direct.total_merchants}); the ceiling-waste win regressed"
+        )
 
     def _stranded_account(self):
         """A far village that cannot afford its own haul, plus a midpoint hub.

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -566,6 +566,44 @@ class TestCropRelay:
             f"{own.ship_per_hour:+.0f}/h -- it kept or funded some of the relay"
         )
 
+    def test_relay_picks_the_best_hub_not_the_lowest_numbered_one(self):
+        """Hubs are iterated in village-id order. Taking the first that merely
+        improved therefore chose by id, which is arbitrary: on a real account it
+        routed a 96-field haul through the lowest-numbered village while four
+        nearer ones sat unused, and left the sender over its merchant budget.
+
+        Here village 2 is the low-numbered far hub and village 9 the near one.
+        The near hub must win on merit despite sorting last.
+        """
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=20, trade_office_level=12),  # capital
+            2: VillageState(2, 100, 60, merchant_count=20, trade_office_level=12),  # far, low id
+            9: VillageState(9, 40, 20, merchant_count=20, trade_office_level=12),  # near, high id
+            5: VillageState(5, 150, 90, merchant_count=8, trade_office_level=10),  # stranded
+        }
+        plans = {
+            Resource.CROP: resolve_resource(
+                Resource.CROP,
+                {1: 0.0, 2: 900.0, 9: 900.0, 5: 9000.0},
+                {
+                    1: Allocation(AllocationMode.REMAINDER),
+                    2: Allocation(AllocationMode.ABSOLUTE, 900.0),
+                    9: Allocation(AllocationMode.ABSOLUTE, 900.0),
+                    5: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                },
+            )
+        }
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+
+        hops = [r.destination for r in plan.routes if r.origin == 5]
+        assert hops, "the stranded village shipped nothing"
+        # Whatever it chose, it must not be dearer than the cheapest option, and
+        # the near hub is strictly cheaper than the far one from village 5.
+        assert 2 not in hops or 9 in hops, (
+            f"routed through the far low-id hub (2) while the nearer hub (9) was available: {hops}"
+        )
+
     @pytest.mark.parametrize("village_count", [5, 12, 22, 40])
     def test_relay_never_makes_a_plan_worse(self, village_count):
         """Relay is adopted only when it strictly lowers the objective.

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -1,0 +1,350 @@
+"""Optimizer invariants, checked over randomly generated accounts.
+
+The account this plans for is a moving target -- 22 villages today, 23 landing,
+and every production figure different between runs -- so correctness is pinned
+with properties that must hold for *any* shape of account rather than by
+reproducing one snapshot. A golden fixture of a 20-village plan would be stale
+the day it was written.
+"""
+
+import random
+
+import pytest
+
+from travian_api.services.distribution.allocation import (
+    Allocation,
+    AllocationMode,
+    Resource,
+    resolve_resource,
+)
+from travian_api.services.distribution.geometry import MapGeometry
+from travian_api.services.distribution.merchants import EUROPE2_TEUTON, route_cost
+from travian_api.services.distribution.optimizer import VillageState, build_plan
+
+GEOMETRY = MapGeometry(span=401, speed_fields_per_hour=12.0)
+MODEL = EUROPE2_TEUTON
+
+
+def make_account(village_count: int, seed: int) -> dict[int, VillageState]:
+    """An arbitrary account of *village_count* villages."""
+    rng = random.Random(seed)
+    return {
+        vid: VillageState(
+            village_id=vid,
+            x=rng.randint(-120, 120),
+            y=rng.randint(-120, 120),
+            merchant_count=rng.choice([2, 13, 19, 20]),
+            trade_office_level=rng.randint(0, 20),
+        )
+        for vid in range(1, village_count + 1)
+    }
+
+
+def make_plans(
+    villages: dict[int, VillageState], seed: int
+) -> tuple[dict[Resource, object], dict[Resource, dict[int, float]]]:
+    """Random production plus one remainder village per resource."""
+    rng = random.Random(seed)
+    plans = {}
+    productions = {}
+    ids = sorted(villages)
+    for resource in Resource:
+        production = {vid: float(rng.randint(200, 9000)) for vid in ids}
+        remainder = ids[rng.randrange(len(ids))]
+        allocations = {remainder: Allocation(AllocationMode.REMAINDER)}
+        for vid in ids:
+            if vid == remainder:
+                continue
+            if rng.random() < 0.5:
+                allocations[vid] = Allocation(AllocationMode.ABSOLUTE, float(rng.randint(0, 9000)))
+        plans[resource] = resolve_resource(resource, production, allocations)
+        productions[resource] = production
+    return plans, productions
+
+
+ACCOUNT_SIZES = [1, 2, 3, 5, 12, 22, 23, 40]
+
+
+class TestScalesToAnyAccountSize:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_produces_a_plan_without_error(self, village_count):
+        villages = make_account(village_count, seed=village_count)
+        plans, _ = make_plans(villages, seed=village_count)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        assert set(plan.merchants_committed) == set(villages)
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_routes_only_reference_known_villages(self, village_count):
+        villages = make_account(village_count, seed=village_count + 100)
+        plans, _ = make_plans(villages, seed=village_count + 100)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        for route in plan.routes:
+            assert route.origin in villages
+            assert route.destination in villages
+            assert route.origin != route.destination
+
+    def test_a_new_village_does_not_break_an_existing_plan(self):
+        """Village 23 lands mid-server; the planner must absorb it."""
+        villages = make_account(22, seed=7)
+        plans, _ = make_plans(villages, seed=7)
+        before = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        grown = dict(villages)
+        grown[23] = VillageState(village_id=23, x=40, y=40, merchant_count=20)
+        after = build_plan(grown, plans, GEOMETRY, MODEL)
+
+        # The newcomer has no allocation yet, so it neither sends nor receives.
+        assert after.merchants_committed[23] == 0
+        assert before.routes == after.routes
+
+    def test_an_empty_account_plans_nothing_rather_than_failing(self):
+        plan = build_plan({}, {}, GEOMETRY, MODEL)
+
+        assert plan.routes == ()
+        assert plan.is_feasible
+
+
+class TestStructuralInvariants:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_never_ships_one_resource_both_ways_between_a_pair(self, village_count):
+        """Known issue #2. Impossible by construction -- netting in the
+        allocation layer means a village cannot both send and receive the same
+        resource -- so this asserts the property rather than a guard."""
+        villages = make_account(village_count, seed=village_count + 3)
+        plans, _ = make_plans(villages, seed=village_count + 3)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        carried: dict[tuple[int, int], set[Resource]] = {}
+        for route in plan.routes:
+            carried[(route.origin, route.destination)] = set(route.cargo_per_hour)
+        for (origin, destination), resources in carried.items():
+            back = carried.get((destination, origin), set())
+            assert not (resources & back), f"{origin}<->{destination} both ways"
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_no_village_relays_the_same_resource(self, village_count):
+        """The no-waterfall rule for W/C/I, and it holds for crop too."""
+        villages = make_account(village_count, seed=village_count + 11)
+        plans, _ = make_plans(villages, seed=village_count + 11)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        sends: dict[int, set[Resource]] = {}
+        receives: dict[int, set[Resource]] = {}
+        for route in plan.routes:
+            sends.setdefault(route.origin, set()).update(route.cargo_per_hour)
+            receives.setdefault(route.destination, set()).update(route.cargo_per_hour)
+        for vid in villages:
+            assert not (sends.get(vid, set()) & receives.get(vid, set()))
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_merchant_arithmetic_matches_the_cost_model(self, village_count):
+        villages = make_account(village_count, seed=village_count + 21)
+        plans, _ = make_plans(villages, seed=village_count + 21)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        for route in plan.routes:
+            expected = route_cost(
+                route.hourly_total,
+                route.cycle_hours,
+                2.0 * route.one_way_minutes,
+                MODEL.capacity(villages[route.origin].trade_office_level),
+            )
+            assert route.merchants_per_send == expected.merchants_per_send
+            assert route.sets_in_flight == expected.sets_in_flight
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_committed_merchants_equal_the_sum_of_the_routes(self, village_count):
+        villages = make_account(village_count, seed=village_count + 31)
+        plans, _ = make_plans(villages, seed=village_count + 31)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        per_origin: dict[int, int] = {vid: 0 for vid in villages}
+        for route in plan.routes:
+            per_origin[route.origin] += route.merchants_committed
+        assert plan.merchants_committed == per_origin
+        assert plan.total_merchants == sum(r.merchants_committed for r in plan.routes)
+
+
+class TestBudgetIsReportedNotHidden:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_every_over_budget_village_is_reported(self, village_count):
+        """Known issue #6: the cap must never be breached invisibly."""
+        villages = make_account(village_count, seed=village_count + 41)
+        plans, _ = make_plans(villages, seed=village_count + 41)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        reported = {o.village_id for o in plan.over_budget}
+        for vid, used in plan.merchants_committed.items():
+            if used > villages[vid].spare_merchants():
+                assert vid in reported, f"village {vid} over budget but not reported"
+        for over in plan.over_budget:
+            assert over.excess > 0
+
+    def test_reserve_is_withheld_from_the_budget(self):
+        village = VillageState(village_id=1, x=0, y=0, merchant_count=20)
+
+        assert village.spare_merchants(reserve=2) == 18
+        assert village.spare_merchants(reserve=0) == 20
+
+    def test_a_village_with_fewer_merchants_than_the_reserve_has_none_spare(self):
+        """Real accounts have low-marketplace villages; 2 merchants is observed."""
+        village = VillageState(village_id=1, x=0, y=0, merchant_count=2)
+
+        assert village.spare_merchants(reserve=2) == 0
+
+
+class TestDeterminism:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_replanning_unchanged_input_gives_an_identical_plan(self, village_count):
+        """Known issue #10: without this the route diff is meaningless."""
+        villages = make_account(village_count, seed=village_count + 51)
+        plans, _ = make_plans(villages, seed=village_count + 51)
+
+        first = build_plan(villages, plans, GEOMETRY, MODEL)
+        second = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        assert first.routes == second.routes
+        assert first.merchants_committed == second.merchants_committed
+
+    def test_village_ordering_does_not_change_the_plan(self):
+        villages = make_account(12, seed=61)
+        plans, _ = make_plans(villages, seed=61)
+        reversed_villages = dict(reversed(list(villages.items())))
+
+        assert (
+            build_plan(villages, plans, GEOMETRY, MODEL).routes
+            == build_plan(reversed_villages, plans, GEOMETRY, MODEL).routes
+        )
+
+
+class TestFlowConservation:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_received_plus_shortfall_equals_demand(self, village_count):
+        """Every receiver either gets what it asked for or the gap is recorded."""
+        villages = make_account(village_count, seed=village_count + 71)
+        plans, _ = make_plans(villages, seed=village_count + 71)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        for resource, resource_plan in plans.items():
+            received: dict[int, float] = {}
+            for route in plan.routes:
+                if resource in route.cargo_per_hour:
+                    received[route.destination] = (
+                        received.get(route.destination, 0.0) + route.cargo_per_hour[resource]
+                    )
+            missing = {s.village_id: s.per_hour for s in plan.shortfalls if s.resource is resource}
+            for village in resource_plan.receivers:
+                got = received.get(village.village_id, 0.0)
+                gap = missing.get(village.village_id, 0.0)
+                assert got + gap == pytest.approx(village.ship_per_hour, rel=1e-6, abs=1e-6)
+
+    def test_unmet_demand_is_reported_as_a_shortfall(self):
+        """Reaches a branch the generated accounts cannot.
+
+        With a remainder village every resource plan is conserved, so supply
+        equals demand exactly and nothing can go unrouted. Only an unconserved
+        plan -- an absolute target with no remainder to fund it -- produces a
+        shortfall, and it must be reported rather than quietly under-shipped.
+        """
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=20, trade_office_level=13),
+            2: VillageState(2, 12, 0, merchant_count=20, trade_office_level=13),
+        }
+        plans = {
+            Resource.IRON: resolve_resource(
+                Resource.IRON,
+                {1: 1000.0, 2: 0.0},
+                {
+                    1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    2: Allocation(AllocationMode.ABSOLUTE, 5000.0),
+                },
+            )
+        }
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        assert len(plan.shortfalls) == 1
+        shortfall = plan.shortfalls[0]
+        assert shortfall.village_id == 2
+        assert shortfall.per_hour == pytest.approx(4000.0)
+        assert not plan.is_feasible
+        # The 1,000 that *could* be shipped still is.
+        assert plan.routes[0].cargo_per_hour[Resource.IRON] == pytest.approx(1000.0)
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_no_village_sends_more_than_its_surplus(self, village_count):
+        villages = make_account(village_count, seed=village_count + 81)
+        plans, _ = make_plans(villages, seed=village_count + 81)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        for resource, resource_plan in plans.items():
+            surplus = {v.village_id: -v.ship_per_hour for v in resource_plan.senders}
+            sent: dict[int, float] = {}
+            for route in plan.routes:
+                if resource in route.cargo_per_hour:
+                    sent[route.origin] = (
+                        sent.get(route.origin, 0.0) + route.cargo_per_hour[resource]
+                    )
+            for vid, amount in sent.items():
+                assert amount <= surplus.get(vid, 0.0) + 1e-6
+
+
+class TestRouteShape:
+    def test_cargo_is_merged_per_pair_not_split_by_resource(self):
+        """A Travian route carries all four resources together, and merchant cost
+        is driven by the combined tonnage -- so one pair means one route."""
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=20, trade_office_level=13),
+            2: VillageState(2, 12, 0, merchant_count=20, trade_office_level=13),
+        }
+        plans = {
+            resource: resolve_resource(
+                resource,
+                {1: 1000.0, 2: 0.0},
+                {
+                    1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    2: Allocation(AllocationMode.REMAINDER),
+                },
+            )
+            for resource in Resource
+        }
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        assert len(plan.routes) == 1
+        route = plan.routes[0]
+        assert (route.origin, route.destination) == (1, 2)
+        assert set(route.cargo_per_hour) == set(Resource)
+        assert route.hourly_total == pytest.approx(4000.0)
+
+    def test_latency_counts_the_cycle_wait_as_well_as_the_trip(self):
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=20),
+            2: VillageState(2, 12, 0, merchant_count=20),
+        }
+        plans = {
+            Resource.IRON: resolve_resource(
+                Resource.IRON,
+                {1: 500.0, 2: 0.0},
+                {
+                    1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    2: Allocation(AllocationMode.REMAINDER),
+                },
+            )
+        }
+
+        route = build_plan(villages, plans, GEOMETRY, MODEL).routes[0]
+
+        assert route.one_way_minutes == pytest.approx(60.0)
+        assert route.latency_hours == pytest.approx(route.cycle_hours + 1.0)

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -7,6 +7,7 @@ reproducing one snapshot. A golden fixture of a 20-village plan would be stale
 the day it was written.
 """
 
+import math
 import random
 
 import pytest
@@ -24,6 +25,7 @@ from travian_api.services.distribution.merchants import (
     route_cost,
 )
 from travian_api.services.distribution.optimizer import (
+    MIN_SEND_FILL,
     VillageState,
     _flows_for_resource,
     _route_for_pair,
@@ -311,6 +313,189 @@ class TestImprovementNeverRegresses:
         for vid, used in with_latency.merchants_committed.items():
             if vid not in minimal_over:
                 assert used <= villages[vid].spare_merchants()
+
+
+class TestSearchTerminationIsHonest:
+    """The pass cap must never quietly hand back a half-finished search.
+
+    A truncated search overstates ``over_budget_excess`` -- the FIRST key of the
+    lexicographic objective -- and that number becomes the UI's over-budget
+    report and the Trade Office upgrade advice derived from it. Villages get told
+    to build things a finished search would not have asked for.
+    """
+
+    def test_a_converged_search_is_a_fixed_point(self):
+        """Re-running the search on its own output must change nothing. This is
+        the detector for truncation: it fails exactly when the cap cut in."""
+        villages = make_account(22, seed=113)
+        plans, _ = make_plans(villages, seed=113)
+
+        once = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+        # Feed the finished plan's own flows back in; a converged local optimum
+        # has no improving swap left, so the second run must be identical.
+        twice = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+
+        assert once.routes == twice.routes
+        assert not [w for w in once.warnings if "improvement passes" in w]
+
+    def test_truncating_the_search_is_reported_not_hidden(self):
+        """With the cap set to 1 the search cannot finish, and the plan must say
+        so rather than presenting its over-budget figures as final."""
+        villages = make_account(22, seed=113)
+        plans, _ = make_plans(villages, seed=113)
+
+        truncated = build_plan(
+            villages, plans, GEOMETRY, MODEL, max_latency_hours=None, max_improve_passes=1
+        )
+        finished = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+
+        assert [w for w in truncated.warnings if "improvement passes" in w], (
+            "a truncated search must warn; silently reporting its inflated "
+            "over-budget figures is how villages get bogus upgrade advice"
+        )
+        # And the truncation genuinely costs something worth warning about.
+        assert truncated.total_merchants >= finished.total_merchants
+
+    def test_a_finished_search_does_not_cry_wolf(self):
+        villages = make_account(12, seed=113)
+        plans, _ = make_plans(villages, seed=113)
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL, max_improve_passes=100_000)
+
+        assert not [w for w in plan.warnings if "improvement passes" in w]
+
+
+class TestLatencyPassRespectsTheFillFloor:
+    def test_removing_the_fill_floor_buys_speed_with_emptier_merchants(self):
+        """Pins what MIN_SEND_FILL is *for*. Without a floor the latency pass
+        runs half-empty merchants purely to go faster, trading away the
+        merchant-fill axis it is not allowed to spend.
+
+        Asserted on the routes the pass actually shortens, not on a median over
+        every route: most routes are never touched, so an account-wide median is
+        dominated by them and barely moves either way.
+        """
+        villages = make_account(22, seed=127)
+        plans, _ = make_plans(villages, seed=127)
+
+        minimal = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+        floored = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=2.0)
+        unfloored = build_plan(
+            villages, plans, GEOMETRY, MODEL, max_latency_hours=2.0, min_send_fill=0.0
+        )
+
+        def worst_shortened_fill(plan):
+            before = {(r.origin, r.destination): r for r in minimal.routes}
+            fills = []
+            for route in plan.routes:
+                was = before.get((route.origin, route.destination))
+                if was is None or route.cycle_hours == was.cycle_hours:
+                    continue
+                capacity = MODEL.capacity(villages[route.origin].trade_office_level)
+                batch = math.ceil(route.hourly_total * route.cycle_hours)
+                fills.append(batch / (route.merchants_per_send * capacity))
+            return min(fills, default=1.0)
+
+        # Without the floor the pass reaches for emptier sends...
+        assert worst_shortened_fill(unfloored) < MIN_SEND_FILL
+        # ...while the floor holds every shortened route at or above it.
+        assert worst_shortened_fill(floored) >= MIN_SEND_FILL - 1e-9
+        # And the emptier sends are not free: they cost strictly more merchants.
+        assert unfloored.total_merchants > floored.total_merchants
+
+    def test_every_route_the_latency_pass_shortened_still_meets_the_floor(self):
+        villages = make_account(22, seed=131)
+        plans, _ = make_plans(villages, seed=131)
+
+        minimal = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+        fast = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=2.0)
+
+        before = {(r.origin, r.destination): r for r in minimal.routes}
+        for route in fast.routes:
+            was = before.get((route.origin, route.destination))
+            if was is None or route.cycle_hours == was.cycle_hours:
+                continue  # untouched by the latency pass
+            capacity = MODEL.capacity(villages[route.origin].trade_office_level)
+            batch = math.ceil(route.hourly_total * route.cycle_hours)
+            fill = batch / (route.merchants_per_send * capacity)
+            assert fill >= MIN_SEND_FILL - 1e-9, (
+                f"route {route.origin}->{route.destination} was shortened to "
+                f"{fill:.0%} full, below the {MIN_SEND_FILL:.0%} floor"
+            )
+
+    def test_routes_already_within_the_target_are_left_alone(self):
+        """Spending merchants on a route that already meets the target is pure
+        waste: the merchants buy nothing the plan asked for.
+
+        Honest note on what this does and does not pin. At the 2h default the
+        guard is unreachable: cycles are whole hours, so a compliant route
+        (cycle + trip <= 2) is necessarily already on the shortest cycle there
+        is. Hence the wider 6h target here, where a route can be both compliant
+        and shortenable. Even there, deleting the guard does not change any plan
+        we can construct -- the fill floor rejects the same candidates first, so
+        the guard is currently a defensive early-exit rather than observable
+        behaviour. This test therefore pins the *invariant* (it would catch an
+        implementation that shortened compliant routes) rather than killing a
+        mutant, and it is documented as such instead of being dressed up as
+        stronger coverage than it is.
+        """
+        target = 6.0
+        villages = make_account(22, seed=113)
+        plans, _ = make_plans(villages, seed=113)
+
+        minimal = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+        fast = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=target)
+
+        before = {(r.origin, r.destination): r for r in minimal.routes}
+        compliant_seen = 0
+        for route in fast.routes:
+            was = before.get((route.origin, route.destination))
+            if was is not None and was.latency_hours <= target:
+                compliant_seen += 1
+                assert route.cycle_hours == was.cycle_hours, (
+                    f"route {route.origin}->{route.destination} already met the "
+                    f"{target:.0f}h target at {was.latency_hours:.1f}h but was "
+                    f"still shortened to a {route.cycle_hours}h cycle"
+                )
+        assert compliant_seen, "fixture produced no compliant routes; test proves nothing"
+
+
+class TestCrossResourceBundling:
+    def test_cargo_riding_an_existing_pair_is_preferred_to_opening_a_new_one(self):
+        """Merchant cost is charged on the MERGED pair cargo, so moving a
+        resource onto a pair another resource already uses can be free, while
+        opening a fresh pair always costs at least one merchant. The search must
+        see that -- costing resources independently would miss it entirely."""
+        # Two senders, two receivers. 1 and 2 sit together; 3 and 4 sit together.
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=20, trade_office_level=20),
+            2: VillageState(2, 1, 0, merchant_count=20, trade_office_level=20),
+            3: VillageState(3, 30, 0, merchant_count=20, trade_office_level=20),
+            4: VillageState(4, 31, 0, merchant_count=20, trade_office_level=20),
+        }
+        plans = {}
+        for resource in (Resource.LUMBER, Resource.CLAY):
+            plans[resource] = resolve_resource(
+                resource,
+                {1: 900.0, 2: 900.0, 3: 0.0, 4: 0.0},
+                {
+                    1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    2: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    3: Allocation(AllocationMode.ABSOLUTE, 900.0),
+                    4: Allocation(AllocationMode.ABSOLUTE, 900.0),
+                },
+            )
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+
+        # Whatever pairing it picks, both resources must ride the same pairs
+        # rather than each sender opening a separate route per resource.
+        assert len(plan.routes) == 2, f"expected 2 bundled routes, got {len(plan.routes)}"
+        for route in plan.routes:
+            assert set(route.cargo_per_hour) == {Resource.LUMBER, Resource.CLAY}, (
+                "each route should carry both resources; costing them separately "
+                "would have opened four single-resource routes"
+            )
 
 
 class TestDeterminism:

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -138,18 +138,27 @@ class TestStructuralInvariants:
             assert not (resources & back), f"{origin}<->{destination} both ways"
 
     @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
-    def test_no_village_relays_the_same_resource(self, village_count):
-        """The no-waterfall rule for W/C/I, and it holds for crop too."""
+    def test_no_village_relays_a_material(self, village_count):
+        """The no-waterfall rule, scoped to W/C/I as profile section 3.5 states.
+
+        Materials must never chain A->B->C. Crop is explicitly exempt there --
+        relay through a sub-hub is permitted -- and the optimizer's relay move
+        uses that exemption to lift merchant load off villages that cannot staff
+        their own haul. Restricting relay to crop is what keeps this rule true by
+        construction for the other three rather than by a runtime check.
+        """
         villages = make_account(village_count, seed=village_count + 11)
         plans, _ = make_plans(villages, seed=village_count + 11)
 
         plan = build_plan(villages, plans, GEOMETRY, MODEL)
 
+        materials = {Resource.LUMBER, Resource.CLAY, Resource.IRON}
         sends: dict[int, set[Resource]] = {}
         receives: dict[int, set[Resource]] = {}
         for route in plan.routes:
-            sends.setdefault(route.origin, set()).update(route.cargo_per_hour)
-            receives.setdefault(route.destination, set()).update(route.cargo_per_hour)
+            carried = set(route.cargo_per_hour) & materials
+            sends.setdefault(route.origin, set()).update(carried)
+            receives.setdefault(route.destination, set()).update(carried)
         for vid in villages:
             assert not (sends.get(vid, set()) & receives.get(vid, set()))
 
@@ -266,36 +275,52 @@ class TestBudgetIsReportedNotHidden:
         assert village.spare_merchants(reserve=2) == 0
 
 
-def _greedy_seed_merchants(villages, plans):
-    """Total merchants the greedy seed alone commits, before local search."""
+def _greedy_seed_objective(villages, plans):
+    """(total merchants, over-budget excess) for the greedy seed alone.
+
+    Both halves are needed because the search optimises them lexicographically:
+    a plan that spends more merchants to relieve excess is an improvement.
+    """
     pair: dict[tuple[int, int], dict[Resource, float]] = {}
     for resource, resource_plan in plans.items():
         flows, _ = _flows_for_resource(resource_plan, villages, GEOMETRY)
         for key, amount in flows.items():
             pair.setdefault(key, {})[resource] = amount
     total = 0
+    committed: dict[int, int] = {}
     for (origin, destination), cargo in pair.items():
         route = _route_for_pair(
             origin, destination, cargo, villages, GEOMETRY, MODEL, DAILY_BEAT_CYCLES
         )
         total += route.merchants_committed
-    return total
+        committed[origin] = committed.get(origin, 0) + route.merchants_committed
+    excess = sum(max(0, used - villages[vid].spare_merchants()) for vid, used in committed.items())
+    return total, excess
 
 
 class TestImprovementNeverRegresses:
     @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
     def test_improved_plan_is_never_worse_than_the_greedy_seed(self, village_count):
-        """The local search only accepts strictly-improving swaps, so the
-        merchant-minimal plan commits no more merchants than the seed it started
-        from. Measured with the latency pass off (``max_latency_hours=None``),
-        which is the stage this property is about — the latency pass then spends
-        idle merchants on speed, deliberately raising the count within budget."""
+        """The search only accepts strictly-improving moves, so the plan is never
+        worse than its seed **on the objective it optimises** -- which is the
+        lexicographic pair (over_budget_excess, total_merchants), not merchants
+        alone. Relay deliberately buys feasibility with extra merchants: it can
+        only be accepted when excess strictly falls, so a plan may commit more
+        merchants than the seed while being unambiguously better.
+
+        Measured with the latency pass off; that stage separately spends idle
+        merchants on speed and is covered by its own tests.
+        """
         villages = make_account(village_count, seed=village_count + 91)
         plans, _ = make_plans(villages, seed=village_count + 91)
 
+        seed_merchants, seed_excess = _greedy_seed_objective(villages, plans)
         plan = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+        got = (sum(o.excess for o in plan.over_budget), plan.total_merchants)
 
-        assert plan.total_merchants <= _greedy_seed_merchants(villages, plans)
+        assert got <= (seed_excess, seed_merchants), (
+            f"plan {got} is worse than the greedy seed {(seed_excess, seed_merchants)}"
+        )
 
     @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
     def test_latency_pass_never_pushes_a_village_over_budget(self, village_count):
@@ -460,6 +485,115 @@ class TestLatencyPassRespectsTheFillFloor:
         assert compliant_seen, "fixture produced no compliant routes; test proves nothing"
 
 
+class TestCropRelay:
+    """Relay exists to buy feasibility, never to save merchants.
+
+    Merchant cost is essentially cargo x round_trip / capacity -- linear in both
+    -- so consolidating n shipments into one long haul costs the same on the long
+    leg and adds the collection legs on top. Measured across every cluster
+    geometry, relay is at best break-even on total merchants. Its real use is to
+    move commitment off a village that cannot staff its own haul.
+    """
+
+    def _stranded_account(self):
+        """A far village that cannot afford its own haul, plus a midpoint hub.
+
+        The midpoint grows and ships crop of its own, so it is part of the crop
+        network and therefore eligible as a hub. That matters: a village with no
+        crop flow at all is excluded on purpose, so that founding a village
+        cannot silently reshuffle routes it has nothing to do with.
+        """
+        return {
+            1: VillageState(1, 0, 0, merchant_count=20, trade_office_level=15),  # capital
+            2: VillageState(2, 60, 0, merchant_count=20, trade_office_level=10),  # midpoint
+            3: VillageState(3, 120, 0, merchant_count=6, trade_office_level=10),  # stranded
+        }, {
+            Resource.CROP: resolve_resource(
+                Resource.CROP,
+                {1: 0.0, 2: 1200.0, 3: 9000.0},
+                {
+                    1: Allocation(AllocationMode.REMAINDER),
+                    2: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    3: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                },
+            )
+        }
+
+    def test_relay_lifts_load_off_a_village_that_cannot_staff_its_haul(self):
+        villages, plans = self._stranded_account()
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+
+        direct = _route_for_pair(
+            3, 1, {Resource.CROP: 9000.0}, villages, GEOMETRY, MODEL, DAILY_BEAT_CYCLES
+        )
+        assert direct.merchants_committed > villages[3].spare_merchants(), (
+            "fixture must be one the stranded village genuinely cannot afford"
+        )
+        # The stranded village now ships only as far as the hub, so its own
+        # commitment drops below what the direct haul demanded.
+        assert plan.merchants_committed[3] < direct.merchants_committed
+        assert any(r.origin == 3 and r.destination == 2 for r in plan.routes), (
+            "expected a short collection leg 3 -> 2"
+        )
+        assert any(r.origin == 2 and r.destination == 1 for r in plan.routes), (
+            "expected the hub to forward on to the capital"
+        )
+
+    def test_the_relay_hub_keeps_none_of_what_it_forwards(self):
+        """Pure pass-through, stated on the net.
+
+        Gross inflow and outflow do NOT match: the hub still ships its own
+        surplus on top of what it forwards. What must hold is that relaying
+        leaves its net crop exactly where its allocation put it -- it keeps none
+        of the relayed cargo and funds none of it from its own granary.
+        """
+        villages, plans = self._stranded_account()
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+
+        inflow = sum(
+            r.cargo_per_hour.get(Resource.CROP, 0.0) for r in plan.routes if r.destination == 2
+        )
+        outflow = sum(
+            r.cargo_per_hour.get(Resource.CROP, 0.0) for r in plan.routes if r.origin == 2
+        )
+        own = next(v for v in plans[Resource.CROP].villages if v.village_id == 2)
+
+        assert inflow > 0, "the hub is not relaying anything; test proves nothing"
+        assert inflow - outflow == pytest.approx(own.ship_per_hour), (
+            f"hub nets {inflow - outflow:+.0f}/h against an allocation of "
+            f"{own.ship_per_hour:+.0f}/h -- it kept or funded some of the relay"
+        )
+
+    @pytest.mark.parametrize("village_count", [5, 12, 22, 40])
+    def test_relay_never_makes_a_plan_worse(self, village_count):
+        """Relay is adopted only when it strictly lowers the objective.
+
+        Note it is NOT purely a feasibility move, which is what the first draft
+        of this test wrongly assumed: relay also wins on integer rounding, since
+        ``ceil(a/c) + ceil(b/c) >= ceil((a+b)/c)`` means consolidating two part
+        loads onto one leg can shed a merchant even when nothing is over budget.
+        Both are genuine improvements, so the property worth pinning is not *when*
+        relay fires but that firing never costs anything: measured against the
+        same plan built with the move disabled.
+        """
+        villages = make_account(village_count, seed=village_count + 255)
+        plans, _ = make_plans(villages, seed=village_count + 255)
+
+        with_relay = build_plan(villages, plans, GEOMETRY, MODEL, max_latency_hours=None)
+        without = build_plan(
+            villages, plans, GEOMETRY, MODEL, max_latency_hours=None, max_relay_hops=0
+        )
+
+        def objective(plan):
+            return (sum(o.excess for o in plan.over_budget), plan.total_merchants)
+
+        assert objective(with_relay) <= objective(without), (
+            f"relay made the plan worse: {objective(with_relay)} vs {objective(without)}"
+        )
+
+
 class TestCrossResourceBundling:
     def test_cargo_riding_an_existing_pair_is_preferred_to_opening_a_new_one(self):
         """Merchant cost is charged on the MERGED pair cargo, so moving a
@@ -524,25 +658,40 @@ class TestDeterminism:
 
 class TestFlowConservation:
     @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
-    def test_received_plus_shortfall_equals_demand(self, village_count):
-        """Every receiver either gets what it asked for or the gap is recorded."""
+    def test_every_village_nets_exactly_what_its_allocation_asked_for(self, village_count):
+        """Inflow minus outflow equals the allocation, for EVERY village.
+
+        This supersedes the older pair of one-directional checks ("a receiver
+        gets what it asked", "a sender never exceeds its surplus"), which both
+        assumed a village is only ever one or the other. A crop relay hub is
+        both: it receives cargo it does not keep and forwards cargo it did not
+        grow, so its gross flows exceed its own allocation in both directions
+        while the *net* is untouched. Netting is the property that actually
+        matters -- nothing may be created or destroyed at any village -- and it
+        holds whether or not relay fires, so it is the stronger statement.
+        """
         villages = make_account(village_count, seed=village_count + 71)
         plans, _ = make_plans(villages, seed=village_count + 71)
 
         plan = build_plan(villages, plans, GEOMETRY, MODEL)
 
         for resource, resource_plan in plans.items():
-            received: dict[int, float] = {}
+            inflow: dict[int, float] = {}
+            outflow: dict[int, float] = {}
             for route in plan.routes:
-                if resource in route.cargo_per_hour:
-                    received[route.destination] = (
-                        received.get(route.destination, 0.0) + route.cargo_per_hour[resource]
-                    )
+                amount = route.cargo_per_hour.get(resource)
+                if amount:
+                    outflow[route.origin] = outflow.get(route.origin, 0.0) + amount
+                    inflow[route.destination] = inflow.get(route.destination, 0.0) + amount
             missing = {s.village_id: s.per_hour for s in plan.shortfalls if s.resource is resource}
-            for village in resource_plan.receivers:
-                got = received.get(village.village_id, 0.0)
-                gap = missing.get(village.village_id, 0.0)
-                assert got + gap == pytest.approx(village.ship_per_hour, rel=1e-6, abs=1e-6)
+            for village in resource_plan.villages:
+                vid = village.village_id
+                net = inflow.get(vid, 0.0) - outflow.get(vid, 0.0)
+                gap = missing.get(vid, 0.0)
+                assert net + gap == pytest.approx(village.ship_per_hour, rel=1e-6, abs=1e-6), (
+                    f"village {vid} nets {net:+.1f}/h of {resource.value} against an "
+                    f"allocation of {village.ship_per_hour:+.1f}/h (shortfall {gap:.1f})"
+                )
 
     def test_unmet_demand_is_reported_as_a_shortfall(self):
         """Reaches a branch the generated accounts cannot.
@@ -578,13 +727,17 @@ class TestFlowConservation:
         assert plan.routes[0].cargo_per_hour[Resource.IRON] == pytest.approx(1000.0)
 
     @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
-    def test_no_village_sends_more_than_its_surplus(self, village_count):
+    def test_no_village_sends_more_material_than_its_surplus(self, village_count):
+        """For W/C/I gross outflow is still capped by the village's own surplus:
+        those never relay, so there is no forwarded cargo to account for. Crop is
+        covered by the net-flow invariant above instead."""
         villages = make_account(village_count, seed=village_count + 81)
         plans, _ = make_plans(villages, seed=village_count + 81)
 
         plan = build_plan(villages, plans, GEOMETRY, MODEL)
 
-        for resource, resource_plan in plans.items():
+        for resource in (Resource.LUMBER, Resource.CLAY, Resource.IRON):
+            resource_plan = plans[resource]
             surplus = {v.village_id: -v.ship_per_hour for v in resource_plan.senders}
             sent: dict[int, float] = {}
             for route in plan.routes:

--- a/tests/test_distribution_optimizer.py
+++ b/tests/test_distribution_optimizer.py
@@ -189,6 +189,59 @@ class TestBudgetIsReportedNotHidden:
         for over in plan.over_budget:
             assert over.excess > 0
 
+    def test_an_over_budget_village_gets_a_trade_office_recommendation(self):
+        """Escalation step 4: say what would fix it, not just that it is broken.
+
+        A TO 0 sender hauling a lot needs more capacity per merchant; the plan
+        must name how many levels rather than only declaring infeasibility.
+        """
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=10, trade_office_level=0),
+            2: VillageState(2, 30, 0, merchant_count=20, trade_office_level=0),
+        }
+        plans = {
+            Resource.IRON: resolve_resource(
+                Resource.IRON,
+                {1: 9000.0, 2: 0.0},
+                {
+                    1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    2: Allocation(AllocationMode.REMAINDER),
+                },
+            )
+        }
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        assert plan.over_budget
+        over = plan.over_budget[0]
+        assert over.village_id == 1
+        assert over.excess > 0
+        assert over.trade_office_levels_needed is not None
+        assert over.trade_office_levels_needed >= 1
+
+    def test_an_impossible_village_reports_no_upgrade_that_would_help(self):
+        """A village with no spare merchants cannot be fixed by any upgrade."""
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=2, trade_office_level=0),
+            2: VillageState(2, 60, 0, merchant_count=20, trade_office_level=0),
+        }
+        plans = {
+            Resource.IRON: resolve_resource(
+                Resource.IRON,
+                {1: 9000.0, 2: 0.0},
+                {
+                    1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                    2: Allocation(AllocationMode.REMAINDER),
+                },
+            )
+        }
+
+        plan = build_plan(villages, plans, GEOMETRY, MODEL)
+
+        over = plan.over_budget[0]
+        assert over.available == 0
+        assert over.trade_office_levels_needed is None
+
     def test_reserve_is_withheld_from_the_budget(self):
         village = VillageState(village_id=1, x=0, y=0, merchant_count=20)
 

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -68,6 +68,64 @@ class TestCollectThenShip:
             f"a whole {cycle_minutes} min cycle -- it is shipping stale stock"
         )
 
+    def test_a_relay_chain_is_ordered_along_the_flow(self):
+        """Every leg of 10 -> 20 -> 30 -> 5 is hub-outbound, so sorting hubs last
+        decides nothing. Ordered by destination id instead of by flow direction,
+        30 -> 5 was placed first and shipped 20.7h-old stock."""
+        beat = build_beat(
+            (self._leg(10, 20, 100.0), self._leg(20, 30, 100.0), self._leg(30, 5, 100.0)),
+            min_arrival_gap_minutes=3,
+        )
+
+        placed = {s.route.origin: s for s in beat.routes}
+        for hub, feeder in ((20, 10), (30, 20)):
+            arrivals = placed[feeder].arrival_minutes
+            worst = max(
+                min((d - a) % MINUTES_PER_DAY for a in arrivals)
+                for d in placed[hub].dispatch_minutes
+            )
+            assert worst < placed[hub].route.cycle_hours * 60, (
+                f"village {hub} waits {worst} min after collecting before forwarding"
+            )
+
+    def test_collect_then_ship_never_costs_the_arrival_gap(self):
+        """Staleness must not outrank the spacing target.
+
+        Ranking raw staleness above the gap made the target unenforceable at
+        relay hubs: staleness differs at nearly every candidate minute, so it
+        decided every comparison and arrivals were allowed to collide outright.
+        A few minutes of extra staleness is always the cheaper trade.
+        """
+        beat = build_beat(
+            (
+                self._leg(1, 2, 60.0),  # feeds the hub
+                self._leg(2, 3, 60.0),  # hub forwards
+                Route(  # an unrelated inbound at the same destination
+                    origin=4,
+                    destination=3,
+                    cargo_per_hour={Resource.LUMBER: 1000.0},
+                    cycle_hours=24,
+                    merchants_per_send=1,
+                    sets_in_flight=1,
+                    one_way_minutes=120.0,
+                ),
+            ),
+            min_arrival_gap_minutes=3,
+        )
+
+        at_three = sorted(
+            minute for s in beat.routes if s.route.destination == 3 for minute in s.arrival_minutes
+        )
+        gaps = [
+            min(abs(a - b), MINUTES_PER_DAY - abs(a - b))
+            for i, a in enumerate(at_three)
+            for b in at_three[i + 1 :]
+        ]
+        assert min(gaps, default=MINUTES_PER_DAY) >= 3, (
+            f"arrivals at village 3 collided ({at_three}); staleness outranked the gap"
+        )
+        assert not [w for w in beat.warnings if "lands within" in w]
+
     def test_ordinary_routes_are_scheduled_exactly_as_before(self):
         """Nothing relays here, so the collect-then-ship term must be inert: two
         legs that merely share a destination are not a relay."""

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -121,6 +121,30 @@ class TestSumPreservingRounding:
         with pytest.raises(ValueError):
             round_preserving_total({"a": -1.0})
 
+    def test_sheet_cargo_matches_the_merchant_budget_ceiling(self):
+        """route_cost budgets merchants for ceil(batch); rounding the sheet to
+        round(sum) under-delivers every cycle when the fraction is below .5,
+        even though merchants were reserved for the higher batch."""
+        values = {"lumber": 1.1}
+
+        rounded = round_preserving_total(values, target_total=2)
+
+        assert sum(rounded.values()) == 2
+
+    @pytest.mark.parametrize("seed", range(25))
+    def test_ceiling_target_keeps_each_entry_within_one(self, seed):
+        import math
+
+        rng = random.Random(seed + 900)
+        values = {f"r{i}": rng.uniform(0, 5000) for i in range(rng.randint(1, 8))}
+        target = math.ceil(sum(values.values()))
+
+        rounded = round_preserving_total(values, target_total=target)
+
+        assert sum(rounded.values()) == target
+        for key, value in values.items():
+            assert abs(rounded[key] - value) < 1.0
+
     def test_rounding_is_deterministic(self):
         values = {"a": 1.5, "b": 1.5, "c": 1.5}
 

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -39,6 +39,50 @@ class TestBeatSpacing:
             one_way_minutes=30.0,
         )
 
+    def test_sheet_reports_per_send_merchants_not_total_commitment(self):
+        """A multi-set route commits merchants_per_send x sets, but the sheet
+        row describes ONE Gold Club route definition; reporting the total
+        overstates the route and conflicts with the budget section."""
+        villages = {
+            1: VillageState(village_id=1, x=0, y=0, merchant_count=20, trade_office_level=0),
+            2: VillageState(village_id=2, x=60, y=0, merchant_count=20, trade_office_level=0),
+        }
+        productions = {Resource.LUMBER: {1: 1000.0, 2: 0.0}}
+        allocations = {
+            Resource.LUMBER: {
+                1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                2: Allocation(AllocationMode.REMAINDER),
+            }
+        }
+
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        assert len(plan.rows) == 1
+        route = plan.routing.routes[0]
+        assert route.sets_in_flight > 1, "60 fields must need several sets in flight"
+        assert plan.rows[0].merchants == route.merchants_per_send
+
+    def test_a_route_outpacing_the_gap_warns_about_its_own_arrivals(self):
+        """A 1h cycle lands hourly; no dispatch offset can space its own
+        arrivals to a 90 min target, and staying silent hides the violation
+        exactly when one busy inbound route causes it alone."""
+        beat = build_beat(
+            (
+                Route(
+                    origin=1,
+                    destination=99,
+                    cargo_per_hour={Resource.LUMBER: 100.0},
+                    cycle_hours=1,
+                    merchants_per_send=1,
+                    sets_in_flight=1,
+                    one_way_minutes=30.0,
+                ),
+            ),
+            min_arrival_gap_minutes=90,
+        )
+
+        assert any("its own" in w for w in beat.warnings)
+
     def test_the_sweep_keeps_the_widest_spacing_not_the_first_legal_one(self):
         """Two daily routes into one village have 720 minutes of room; stopping
         at the first offset that merely clears the minimum gap crowds arrivals

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -27,6 +27,90 @@ CONFIG = PlannerConfig(
 )
 
 
+class TestCollectThenShip:
+    """A relay hub must forward cargo it has already collected.
+
+    This was moot until crop relay existed: netting left every village a sender
+    or a receiver of a resource but never both, so nothing relayed and no
+    ordering constraint could arise. A hub whose outbound fires just before its
+    inbound lands ships from its own granary and waits nearly a whole cycle for
+    the replacement, which is exactly the buffer the relay was meant to avoid
+    needing.
+    """
+
+    def _leg(self, origin: int, destination: int, one_way: float, cycle: int = 4) -> Route:
+        return Route(
+            origin=origin,
+            destination=destination,
+            cargo_per_hour={Resource.CROP: 3000.0},
+            cycle_hours=cycle,
+            merchants_per_send=1,
+            sets_in_flight=1,
+            one_way_minutes=one_way,
+        )
+
+    def test_a_relay_hub_ships_soon_after_it_collects(self):
+        # 1 -> 2 -> 3: village 2 forwards what village 1 sends it.
+        inbound = self._leg(1, 2, one_way=30.0)
+        outbound = self._leg(2, 3, one_way=45.0)
+
+        beat = build_beat((inbound, outbound), min_arrival_gap_minutes=3)
+
+        placed = {s.route.origin: s for s in beat.routes}
+        arrivals = placed[1].arrival_minutes  # when cargo lands at the hub
+        dispatches = placed[2].dispatch_minutes  # when the hub forwards it
+
+        # Worst wait between collecting and shipping, measured round the clock.
+        worst = max(min((d - a) % MINUTES_PER_DAY for a in arrivals) for d in dispatches)
+        cycle_minutes = outbound.cycle_hours * 60
+        assert worst < cycle_minutes, (
+            f"hub waits {worst} min after collecting before it forwards, which is "
+            f"a whole {cycle_minutes} min cycle -- it is shipping stale stock"
+        )
+
+    def test_ordinary_routes_are_scheduled_exactly_as_before(self):
+        """Nothing relays here, so the collect-then-ship term must be inert: two
+        legs that merely share a destination are not a relay."""
+        a = self._leg(1, 3, one_way=30.0)
+        b = self._leg(2, 3, one_way=45.0)
+
+        beat = build_beat((a, b), min_arrival_gap_minutes=3)
+
+        assert beat.warnings == ()
+        # Both still get the widest-spacing treatment across the shared receiver.
+        first, second = (s.arrival_minutes[0] for s in beat.routes)
+        raw = abs(first - second)
+        assert min(raw, MINUTES_PER_DAY - raw) >= 3
+
+
+class TestReservedWindow:
+    def _route(self) -> Route:
+        return Route(
+            origin=1,
+            destination=2,
+            cargo_per_hour={Resource.LUMBER: 1000.0},
+            cycle_hours=24,
+            merchants_per_send=1,
+            sets_in_flight=1,
+            one_way_minutes=30.0,
+        )
+
+    def test_arrivals_avoid_the_reserved_npc_burst(self):
+        """schedule.py has honoured reserved_window all along; until now the
+        route never passed one, so the NPC slot could not actually be kept."""
+        window = (120, 300)  # 02:00-05:00
+
+        beat = build_beat((self._route(),), reserved_window=window)
+
+        for scheduled in beat.routes:
+            for minute in scheduled.arrival_minutes:
+                assert not (window[0] <= minute < window[1]), (
+                    f"arrival at {minute // 60:02d}:{minute % 60:02d} lands inside "
+                    f"the reserved window {window}"
+                )
+        assert beat.warnings == ()
+
+
 class TestBeatSpacing:
     def _route(self, origin: int) -> Route:
         return Route(

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -1,0 +1,272 @@
+"""Rounding, the daily beat, and end-to-end orchestration.
+
+Same approach as the optimizer tests: properties that must hold for any account,
+checked across a range of sizes, because the real account grows and every figure
+changes between runs.
+"""
+
+import random
+
+import pytest
+
+from travian_api.services.distribution.allocation import (
+    Allocation,
+    AllocationMode,
+    Resource,
+)
+from travian_api.services.distribution.geometry import MapGeometry
+from travian_api.services.distribution.merchants import EUROPE2_TEUTON
+from travian_api.services.distribution.optimizer import VillageState
+from travian_api.services.distribution.planner import PlannerConfig, craft_plan
+from travian_api.services.distribution.rounding import round_preserving_total
+from travian_api.services.distribution.schedule import MINUTES_PER_DAY, build_beat
+
+CONFIG = PlannerConfig(
+    geometry=MapGeometry(span=401, speed_fields_per_hour=12.0),
+    merchant_model=EUROPE2_TEUTON,
+)
+ACCOUNT_SIZES = [1, 2, 3, 6, 12, 22, 23, 35]
+
+
+def make_inputs(village_count: int, seed: int):
+    """An arbitrary account: villages, production, and allocations."""
+    rng = random.Random(seed)
+    villages = {
+        vid: VillageState(
+            village_id=vid,
+            x=rng.randint(-60, 60),
+            y=rng.randint(-60, 60),
+            merchant_count=rng.choice([2, 13, 19, 20]),
+            trade_office_level=rng.randint(0, 20),
+        )
+        for vid in range(1, village_count + 1)
+    }
+    ids = sorted(villages)
+    productions, allocations = {}, {}
+    for resource in Resource:
+        productions[resource] = {vid: float(rng.randint(300, 9000)) for vid in ids}
+        remainder = ids[rng.randrange(len(ids))]
+        per_village = {remainder: Allocation(AllocationMode.REMAINDER)}
+        for vid in ids:
+            if vid != remainder and rng.random() < 0.5:
+                per_village[vid] = Allocation(AllocationMode.ABSOLUTE, float(rng.randint(0, 9000)))
+        allocations[resource] = per_village
+    return villages, productions, allocations
+
+
+class TestSumPreservingRounding:
+    def test_total_survives_rounding(self):
+        """Profile section 12: rounding must not create or destroy resources."""
+        values = {Resource.LUMBER: 10.4, Resource.CLAY: 10.4, Resource.IRON: 10.4}
+
+        rounded = round_preserving_total(values)
+
+        assert sum(rounded.values()) == round(sum(values.values()))  # 31, not 30
+
+    @pytest.mark.parametrize("seed", range(25))
+    def test_total_survives_for_arbitrary_values(self, seed):
+        rng = random.Random(seed)
+        values = {f"r{i}": rng.uniform(0, 5000) for i in range(rng.randint(1, 8))}
+
+        rounded = round_preserving_total(values)
+
+        assert sum(rounded.values()) == round(sum(values.values()))
+
+    @pytest.mark.parametrize("seed", range(25))
+    def test_each_entry_stays_within_one_of_its_exact_value(self, seed):
+        rng = random.Random(seed + 500)
+        values = {f"r{i}": rng.uniform(0, 5000) for i in range(rng.randint(1, 8))}
+
+        rounded = round_preserving_total(values)
+
+        for key, value in values.items():
+            assert abs(rounded[key] - value) < 1.0
+
+    def test_exact_integers_are_untouched(self):
+        values = {"a": 100.0, "b": 250.0}
+
+        assert round_preserving_total(values) == {"a": 100, "b": 250}
+
+    def test_empty_input_is_empty_output(self):
+        assert round_preserving_total({}) == {}
+
+    def test_negative_cargo_is_rejected(self):
+        with pytest.raises(ValueError):
+            round_preserving_total({"a": -1.0})
+
+    def test_rounding_is_deterministic(self):
+        values = {"a": 1.5, "b": 1.5, "c": 1.5}
+
+        assert round_preserving_total(values) == round_preserving_total(values)
+
+
+class TestBeat:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_every_route_is_scheduled(self, village_count):
+        villages, productions, allocations = make_inputs(village_count, seed=village_count)
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        assert len(plan.beat.routes) == len(plan.routing.routes)
+        assert len(plan.rows) == len(plan.routing.routes)
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_dispatch_falls_inside_the_first_cycle(self, village_count):
+        """The slot repeats every cycle, so the offset must be within one."""
+        villages, productions, allocations = make_inputs(village_count, seed=village_count + 5)
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        for scheduled in plan.beat.routes:
+            assert 0 <= scheduled.dispatch_minute < scheduled.route.cycle_hours * 60
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_firing_count_matches_the_cycle(self, village_count):
+        """A 3h cycle fires 8 times a day -- which a 60-minute table could not
+        express at all (review R5)."""
+        villages, productions, allocations = make_inputs(village_count, seed=village_count + 9)
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        for scheduled in plan.beat.routes:
+            assert len(scheduled.dispatch_minutes) == 24 // scheduled.route.cycle_hours
+            assert len(scheduled.arrival_minutes) == len(scheduled.dispatch_minutes)
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_all_minutes_are_within_the_day(self, village_count):
+        villages, productions, allocations = make_inputs(village_count, seed=village_count + 13)
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        for scheduled in plan.beat.routes:
+            for minute in scheduled.dispatch_minutes + scheduled.arrival_minutes:
+                assert 0 <= minute < MINUTES_PER_DAY
+
+    def test_arrivals_at_one_village_are_spaced_when_there_is_room(self):
+        """Two inbound routes on a quiet village must not land together."""
+        villages, productions, allocations = make_inputs(6, seed=77)
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        for vid in villages:
+            arrivals = [minute for minute, _ in plan.beat.arrivals_at(vid)]
+            if len(arrivals) < 2:
+                continue
+            # Only assert where the day is not saturated by this village's own
+            # inbound firings; a busy hub legitimately cannot space everything.
+            if len(arrivals) <= 8:
+                assert len(set(arrivals)) == len(arrivals), vid
+
+    def test_a_reserved_window_is_avoided_when_possible(self):
+        """The manual NPC burst needs a clear slot."""
+        villages, productions, allocations = make_inputs(4, seed=91)
+        config = PlannerConfig(
+            geometry=CONFIG.geometry,
+            merchant_model=CONFIG.merchant_model,
+            reserved_window=(600, 660),
+        )
+
+        plan = craft_plan(villages, productions, allocations, config)
+        landed_in_window = [
+            minute
+            for scheduled in plan.beat.routes
+            for minute in scheduled.arrival_minutes
+            if 600 <= minute < 660
+        ]
+
+        # Any unavoidable collision must be declared, not silent.
+        if landed_in_window:
+            assert any("reserved window" in w for w in plan.beat.warnings)
+
+    def test_scheduling_is_deterministic(self):
+        villages, productions, allocations = make_inputs(12, seed=101)
+
+        first = craft_plan(villages, productions, allocations, CONFIG)
+        second = craft_plan(villages, productions, allocations, CONFIG)
+
+        assert first.rows == second.rows
+
+    def test_route_order_does_not_change_the_beat(self):
+        villages, productions, allocations = make_inputs(8, seed=113)
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        reversed_beat = build_beat(tuple(reversed(plan.routing.routes)))
+
+        assert {
+            (s.route.origin, s.route.destination, s.dispatch_minute) for s in plan.beat.routes
+        } == {
+            (s.route.origin, s.route.destination, s.dispatch_minute) for s in reversed_beat.routes
+        }
+
+    def test_invalid_settings_are_rejected(self):
+        with pytest.raises(ValueError):
+            build_beat((), min_arrival_gap_minutes=-1)
+        with pytest.raises(ValueError):
+            build_beat((), step_minutes=0)
+
+
+class TestEndToEnd:
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_produces_a_sheet_for_any_account_size(self, village_count):
+        villages, productions, allocations = make_inputs(village_count, seed=village_count + 17)
+
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        assert set(plan.merchants_committed) == set(villages)
+        assert set(plan.spare_merchants) == set(villages)
+        for row in plan.rows:
+            assert row.total_cargo == sum(row.cargo.values())
+            assert row.merchants > 0
+
+    @pytest.mark.parametrize("village_count", ACCOUNT_SIZES)
+    def test_cargo_totals_survive_the_round_trip_to_integers(self, village_count):
+        villages, productions, allocations = make_inputs(village_count, seed=village_count + 23)
+
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        for scheduled, row in zip(plan.beat.routes, plan.rows, strict=True):
+            exact = sum(scheduled.route.batch_per_resource.values())
+            assert row.total_cargo == round(exact)
+
+    def test_an_empty_account_yields_an_empty_sheet(self):
+        plan = craft_plan({}, {}, {}, CONFIG)
+
+        assert plan.rows == ()
+        assert plan.is_feasible
+        assert plan.total_merchants == 0
+
+    def test_a_new_village_needs_no_reconfiguration(self):
+        """Village 23 arrives; the plan absorbs it without re-entry."""
+        villages, productions, allocations = make_inputs(22, seed=31)
+        before = craft_plan(villages, productions, allocations, CONFIG)
+
+        villages[23] = VillageState(23, 15, 15, merchant_count=20)
+        after = craft_plan(villages, productions, allocations, CONFIG)
+
+        assert after.rows == before.rows
+        assert after.merchants_committed[23] == 0
+        assert after.free_merchants(23) == 18
+
+    def test_free_merchants_accounts_for_the_reserve(self):
+        villages = {
+            1: VillageState(1, 0, 0, merchant_count=20, trade_office_level=13),
+            2: VillageState(2, 12, 0, merchant_count=20, trade_office_level=13),
+        }
+        productions = {Resource.IRON: {1: 1000.0, 2: 0.0}}
+        allocations = {
+            Resource.IRON: {
+                1: Allocation(AllocationMode.ABSOLUTE, 0.0),
+                2: Allocation(AllocationMode.REMAINDER),
+            }
+        }
+
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        assert plan.spare_merchants[1] == 18
+        assert plan.free_merchants(1) == 18 - plan.merchants_committed[1]
+        assert plan.merchants_committed[2] == 0
+
+    def test_allocation_warnings_reach_the_plan(self):
+        """A warning raised three layers down must not be swallowed."""
+        villages = {1: VillageState(1, 0, 0, merchant_count=20)}
+        productions = {Resource.LUMBER: {1: 1000.0}}
+        allocations = {Resource.LUMBER: {1: Allocation(AllocationMode.ABSOLUTE, 400.0)}}
+
+        plan = craft_plan(villages, productions, allocations, CONFIG)
+
+        assert any("unallocated" in w for w in plan.warnings)

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -17,7 +17,7 @@ from travian_api.services.distribution.allocation import (
 from travian_api.services.distribution.geometry import MapGeometry
 from travian_api.services.distribution.merchants import EUROPE2_TEUTON
 from travian_api.services.distribution.optimizer import VillageState
-from travian_api.services.distribution.planner import PlannerConfig, craft_plan
+from travian_api.services.distribution.planner import PlannerConfig, SheetRow, craft_plan
 from travian_api.services.distribution.rounding import round_preserving_total
 from travian_api.services.distribution.schedule import MINUTES_PER_DAY, build_beat
 
@@ -260,6 +260,22 @@ class TestEndToEnd:
         assert plan.spare_merchants[1] == 18
         assert plan.free_merchants(1) == 18 - plan.merchants_committed[1]
         assert plan.merchants_committed[2] == 0
+
+    def test_sheet_rows_render_clock_times_for_the_operator(self):
+        """The sheet is copied into the game by hand, so minutes need faces."""
+        row = SheetRow(
+            origin=1,
+            destination=2,
+            cargo={Resource.IRON: 100},
+            cycle_hours=3,
+            dispatch_minute=125,
+            arrival_minute=605,
+            merchants=4,
+        )
+
+        assert row.dispatch_clock() == "02:05"
+        assert row.arrival_clock() == "10:05"
+        assert row.total_cargo == 100
 
     def test_allocation_warnings_reach_the_plan(self):
         """A warning raised three layers down must not be swallowed."""

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -16,7 +16,7 @@ from travian_api.services.distribution.allocation import (
 )
 from travian_api.services.distribution.geometry import MapGeometry
 from travian_api.services.distribution.merchants import EUROPE2_TEUTON
-from travian_api.services.distribution.optimizer import VillageState
+from travian_api.services.distribution.optimizer import Route, VillageState
 from travian_api.services.distribution.planner import PlannerConfig, SheetRow, craft_plan
 from travian_api.services.distribution.rounding import round_preserving_total
 from travian_api.services.distribution.schedule import MINUTES_PER_DAY, build_beat
@@ -25,6 +25,33 @@ CONFIG = PlannerConfig(
     geometry=MapGeometry(span=401, speed_fields_per_hour=12.0),
     merchant_model=EUROPE2_TEUTON,
 )
+
+
+class TestBeatSpacing:
+    def _route(self, origin: int) -> Route:
+        return Route(
+            origin=origin,
+            destination=99,
+            cargo_per_hour={Resource.LUMBER: 1000.0},
+            cycle_hours=24,
+            merchants_per_send=1,
+            sets_in_flight=1,
+            one_way_minutes=30.0,
+        )
+
+    def test_the_sweep_keeps_the_widest_spacing_not_the_first_legal_one(self):
+        """Two daily routes into one village have 720 minutes of room; stopping
+        at the first offset that merely clears the minimum gap crowds arrivals
+        for no reason and contradicts the stated widest-spacing preference."""
+        beat = build_beat((self._route(1), self._route(2)), min_arrival_gap_minutes=3)
+
+        first, second = (s.arrival_minutes[0] for s in beat.routes)
+        raw = abs(first - second)
+        gap = min(raw, MINUTES_PER_DAY - raw)
+        assert gap >= 360
+        assert beat.warnings == ()
+
+
 ACCOUNT_SIZES = [1, 2, 3, 6, 12, 22, 23, 35]
 
 

--- a/tests/test_distribution_planner.py
+++ b/tests/test_distribution_planner.py
@@ -5,6 +5,7 @@ checked across a range of sizes, because the real account grows and every figure
 changes between runs.
 """
 
+import math
 import random
 
 import pytest
@@ -458,7 +459,12 @@ class TestEndToEnd:
 
         for scheduled, row in zip(plan.beat.routes, plan.rows, strict=True):
             exact = sum(scheduled.route.batch_per_resource.values())
-            assert row.total_cargo == round(exact)
+            # Ceil, not round: the sheet must ship the same ceil(batch) the
+            # merchant budget was sized for. round() only agreed while every
+            # flow was integer-valued; breakpoint transfers made genuinely
+            # fractional batches possible, where the two differ and ceil is
+            # the designed contract. The tolerance mirrors route_cost's.
+            assert row.total_cargo == math.ceil(exact - 1e-6)
 
     def test_an_empty_account_yields_an_empty_sheet(self):
         plan = craft_plan({}, {}, {}, CONFIG)

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -123,6 +123,16 @@ def _session(http: _SnapshotHttp) -> SimpleNamespace:
 
 
 class TestSnapshotPricing:
+    def test_snapshot_never_spends_an_implicit_login(self):
+        """The endpoint prices itself at 3-4 requests; auto-reconnect would
+        spend unreported login traffic before the handler even starts. It must
+        depend on the live session only and 403 otherwise."""
+        from travian_api.web.sessions import get_travian_session as reconnecting
+
+        for parameter in inspect.signature(get_snapshot).parameters.values():
+            dependency = getattr(parameter.default, "dependency", None)
+            assert dependency is not reconnecting
+
     def test_reports_three_requests_when_nothing_is_filling(self):
         """The capacity page is only fetched for filling villages, and the
         reported price must match what was actually spent."""

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -280,6 +280,25 @@ class TestForeignTribute:
 
         assert not [row for row in res.rows if row.origin < 0]
 
+    def test_sheet_rows_carry_the_targets_name_not_a_negative_id(self):
+        """Reported from the UI: foreign villages rendered as '-1' in the plan.
+
+        The frontend resolved names from its own snapshot, which cannot know
+        foreign tributes -- their negative ids fell through the lookup and the
+        raw id was shown. Names are now resolved server-side on every row, so
+        no client needs to know how sink ids are generated.
+        """
+        res = asyncio.run(post_plan(self._body()))
+
+        tribute_rows = [row for row in res.rows if row.destination < 0]
+        assert tribute_rows, "the tribute was never shipped; fixture drifted"
+        for row in tribute_rows:
+            assert row.destination_name == "Ally-Keep"
+            assert row.origin_name, "real villages must carry their name too"
+
+        for shortfall in res.shortfalls:
+            assert shortfall.village_name, "shortfalls must be named, never numbered"
+
     def test_the_cold_start_is_reported(self):
         """The first delivery only lands after a full one-way trip; a tribute
         that silently starts late looks like a broken promise."""

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -272,6 +272,43 @@ class TestStorageSafety:
 
         assert not [w for w in result.warnings if "fills its store" in w or "hits the cap" in w]
 
+    def test_route_flows_are_not_counted_twice(self):
+        """The two checks take different inputs and must not be crossed.
+
+        store_status works on the post-plan NET rate, with routes folded into a
+        continuous average. simulate_day applies the routes itself, as discrete
+        dispatches and arrivals. Handing the net rate to the simulation banks
+        every delivery twice -- a receiver ends the day holding double what
+        arrived -- and invents overflows that do not exist.
+        """
+        body = PlanRequest(
+            snapshot=[
+                # A sender with a large surplus and a receiver sized so that one
+                # day of genuine delivery fits, but a doubled one does not.
+                self._village(
+                    1, x=0, y=0, lumber_per_hour=8000, lumber_stock=0, warehouse_capacity=2_000_000
+                ),
+                self._village(
+                    2,
+                    x=3,
+                    y=0,
+                    lumber_per_hour=0,
+                    lumber_stock=0,
+                    warehouse_capacity=250_000,
+                    crop_per_hour=1000,
+                ),
+            ],
+            allocations={
+                "lumber": {1: {"mode": "absolute", "value": 0}, 2: {"mode": "remainder"}},
+            },
+        )
+
+        result = asyncio.run(post_plan(body, SimpleNamespace(id=1)))
+
+        # 8,000/h = 192,000 a day, inside the 250,000 cap. Doubled it would not be.
+        bogus = [w for w in result.warnings if "hits the cap" in w and "village 2" in w]
+        assert not bogus, f"phantom overflow from double-counted deliveries: {bogus}"
+
     def test_storage_checks_cost_no_game_requests(self):
         """post_plan takes no Travian session at all, so the whole check runs on
         state the caller already has."""

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -1,0 +1,240 @@
+"""Regression tests for the distribution planner HTTP surface.
+
+Each test pins one finding from the feature/resource-distribution-planner code
+review: request pricing, silent drops, error status codes, and the plan
+endpoint's independence from a live Travian session.
+"""
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from travian_api.services.building_service import BuildingService
+from travian_api.web.routes.distribution import (
+    PlanRequest,
+    get_snapshot,
+    post_plan,
+)
+from travian_api.web.sessions import get_travian_session
+
+PRODUCTION_HTML = """
+<table id="production">
+    <thead><tr><td>Village</td><td><i class="r1"></i></td><td><i class="r2"></i></td>
+        <td><i class="r3"></i></td><td><i class="r4"></i></td></tr></thead>
+    <tbody>
+        <tr class="hover">
+            <td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+            <td class="lum">‭2,000‬</td><td class="clay">‭1,000‬</td>
+            <td class="iron">‭1,000‬</td><td class="crop">‭2,848‬</td>
+        </tr>
+        <tr class="hl">
+            <td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+            <td class="lum">‭500‬</td><td class="clay">‭500‬</td>
+            <td class="iron">‭500‬</td><td class="crop">‭1,000‬</td>
+        </tr>
+    </tbody>
+</table>
+"""
+
+RESOURCES_HTML = """
+<table id="ressources"><tbody>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+        <td class="lum">‭1‬</td><td class="clay">‭1‬</td><td class="iron">‭1‬</td>
+        <td class="crop">‭67,397‬</td><td class="tra lc"><a href="#">‭20‬/‭20‬</a></td></tr>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+        <td class="lum">‭1‬</td><td class="clay">‭1‬</td><td class="iron">‭1‬</td>
+        <td class="crop">‭89,600‬</td><td class="tra lc"><a href="#">‭20‬/‭20‬</a></td></tr>
+</tbody></table>
+"""
+
+# Village 03 drains, village 11 fills -- the filling one forces a capacity fetch.
+WAREHOUSE_HTML = """
+<table id="warehouse">
+    <thead><tr><td>Village</td><td><i class="r1"></i></td><td><i class="r2"></i></td>
+        <td><i class="r3"></i></td><td><img class="clock" alt="Duration"></td>
+        <td><i class="r4"></i></td><td><img class="clock" alt="Duration"></td></tr></thead>
+    <tbody>
+    <tr class="hover">
+        <td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+        <td class="lum">‭55‬%</td><td class="clay">‭53‬%</td><td class="iron">‭58‬%</td>
+        <td class="max123"><span class="timer" counting="down" value="72065" data-value="72065">20:01:05</span></td>
+        <td class="crop">‭28‬%</td>
+        <td class="max4 lc"><span class="crit">−</span>&nbsp;<span class="timer crit" counting="down" value="43899" data-value="43899">12:11:39</span></td>
+    </tr><tr class="hover">
+        <td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+        <td class="lum">‭18‬%</td><td class="clay">‭35‬%</td><td class="iron">‭0‬%</td>
+        <td class="max123"><span class="timer" counting="down" value="88017" data-value="88017">24:26:57</span></td>
+        <td class="crop">‭56‬%</td>
+        <td class="max4 lc"><span class="timer" counting="down" value="211328" data-value="211328">58:42:08</span></td>
+    </tr>
+    </tbody>
+</table>
+"""
+
+# Both villages draining: capacity is never needed, so the snapshot is cheaper.
+WAREHOUSE_ALL_DRAINING_HTML = WAREHOUSE_HTML.replace(
+    '<span class="timer" counting="down" value="211328" data-value="211328">',
+    '<span class="timer crit" counting="down" value="211328" data-value="211328">',
+)
+
+CAPACITY_HTML = """
+<table id="capacity"><tbody>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20003">03</a></td>
+        <td class="max123">‭160,000‬</td><td class="max4">‭240,000‬</td></tr>
+    <tr class="hover"><td class="vil fc"><a href="/dorf1.php?newdid=20011">11</a></td>
+        <td class="max123">‭160,000‬</td><td class="max4">‭160,000‬</td></tr>
+</tbody></table>
+"""
+
+
+class _SnapshotHttp:
+    """Serves the statistics pages and records every request made."""
+
+    def __init__(self, production=PRODUCTION_HTML, warehouse=WAREHOUSE_HTML):
+        self.production = production
+        self.warehouse = warehouse
+        self.urls: list[str] = []
+
+    async def get_html(self, url: str, skip_reauth: bool = True) -> str:
+        self.urls.append(url)
+        if url.endswith("/production"):
+            return self.production
+        if url.endswith("/warehouse"):
+            return self.warehouse
+        if url.endswith("/capacity"):
+            return CAPACITY_HTML
+        return RESOURCES_HTML
+
+
+def _session(http: _SnapshotHttp) -> SimpleNamespace:
+    return SimpleNamespace(
+        auth_state=SimpleNamespace(
+            villages=[
+                SimpleNamespace(id=20003, name="03", x=23, y=88),
+                SimpleNamespace(id=20011, name="11", x=30, y=90),
+            ]
+        ),
+        http_client=http,
+        building_service=BuildingService(http),
+    )
+
+
+class TestSnapshotPricing:
+    def test_reports_three_requests_when_nothing_is_filling(self):
+        """The capacity page is only fetched for filling villages, and the
+        reported price must match what was actually spent."""
+        http = _SnapshotHttp(warehouse=WAREHOUSE_ALL_DRAINING_HTML)
+
+        res = asyncio.run(get_snapshot(_session(http)))
+
+        assert len(http.urls) == 3
+        assert res.requests_used == 3
+
+    def test_reports_four_requests_when_capacity_is_fetched(self):
+        http = _SnapshotHttp()
+
+        res = asyncio.run(get_snapshot(_session(http)))
+
+        assert len(http.urls) == 4
+        assert res.requests_used == 4
+
+    def test_warns_when_the_production_table_is_missing(self):
+        """Without Travian Plus the production table is absent; rates silently
+        defaulting to 0/h must at least be said out loud."""
+        http = _SnapshotHttp(production="<html>no table</html>")
+
+        res = asyncio.run(get_snapshot(_session(http)))
+
+        assert any("production" in w for w in res.warnings)
+
+
+def _plan_request(allocations, merchants_free=20, crop=None):
+    return PlanRequest.model_validate(
+        {
+            "snapshot": [
+                {
+                    "village_id": 20003,
+                    "name": "03",
+                    "x": 0,
+                    "y": 0,
+                    "merchants_total": 20,
+                    "merchants_free": merchants_free,
+                    "lumber_per_hour": 2000,
+                    "clay_per_hour": 1000,
+                    "iron_per_hour": 1000,
+                    "crop_per_hour": crop,
+                },
+                {
+                    "village_id": 20011,
+                    "name": "11",
+                    "x": 10,
+                    "y": 0,
+                    "merchants_total": 20,
+                    "merchants_free": merchants_free,
+                    "lumber_per_hour": 500,
+                    "clay_per_hour": 500,
+                    "iron_per_hour": 500,
+                    "crop_per_hour": crop,
+                },
+            ],
+            "allocations": allocations,
+        }
+    )
+
+
+class TestPlanEndpoint:
+    def test_needs_no_travian_session(self):
+        """Planning is pure over the request body. A session dependency makes
+        the zero-request endpoint spend real login traffic (or 403) when the
+        session has expired."""
+        for parameter in inspect.signature(post_plan).parameters.values():
+            dependency = getattr(parameter.default, "dependency", None)
+            assert dependency is not get_travian_session
+
+    def test_out_of_range_values_return_400_not_500(self):
+        body = _plan_request({"lumber": {"20003": {"mode": "percentage", "value": 150}}})
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(post_plan(body))
+
+        assert exc.value.status_code == 400
+        assert "percentage" in exc.value.detail
+
+    def test_inert_keep_entries_for_unknown_villages_do_not_fail_the_plan(self):
+        """The UI's remainder radio leaves `keep` husks behind, and villages get
+        lost or chiefed; an entry that means 'do nothing' must not 400."""
+        body = _plan_request({"lumber": {"99999": {"mode": "keep", "value": 0}}})
+
+        res = asyncio.run(post_plan(body))
+
+        assert res.feasible is not None
+
+    def test_allocations_for_a_resource_with_no_production_warn_instead_of_vanishing(self):
+        """All crop rates unknown: the user's crop targets cannot be planned,
+        and saying nothing violates the planner's own no-silent-drop rule."""
+        body = _plan_request({"crop": {"20003": {"mode": "absolute", "value": 500}}}, crop=None)
+
+        res = asyncio.run(post_plan(body))
+
+        assert any("crop" in w and "ignor" in w for w in res.warnings)
+
+    def test_committing_more_than_the_free_merchants_warns(self):
+        """The plan budgets against merchants_total; when in-game routes hold
+        most of them, the sheet is not executable until they are released."""
+        body = _plan_request(
+            {
+                "lumber": {
+                    "20003": {"mode": "absolute", "value": 500},
+                    "20011": {"mode": "remainder"},
+                }
+            },
+            merchants_free=0,
+        )
+
+        res = asyncio.run(post_plan(body))
+
+        assert res.total_merchants > 0
+        assert any("free" in w for w in res.warnings)

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -109,7 +109,7 @@ class _SnapshotHttp:
         return RESOURCES_HTML
 
 
-def _session(http: _SnapshotHttp) -> SimpleNamespace:
+def _session(http: _SnapshotHttp, tribe_id: int = 2) -> SimpleNamespace:
     return SimpleNamespace(
         auth_state=SimpleNamespace(
             villages=[
@@ -117,6 +117,7 @@ def _session(http: _SnapshotHttp) -> SimpleNamespace:
                 SimpleNamespace(id=20011, name="11", x=30, y=90),
             ]
         ),
+        tribe_id=tribe_id,
         http_client=http,
         building_service=BuildingService(http),
     )
@@ -150,6 +151,22 @@ class TestSnapshotPricing:
 
         assert len(http.urls) == 4
         assert res.requests_used == 4
+
+    def test_merchant_speed_comes_from_the_connected_tribe(self):
+        """Merchant travel speed is tribe-specific; hardcoding Teuton's 12
+        f/h inflates travel times and merchant counts for Romans/Gauls."""
+        assert (
+            asyncio.run(get_snapshot(_session(_SnapshotHttp(), tribe_id=2))).speed_fields_per_hour
+            == 12
+        )  # Teuton
+        assert (
+            asyncio.run(get_snapshot(_session(_SnapshotHttp(), tribe_id=1))).speed_fields_per_hour
+            == 16
+        )  # Roman
+        assert (
+            asyncio.run(get_snapshot(_session(_SnapshotHttp(), tribe_id=3))).speed_fields_per_hour
+            == 24
+        )  # Gaul
 
     def test_warns_when_the_production_table_is_missing(self):
         """Without Travian Plus the production table is absent; rates silently

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -212,6 +212,73 @@ def _plan_request(allocations, merchants_free=20, crop=None):
     )
 
 
+class TestStorageSafety:
+    """The plan must say when a village will starve or overflow.
+
+    A route set can balance perfectly as rates and still be wrong in the game:
+    a granary emptying inside the day kills troops, and a store that reaches its
+    cap silently discards everything above it. Both are computed from the
+    snapshot the caller already holds, so the check costs no game requests.
+    """
+
+    def _village(self, vid, **overrides):
+        base = dict(
+            village_id=vid,
+            name=str(vid),
+            x=0,
+            y=0,
+            merchants_total=20,
+            merchants_free=20,
+            lumber_per_hour=1000,
+            clay_per_hour=1000,
+            iron_per_hour=1000,
+            crop_per_hour=1000,
+            crop_stock=50_000,
+            lumber_stock=10_000,
+            clay_stock=10_000,
+            iron_stock=10_000,
+            warehouse_capacity=800_000,
+            granary_capacity=800_000,
+        )
+        base.update(overrides)
+        return base
+
+    def test_a_starving_village_is_reported(self):
+        body = PlanRequest(
+            snapshot=[
+                self._village(1, x=0, y=0),
+                # Eats far more crop than it grows, with hours of stock left.
+                self._village(2, x=5, y=0, crop_per_hour=-9000, crop_stock=9000),
+            ],
+        )
+
+        result = asyncio.run(post_plan(body, SimpleNamespace(id=1)))
+
+        starving = [w for w in result.warnings if "runs out" in w and "village 2" in w]
+        assert starving, f"no starvation warning in {result.warnings}"
+        assert "crop" in starving[0]
+
+    def test_a_village_without_a_capacity_reading_is_skipped_not_guessed(self):
+        """The capacity page is only fetched when the crop derivation needs it.
+        Where it was not read, the plan must stay quiet rather than invent a cap."""
+        body = PlanRequest(
+            snapshot=[
+                self._village(1, warehouse_capacity=None, granary_capacity=None),
+                self._village(2, x=5, warehouse_capacity=None, granary_capacity=None),
+            ],
+        )
+
+        result = asyncio.run(post_plan(body, SimpleNamespace(id=1)))
+
+        assert not [w for w in result.warnings if "fills its store" in w or "hits the cap" in w]
+
+    def test_storage_checks_cost_no_game_requests(self):
+        """post_plan takes no Travian session at all, so the whole check runs on
+        state the caller already has."""
+        for parameter in inspect.signature(post_plan).parameters.values():
+            assert getattr(parameter.default, "dependency", None) is not get_travian_session
+
+
 class TestPlanEndpoint:
     def test_needs_no_travian_session(self):
         """Planning is pure over the request body. A session dependency makes

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -13,7 +13,9 @@ import pytest
 from fastapi import HTTPException
 
 from travian_api.services.building_service import BuildingService
+from travian_api.services.distribution.allocation import Resource
 from travian_api.web.routes.distribution import (
+    ForeignTarget,
     PlanRequest,
     get_snapshot,
     post_plan,
@@ -210,6 +212,81 @@ def _plan_request(allocations, merchants_free=20, crop=None):
             "allocations": allocations,
         }
     )
+
+
+class TestForeignTribute:
+    """Crop owed to a village outside the account (profile section 7.3).
+
+    Supplied by hand, because nothing in the game tells us about it. It is a
+    sink, not a village: it grows nothing, holds nothing and can never ship
+    anything, and the crop it is owed has to come out of the account's pool
+    rather than appearing from nowhere.
+    """
+
+    def _body(self, crop_per_hour=500.0, margin=0.0, **kw):
+        body = _plan_request(
+            {"crop": {"20003": {"mode": "absolute", "value": 0}, "20011": {"mode": "remainder"}}},
+            crop=3000.0,
+        )
+        body.foreign_targets = [
+            ForeignTarget(
+                name="Ally-Keep",
+                x=40,
+                y=40,
+                crop_per_hour=crop_per_hour,
+                safety_margin_pct=margin,
+                **kw,
+            )
+        ]
+        return body
+
+    def test_the_tribute_is_shipped_and_comes_out_of_the_pool(self):
+        with_tribute = asyncio.run(post_plan(self._body(crop_per_hour=500.0)))
+        without = asyncio.run(
+            post_plan(self._body(crop_per_hour=500.0).model_copy(update={"foreign_targets": []}))
+        )
+
+        delivered = sum(
+            row.cargo.get(Resource.CROP, 0) for row in with_tribute.rows if row.destination < 0
+        )
+        assert delivered > 0, "the tribute was never actually shipped"
+
+        # It is deducted, not conjured: the remainder village keeps less crop
+        # than it would have with no obligation.
+        crop_before = next(u for u in without.unallocated if u.resource is Resource.CROP)
+        crop_after = next(u for u in with_tribute.unallocated if u.resource is Resource.CROP)
+        assert crop_after.unallocated < crop_before.unallocated
+
+    def test_the_safety_margin_ships_above_the_promise(self):
+        plain = asyncio.run(post_plan(self._body(crop_per_hour=500.0, margin=0.0)))
+        padded = asyncio.run(post_plan(self._body(crop_per_hour=500.0, margin=20.0)))
+
+        def to_target(res):
+            return sum(row.cargo.get(Resource.CROP, 0) for row in res.rows if row.destination < 0)
+
+        assert to_target(padded) > to_target(plain)
+
+    def test_a_tribute_can_never_be_asked_to_ship(self):
+        """It has no merchants, so any plan that made it an origin would be
+        proposing something the game cannot execute."""
+        res = asyncio.run(post_plan(self._body()))
+
+        assert not [row for row in res.rows if row.origin < 0]
+
+    def test_the_cold_start_is_reported(self):
+        """The first delivery only lands after a full one-way trip; a tribute
+        that silently starts late looks like a broken promise."""
+        res = asyncio.run(post_plan(self._body()))
+
+        assert any("first delivery lands" in w and "Ally-Keep" in w for w in res.warnings)
+
+    def test_an_unsuppliable_tribute_says_so(self):
+        """Promising more crop than the account grows must be reported, not
+        quietly under-shipped."""
+        res = asyncio.run(post_plan(self._body(crop_per_hour=10_000_000.0)))
+
+        assert any("Ally-Keep" in w for w in res.warnings)
+        assert res.shortfalls or not res.feasible
 
 
 class TestWarningsNameVillages:

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -281,21 +281,35 @@ class TestStorageSafety:
         every delivery twice -- a receiver ends the day holding double what
         arrived -- and invents overflows that do not exist.
         """
+        # Everything nets to zero: village 1 grows 8,000/h of lumber and ships
+        # all of it; village 2 burns exactly what arrives. Nothing accumulates,
+        # so a correctly-wired simulation settles and reports nothing. Counting
+        # the deliveries twice cancels village 2's consumption, so it banks
+        # 192,000 a day out of nowhere and any finite store fills.
+        #
+        # Village 1 is given a deep reserve on purpose. Under the doubled wiring
+        # its own production also cancels, and with a shallow store it would
+        # simply run dry, stop shipping, and hide the very bug this pins.
+        quiet = dict(clay_per_hour=0, iron_per_hour=0, crop_per_hour=0)
         body = PlanRequest(
             snapshot=[
-                # A sender with a large surplus and a receiver sized so that one
-                # day of genuine delivery fits, but a doubled one does not.
                 self._village(
-                    1, x=0, y=0, lumber_per_hour=8000, lumber_stock=0, warehouse_capacity=2_000_000
+                    1,
+                    x=0,
+                    y=0,
+                    lumber_per_hour=8000,
+                    lumber_stock=3_000_000,
+                    warehouse_capacity=5_000_000,
+                    **quiet,
                 ),
                 self._village(
                     2,
                     x=3,
                     y=0,
-                    lumber_per_hour=0,
-                    lumber_stock=0,
-                    warehouse_capacity=250_000,
-                    crop_per_hour=1000,
+                    lumber_per_hour=-8000,
+                    lumber_stock=100_000,
+                    warehouse_capacity=400_000,
+                    **quiet,
                 ),
             ],
             allocations={
@@ -305,8 +319,7 @@ class TestStorageSafety:
 
         result = asyncio.run(post_plan(body, SimpleNamespace(id=1)))
 
-        # 8,000/h = 192,000 a day, inside the 250,000 cap. Doubled it would not be.
-        bogus = [w for w in result.warnings if "hits the cap" in w and "village 2" in w]
+        bogus = [w for w in result.warnings if "hits the cap" in w]
         assert not bogus, f"phantom overflow from double-counted deliveries: {bogus}"
 
     def test_storage_checks_cost_no_game_requests(self):

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -76,7 +76,8 @@ WAREHOUSE_HTML = """
 </table>
 """
 
-# Both villages draining: capacity is never needed, so the snapshot is cheaper.
+# Both villages draining: crop derivation needs no capacity, but the capacity
+# page is still fetched for storage-overflow safety (see the pricing test).
 WAREHOUSE_ALL_DRAINING_HTML = WAREHOUSE_HTML.replace(
     '<span class="timer" counting="down" value="211328" data-value="211328">',
     '<span class="timer crit" counting="down" value="211328" data-value="211328">',
@@ -136,15 +137,18 @@ class TestSnapshotPricing:
             dependency = getattr(parameter.default, "dependency", None)
             assert dependency is not reconnecting
 
-    def test_reports_three_requests_when_nothing_is_filling(self):
-        """The capacity page is only fetched for filling villages, and the
-        reported price must match what was actually spent."""
+    def test_reports_four_requests_including_capacity_when_nothing_is_filling(self):
+        """The capacity page is fetched even on an all-draining account — its
+        warehouse figures are the only source for storage overflow safety, so it
+        must not be skipped just because crop derivation didn't need it. The
+        reported price matches what was actually spent."""
         http = _SnapshotHttp(warehouse=WAREHOUSE_ALL_DRAINING_HTML)
 
         res = asyncio.run(get_snapshot(_session(http)))
 
-        assert len(http.urls) == 3
-        assert res.requests_used == 3
+        assert any("capacity" in url for url in http.urls)
+        assert len(http.urls) == 4
+        assert res.requests_used == 4
 
     def test_reports_four_requests_when_capacity_is_fetched(self):
         http = _SnapshotHttp()
@@ -242,6 +246,10 @@ class TestForeignTribute:
                 y=40,
                 crop_per_hour=crop_per_hour,
                 safety_margin_pct=margin,
+                # These tests exercise a tribute that IS shipped by a route, so
+                # the target must be one Travian allows a route to (own / WW /
+                # alliance-artifact). Ineligible targets are covered separately.
+                route_eligible=kw.pop("route_eligible", True),
                 **kw,
             )
         ]
@@ -300,14 +308,14 @@ class TestForeignTribute:
             assert shortfall.village_name, "shortfalls must be named, never numbered"
 
     def test_the_cold_start_is_reported(self):
-        """The first delivery only lands after a full one-way trip; a tribute
-        that silently starts late looks like a broken promise. With several
-        suppliers the FIRST crop lands at the minimum startup, not the
-        maximum -- calling the last route's startup "first delivery" would
-        overstate the gap the operator has to cover by hand."""
+        """The first delivery can take up to a full cycle plus travel (worst case
+        being the route created just after its scheduled send time); a tribute
+        that silently starts late looks like a broken promise. The warning states
+        this as an upper bound on the manual-coverage window, using the minimum
+        startup across suppliers as the first-crop bound."""
         res = asyncio.run(post_plan(self._body()))
 
-        cold = [w for w in res.warnings if "first crop lands" in w and "Ally-Keep" in w]
+        cold = [w for w in res.warnings if "first crop can take up to" in w and "Ally-Keep" in w]
         assert cold, f"warnings: {res.warnings}"
         tribute_firsts = [row.first_delivery_hours for row in res.rows if row.destination < 0]
         assert f"{min(tribute_firsts):.1f}h" in cold[0]
@@ -319,6 +327,51 @@ class TestForeignTribute:
 
         assert any("Ally-Keep" in w for w in res.warnings)
         assert res.shortfalls or not res.feasible
+
+    def test_two_tributes_at_the_same_coords_never_relay_through_each_other(self):
+        """Two foreign obligations at identical coordinates are plausible operator
+        input. The zero-distance leg between them must not let the crop relay
+        adopt a sink as a hub — no route may originate at a foreign (negative) id,
+        and the plan may not claim feasible while emitting an impossible row."""
+        body = self._body()
+        body.foreign_targets = [
+            ForeignTarget(name="A", x=40, y=40, crop_per_hour=500.0, route_eligible=True),
+            ForeignTarget(name="B", x=40, y=40, crop_per_hour=500.0, route_eligible=True),
+        ]
+        res = asyncio.run(post_plan(body))
+        assert all(row.origin > 0 for row in res.rows), (
+            f"a route originates at a foreign sink: {[(r.origin, r.destination) for r in res.rows]}"
+        )
+
+    def test_an_ineligible_target_is_a_manual_transfer_not_a_route(self):
+        """Travian only allows routes to own / WW / alliance-artifact villages.
+        An ordinary foreign village must not be emitted as an executable route;
+        it is reported as a manual transfer instead."""
+        res = asyncio.run(post_plan(self._body(route_eligible=False)))
+        assert not [row for row in res.rows if row.destination < 0], (
+            "an ordinary foreign village must not become a Gold Club route row"
+        )
+        assert any("manual transfer" in w.lower() and "Ally-Keep" in w for w in res.warnings)
+
+
+class TestOverAllocation:
+    def test_over_allocation_is_infeasible_not_a_green_plan(self):
+        """Explicit targets exceeding production drive the remainder village's
+        target negative — an unsustainable "ship more than you make" allocation.
+        The routing may still show diagnostic rows, but the plan must NOT be
+        reported feasible, and the over-allocation must be surfaced in words."""
+        body = _plan_request(
+            {
+                "lumber": {
+                    # 3000 + 500(remainder floor) far exceeds total 2500/h produced
+                    "20003": {"mode": "absolute", "value": 3000},
+                    "20011": {"mode": "remainder"},
+                }
+            }
+        )
+        res = asyncio.run(post_plan(body))
+        assert res.feasible is False, "an over-allocated sheet must not read as feasible"
+        assert any("exceed production" in w for w in res.warnings)
 
 
 class TestWarningsNameVillages:

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -212,6 +212,62 @@ def _plan_request(allocations, merchants_free=20, crop=None):
     )
 
 
+class TestWarningsNameVillages:
+    """No message a human reads may identify a village by its internal id.
+
+    An id is a database handle. Told that "village 53629 would have to send more
+    than it has", the operator has to go and look up which village that even is
+    before they can act -- and a warning nobody can act on is barely better than
+    no warning at all.
+    """
+
+    def test_no_warning_leaks_a_village_id(self):
+        # Deliberately provoke several warnings at once: an over-allocated
+        # remainder, a sustain on a village that is not in deficit, and a
+        # merchant budget that cannot cover what the plan commits.
+        body = _plan_request(
+            {
+                "iron": {
+                    "20003": {"mode": "absolute", "value": 50_000},
+                    "20011": {"mode": "remainder"},
+                },
+                "crop": {
+                    "20003": {"mode": "sustain", "value": 10},
+                    "20011": {"mode": "remainder"},
+                },
+            },
+            merchants_free=2,
+            crop=1000.0,
+        )
+
+        res = asyncio.run(post_plan(body))
+
+        assert res.warnings, "fixture produced no warnings; the test proves nothing"
+        for warning in res.warnings:
+            for village in body.snapshot:
+                assert str(village.village_id) not in warning, (
+                    f"warning identifies a village by id instead of name: {warning}"
+                )
+
+    def test_a_village_with_no_name_still_gets_an_intelligible_warning(self):
+        """Falling back to the id is fine when there is genuinely no name --
+        silently dropping the identity would be worse."""
+        body = _plan_request(
+            {
+                "iron": {
+                    "20003": {"mode": "absolute", "value": 50_000},
+                    "20011": {"mode": "remainder"},
+                }
+            }
+        )
+        for village in body.snapshot:
+            village.name = ""
+
+        res = asyncio.run(post_plan(body))
+
+        assert any("village " in w for w in res.warnings)
+
+
 class TestStorageSafety:
     """The plan must say when a village will starve or overflow.
 
@@ -254,7 +310,8 @@ class TestStorageSafety:
 
         result = asyncio.run(post_plan(body, SimpleNamespace(id=1)))
 
-        starving = [w for w in result.warnings if "runs out" in w and "village 2" in w]
+        # The fixture names village 2 "2", so the warning leads with the name.
+        starving = [w for w in result.warnings if "runs out" in w and w.startswith("2:")]
         assert starving, f"no starvation warning in {result.warnings}"
         assert "crop" in starving[0]
 
@@ -383,7 +440,13 @@ class TestPlanEndpoint:
 
         res = asyncio.run(post_plan(body))
 
-        assert any("20011" in w and "ignor" in w for w in res.warnings)
+        dropped = [w for w in res.warnings if "ignor" in w]
+        assert dropped, f"the dropped allocation must be reported: {res.warnings}"
+        # Named, not numbered. An operator knows village "11"; nobody knows 20011.
+        assert any("11" in w for w in dropped)
+        assert not any("20011" in w for w in dropped), (
+            f"warning leaks the internal village id: {dropped}"
+        )
 
     @pytest.mark.parametrize(
         "overrides",

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -169,6 +169,13 @@ class TestSnapshotPricing:
             asyncio.run(get_snapshot(_session(_SnapshotHttp(), tribe_id=3))).speed_fields_per_hour
             == 24
         )  # Gaul
+        # Hun merchants travel at 20 f/h on x1 — the table shipped with 12
+        # (Teuton's), overstating every Hun plan's travel time and merchant
+        # counts, and potentially flipping feasible routes to over-budget.
+        assert (
+            asyncio.run(get_snapshot(_session(_SnapshotHttp(), tribe_id=7))).speed_fields_per_hour
+            == 20
+        )  # Hun
 
     def test_warns_when_the_production_table_is_missing(self):
         """Without Travian Plus the production table is absent; rates silently

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -301,10 +301,16 @@ class TestForeignTribute:
 
     def test_the_cold_start_is_reported(self):
         """The first delivery only lands after a full one-way trip; a tribute
-        that silently starts late looks like a broken promise."""
+        that silently starts late looks like a broken promise. With several
+        suppliers the FIRST crop lands at the minimum startup, not the
+        maximum -- calling the last route's startup "first delivery" would
+        overstate the gap the operator has to cover by hand."""
         res = asyncio.run(post_plan(self._body()))
 
-        assert any("first delivery lands" in w and "Ally-Keep" in w for w in res.warnings)
+        cold = [w for w in res.warnings if "first crop lands" in w and "Ally-Keep" in w]
+        assert cold, f"warnings: {res.warnings}"
+        tribute_firsts = [row.first_delivery_hours for row in res.rows if row.destination < 0]
+        assert f"{min(tribute_firsts):.1f}h" in cold[0]
 
     def test_an_unsuppliable_tribute_says_so(self):
         """Promising more crop than the account grows must be reported, not

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -113,7 +113,7 @@ def _session(http: _SnapshotHttp, tribe_id: int = 2) -> SimpleNamespace:
     return SimpleNamespace(
         auth_state=SimpleNamespace(
             villages=[
-                SimpleNamespace(id=20003, name="03", x=23, y=88),
+                SimpleNamespace(id=20003, name="03", x=42, y=17),
                 SimpleNamespace(id=20011, name="11", x=30, y=90),
             ]
         ),

--- a/tests/test_distribution_routes.py
+++ b/tests/test_distribution_routes.py
@@ -221,6 +221,45 @@ class TestPlanEndpoint:
 
         assert any("crop" in w and "ignor" in w for w in res.warnings)
 
+    def test_one_unreadable_crop_village_does_not_fail_the_whole_plan(self):
+        """A village whose granary countdown could not be read is excluded from
+        crop productions; an allocation pointing at it must be dropped with a
+        warning, not 400 the entire account's plan."""
+        body = _plan_request(
+            {
+                "crop": {
+                    "20003": {"mode": "absolute", "value": 500},
+                    "20011": {"mode": "remainder"},
+                }
+            }
+        )
+        # Village 03 keeps its crop rate; village 11's granary was unreadable.
+        body.snapshot[0].crop_per_hour = 1000.0
+        body.snapshot[1].crop_per_hour = None
+
+        res = asyncio.run(post_plan(body))
+
+        assert any("20011" in w and "ignor" in w for w in res.warnings)
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"merchant_base_capacity": 0},
+            {"merchant_base_capacity": -100},
+            {"trade_office_bonus_per_level": -0.2},
+        ],
+    )
+    def test_merchant_model_overrides_are_validated_as_request_errors(self, overrides):
+        """merchant_base_capacity <= 0 must be a validation error (422), not a
+        ValueError escaping MerchantModel deep inside the planner as a 500."""
+        from pydantic import ValidationError
+
+        payload = _plan_request({}).model_dump()
+        payload.update(overrides)
+
+        with pytest.raises(ValidationError):
+            PlanRequest.model_validate(payload)
+
     def test_committing_more_than_the_free_merchants_warns(self):
         """The plan budgets against merchants_total; when in-game routes hold
         most of them, the sheet is not executable until they are released."""

--- a/tests/test_distribution_storage.py
+++ b/tests/test_distribution_storage.py
@@ -1,0 +1,161 @@
+"""Storage safety: overflow in one direction, starvation in the other.
+
+Review R7 is the reason this module exists at all: the profile's
+``fill_time = (capacity - stock) / net`` silently returns a NEGATIVE number for a
+village whose crop is draining, and a negative "hours until full" reads as no
+problem while the granary empties and troops starve. Every test here is really
+asking the same question -- does the answer stay honest when the village is
+heading the other way?
+"""
+
+import pytest
+
+from travian_api.services.distribution.allocation import Resource
+from travian_api.services.distribution.optimizer import Route
+from travian_api.services.distribution.schedule import build_beat
+from travian_api.services.distribution.storage import (
+    DEFAULT_WARN_HOURS,
+    Trend,
+    simulate_day,
+    storage_warnings,
+    store_status,
+)
+
+
+class TestBothDirections:
+    def test_a_filling_store_reports_time_until_it_overflows(self):
+        status = store_status(1, Resource.LUMBER, stock=10_000, capacity=80_000, net_per_hour=7_000)
+
+        assert status.trend is Trend.FILLING
+        assert status.hours_remaining == pytest.approx(10.0)
+
+    def test_a_draining_store_reports_time_until_it_is_empty(self):
+        """R7. The old one-directional formula would give
+        (80000 - 12000) / -4000 = -17h, which sorts and displays as 'fine'."""
+        status = store_status(1, Resource.CROP, stock=12_000, capacity=80_000, net_per_hour=-4_000)
+
+        assert status.trend is Trend.DRAINING
+        assert status.hours_remaining == pytest.approx(3.0)
+        assert status.hours_remaining > 0, "a countdown to disaster must never be negative"
+
+    def test_starvation_is_answerable_without_knowing_the_capacity(self):
+        """The draining branch needs only the stock, so a village whose capacity
+        was never fetched still gets the warning that actually matters."""
+        status = store_status(1, Resource.CROP, stock=6_000, capacity=None, net_per_hour=-3_000)
+
+        assert status.trend is Trend.DRAINING
+        assert status.hours_remaining == pytest.approx(2.0)
+
+    def test_a_filling_store_without_capacity_says_so_rather_than_guessing(self):
+        status = store_status(1, Resource.IRON, stock=6_000, capacity=None, net_per_hour=3_000)
+
+        assert status.trend is Trend.FILLING
+        assert status.hours_remaining is None
+        assert not status.is_urgent
+
+    def test_a_level_store_is_not_divided_by_its_own_rounding_error(self):
+        """A rate of 0.2/h is level, not 'full in 400,000 hours'."""
+        status = store_status(1, Resource.CLAY, stock=5_000, capacity=80_000, net_per_hour=0.2)
+
+        assert status.trend is Trend.STEADY
+        assert status.hours_remaining is None
+
+    def test_an_already_full_store_reports_zero_not_a_negative(self):
+        status = store_status(1, Resource.CLAY, stock=90_000, capacity=80_000, net_per_hour=1_000)
+
+        assert status.hours_remaining == 0.0
+
+
+class TestWarnings:
+    def test_starvation_is_reported_before_overflow(self):
+        """Overflow wastes surplus; starvation destroys troops. When both are
+        urgent the one that cannot be undone must be read first."""
+        overflowing = store_status(1, Resource.LUMBER, 79_000, 80_000, 5_000)
+        starving = store_status(2, Resource.CROP, 3_000, 80_000, -3_000)
+
+        warnings = storage_warnings([overflowing, starving], [])
+
+        assert len(warnings) == 2
+        assert "runs out" in warnings[0]
+        assert "fills its store" in warnings[1]
+
+    def test_a_comfortable_store_is_not_mentioned(self):
+        calm = store_status(1, Resource.IRON, 1_000, 800_000, 500)
+
+        assert storage_warnings([calm], []) == ()
+        assert (calm.hours_remaining or 0) > DEFAULT_WARN_HOURS
+
+
+class TestDiscreteArrivals:
+    """Known issue #12: the average fits, the batch does not."""
+
+    def _daily_route(self, origin: int, destination: int, per_hour: float) -> Route:
+        # A 24h cycle delivers a whole day of production in one lump.
+        return Route(
+            origin=origin,
+            destination=destination,
+            cargo_per_hour={Resource.LUMBER: per_hour},
+            cycle_hours=24,
+            merchants_per_send=1,
+            sets_in_flight=1,
+            one_way_minutes=60.0,
+        )
+
+    def test_a_lumpy_batch_overflows_while_the_average_rate_says_steady(self):
+        """The exact shape of known issue #12.
+
+        Village 2 burns 1,000/h and receives 1,000/h on average, so on a
+        continuous view it is perfectly level -- the rate check reports STEADY
+        and raises nothing, forever. But the delivery is a 24h cycle: a whole
+        day's worth lands in one lump on a store that is already nearly full,
+        and everything past the cap is gone. Averages cannot see this; only
+        replaying the actual beat can.
+        """
+        # The continuous check, on the same numbers, is content.
+        averaged = store_status(2, Resource.LUMBER, stock=70_000, capacity=80_000, net_per_hour=0.0)
+        assert averaged.trend is Trend.STEADY
+        assert storage_warnings([averaged], []) == ()
+
+        beat = build_beat((self._daily_route(1, 2, 1_000),))
+        overflows = simulate_day(
+            beat,
+            stocks={1: {Resource.LUMBER: 0}, 2: {Resource.LUMBER: 70_000}},
+            capacities={1: {Resource.LUMBER: 800_000}, 2: {Resource.LUMBER: 80_000}},
+            net_per_hour={1: {Resource.LUMBER: 1_000}, 2: {Resource.LUMBER: -1_000}},
+        )
+
+        event = next((e for e in overflows if e.village_id == 2), None)
+        assert event is not None, "the batch overflows, but the average-rate check passed"
+        assert event.resource is Resource.LUMBER
+        assert event.wasted_per_day > 0
+        # And it is reported in terms the operator can act on.
+        assert any("hits the cap" in w for w in storage_warnings([averaged], overflows))
+
+    def test_a_sender_is_not_reported_as_overflowing_its_own_outbound(self):
+        """Cargo leaves the origin when the merchants do. Counting only arrivals
+        would let every sender's store grow without bound and invent an overflow
+        that the outbound route is in fact preventing."""
+        beat = build_beat((self._daily_route(1, 2, 1_000),))
+
+        overflows = simulate_day(
+            beat,
+            stocks={1: {Resource.LUMBER: 70_000}, 2: {Resource.LUMBER: 0}},
+            capacities={1: {Resource.LUMBER: 80_000}, 2: {Resource.LUMBER: 800_000}},
+            net_per_hour={1: {Resource.LUMBER: 1_000}, 2: {Resource.LUMBER: 0}},
+        )
+
+        assert not [e for e in overflows if e.village_id == 1], (
+            "the sender ships its production out daily; it must not read as overflowing"
+        )
+
+    def test_a_store_with_no_known_capacity_is_skipped_not_assumed(self):
+        beat = build_beat((self._daily_route(1, 2, 1_000),))
+
+        overflows = simulate_day(
+            beat,
+            stocks={2: {Resource.LUMBER: 79_000}},
+            capacities={},  # capacity page was never fetched
+            net_per_hour={2: {Resource.LUMBER: 5_000}},
+        )
+
+        assert overflows == ()

--- a/tests/test_distribution_storage.py
+++ b/tests/test_distribution_storage.py
@@ -101,35 +101,79 @@ class TestDiscreteArrivals:
             one_way_minutes=60.0,
         )
 
-    def test_a_lumpy_batch_overflows_while_the_average_rate_says_steady(self):
-        """The exact shape of known issue #12.
+    def test_a_batch_bigger_than_the_store_overflows_every_single_day(self):
+        """The exact shape of known issue #12, in its RECURRING form.
 
-        Village 2 burns 1,000/h and receives 1,000/h on average, so on a
+        Village 2 burns 5,000/h and receives 5,000/h on average, so on a
         continuous view it is perfectly level -- the rate check reports STEADY
-        and raises nothing, forever. But the delivery is a 24h cycle: a whole
-        day's worth lands in one lump on a store that is already nearly full,
-        and everything past the cap is gone. Averages cannot see this; only
-        replaying the actual beat can.
+        and raises nothing, forever. But the delivery is a 24h cycle, so a whole
+        day's worth (120,000) lands in one lump on a store that only holds
+        80,000. At least 40,000 is lost, and it is lost again tomorrow, and the
+        day after: the batch does not fit no matter what the village started
+        with. Averages cannot see this; only replaying the beat can.
         """
         # The continuous check, on the same numbers, is content.
-        averaged = store_status(2, Resource.LUMBER, stock=70_000, capacity=80_000, net_per_hour=0.0)
+        averaged = store_status(2, Resource.LUMBER, stock=40_000, capacity=80_000, net_per_hour=0.0)
         assert averaged.trend is Trend.STEADY
         assert storage_warnings([averaged], []) == ()
 
-        beat = build_beat((self._daily_route(1, 2, 1_000),))
+        beat = build_beat((self._daily_route(1, 2, 5_000),))
         overflows = simulate_day(
             beat,
-            stocks={1: {Resource.LUMBER: 0}, 2: {Resource.LUMBER: 70_000}},
+            stocks={1: {Resource.LUMBER: 120_000}, 2: {Resource.LUMBER: 40_000}},
+            capacities={1: {Resource.LUMBER: 1_000_000}, 2: {Resource.LUMBER: 80_000}},
+            net_per_hour={1: {Resource.LUMBER: 5_000}, 2: {Resource.LUMBER: -5_000}},
+        )
+
+        event = next((e for e in overflows if e.village_id == 2), None)
+        assert event is not None, "a 120,000 batch cannot fit an 80,000 store, ever"
+        assert event.resource is Resource.LUMBER
+        assert event.wasted_per_day >= 40_000
+        assert any("hits the cap" in w for w in storage_warnings([averaged], overflows))
+
+    def test_a_store_that_is_merely_full_today_is_not_called_a_daily_loss(self):
+        """A one-off transient must not be reported as a recurring rate.
+
+        A village sitting near its cap loses one batch, settles, and never loses
+        anything again -- the beat is fine, the village just needs draining
+        today. Reporting that as 'loses N per day' overstates it indefinitely,
+        and it is already covered by the continuous fill-time check. Only waste
+        that survives to a settled day belongs here.
+        """
+        beat = build_beat((self._daily_route(1, 2, 1_000),))
+
+        overflows = simulate_day(
+            beat,
+            # 24,000 lands daily and 24,000 is consumed daily: the batch fits the
+            # 80,000 store comfortably. Only the 70,000 opening stock makes day
+            # one overflow.
+            stocks={1: {Resource.LUMBER: 24_000}, 2: {Resource.LUMBER: 70_000}},
             capacities={1: {Resource.LUMBER: 800_000}, 2: {Resource.LUMBER: 80_000}},
             net_per_hour={1: {Resource.LUMBER: 1_000}, 2: {Resource.LUMBER: -1_000}},
         )
 
-        event = next((e for e in overflows if e.village_id == 2), None)
-        assert event is not None, "the batch overflows, but the average-rate check passed"
-        assert event.resource is Resource.LUMBER
-        assert event.wasted_per_day > 0
-        # And it is reported in terms the operator can act on.
-        assert any("hits the cap" in w for w in storage_warnings([averaged], overflows))
+        assert not [e for e in overflows if e.village_id == 2], (
+            "day-one transient reported as a recurring daily loss"
+        )
+
+    def test_a_delivery_the_origin_cannot_fund_is_not_invented(self):
+        """Cargo must be conserved. If the origin has nothing to ship, taking
+        the shortfall out at zero while still crediting the destination a full
+        batch creates resources -- and the invented cargo then reappears as an
+        overflow at the far end."""
+        beat = build_beat((self._daily_route(1, 2, 1_000),))
+
+        overflows = simulate_day(
+            beat,
+            # Village 1 has no stock and no production: it can ship nothing.
+            stocks={1: {Resource.LUMBER: 0}, 2: {Resource.LUMBER: 60_000}},
+            capacities={1: {Resource.LUMBER: 800_000}, 2: {Resource.LUMBER: 80_000}},
+            net_per_hour={1: {Resource.LUMBER: 0}, 2: {Resource.LUMBER: 0}},
+        )
+
+        assert overflows == (), (
+            "nothing was ever shipped, so nothing can overflow at the destination"
+        )
 
     def test_a_sender_is_not_reported_as_overflowing_its_own_outbound(self):
         """Cargo leaves the origin when the merchants do. Counting only arrivals

--- a/tests/test_farm_builder_scan_cache.py
+++ b/tests/test_farm_builder_scan_cache.py
@@ -1,0 +1,43 @@
+"""Scan-cache age math must survive SQLite's naive datetimes.
+
+The column is declared timezone=True, but SQLite has no timezone storage:
+rows come back naive. Subtracting a naive `updated_at` from an aware
+`datetime.now(UTC)` raises TypeError, turning GET /api/farm-builder/scan-cache
+into a 500 for every user who has ever saved a scan.
+"""
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from travian_api.web.routes.farm_builder import get_scan_cache
+
+
+class _Db:
+    def __init__(self, row):
+        self._row = row
+
+    async def execute(self, _stmt):
+        row = self._row
+        return SimpleNamespace(scalar_one_or_none=lambda: row)
+
+
+def _row(updated_at):
+    return SimpleNamespace(updated_at=updated_at, scan_json=json.dumps({"targets": []}))
+
+
+class TestNaiveTimestamps:
+    def test_a_fresh_naive_row_is_served_not_500(self):
+        naive_now = datetime.now(UTC).replace(tzinfo=None)  # what SQLite returns
+        out = asyncio.run(get_scan_cache(SimpleNamespace(id=1), _Db(_row(naive_now))))
+        assert out.has_cache is True
+
+    def test_a_stale_naive_row_is_expired_not_500(self):
+        naive_old = (datetime.now(UTC) - timedelta(hours=2)).replace(tzinfo=None)
+        out = asyncio.run(get_scan_cache(SimpleNamespace(id=1), _Db(_row(naive_old))))
+        assert out.has_cache is False
+
+    def test_an_aware_row_still_works(self):
+        out = asyncio.run(get_scan_cache(SimpleNamespace(id=1), _Db(_row(datetime.now(UTC)))))
+        assert out.has_cache is True

--- a/tests/test_farm_list_mutations_no_retry.py
+++ b/tests/test_farm_list_mutations_no_retry.py
@@ -1,0 +1,58 @@
+"""Farm-list mutations must not be transport-retried.
+
+post_json now retries transient failures by default (the round-2 fix). For
+non-idempotent calls that is dangerous: if Travian commits the create/add and
+the response connection then drops, a retry makes a duplicate list or slot.
+These tests pin that every farm-list mutation opts out with safe_to_retry=False.
+"""
+
+import asyncio
+
+import pytest
+
+from travian_api.services.farm_list_service import FarmListService
+
+
+class _RecordingClient:
+    """Captures the kwargs of each write call; returns benign payloads."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    async def post_json(self, url, data=None, **kwargs):
+        self.calls.append(("post_json", kwargs))
+        return {"id": 1}
+
+    async def delete_json(self, url, **kwargs):
+        self.calls.append(("delete_json", kwargs))
+        return {}
+
+
+@pytest.fixture
+def client_and_service():
+    client = _RecordingClient()
+    return client, FarmListService(client)
+
+
+def test_create_farm_list_opts_out_of_retries(client_and_service):
+    client, svc = client_and_service
+    asyncio.run(svc.create_farm_list(village_id=1, name="raids"))
+    assert client.calls[-1][1].get("safe_to_retry") is False
+
+
+def test_add_slot_opts_out_of_retries(client_and_service):
+    client, svc = client_and_service
+    asyncio.run(svc.add_slot(list_id=1, x=10, y=20))
+    assert client.calls[-1][1].get("safe_to_retry") is False
+
+
+def test_delete_farm_list_opts_out_of_retries(client_and_service):
+    client, svc = client_and_service
+    asyncio.run(svc.delete_farm_list(list_id=1))
+    assert client.calls[-1][1].get("safe_to_retry") is False
+
+
+def test_delete_slots_opts_out_of_retries(client_and_service):
+    client, svc = client_and_service
+    asyncio.run(svc.delete_slots(slot_ids=[1, 2, 3]))
+    assert client.calls[-1][1].get("safe_to_retry") is False

--- a/tests/test_http_client_retries.py
+++ b/tests/test_http_client_retries.py
@@ -1,0 +1,134 @@
+"""Transient-failure retries on the write helpers.
+
+post_json/delete_json/post_form all contain `raise  # Let tenacity see the
+original exception and retry` -- but only get_html actually carried the
+tenacity decorator, so a single transient ConnectError aborted eligible
+requests on the first failure. These tests pin that the retry machinery is
+really attached and that safe_to_retry=False still fails fast.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from tenacity import wait_fixed
+
+from travian_api.clients.http_client import HttpClient
+from travian_api.config import Settings
+from travian_api.exceptions import NetworkError
+
+
+def _client() -> HttpClient:
+    client = HttpClient(
+        Settings(
+            base_url="https://ts2.x1.europe.travian.com",
+            username="test@example.com",
+            password="test123",
+        )
+    )
+    # The retry contract is what is under test, not stealth pacing or the
+    # curl transport: plain httpx with no throttler sleeps.
+    client._stealth_enabled = False
+    client._use_curl = False
+    return client
+
+
+def _ok_response(text: str = '{"ok": true}') -> SimpleNamespace:
+    return SimpleNamespace(
+        status_code=200,
+        text=text,
+        headers={},
+        json=lambda: {"ok": True},
+        url="https://ts2.x1.europe.travian.com/api/v1/x",
+    )
+
+
+def _no_wait(bound_method) -> None:
+    """Zero out the tenacity wait so the test does not sleep."""
+    bound_method.retry.wait = wait_fixed(0)
+
+
+class TestTransientErrorsAreRetried:
+    def test_post_json_survives_two_connect_errors(self, monkeypatch):
+        client = _client()
+        attempts = {"n": 0}
+
+        async def flaky_post(url, **kwargs):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise httpx.ConnectError("connection dropped")
+            return _ok_response()
+
+        monkeypatch.setattr(client.client, "post", flaky_post)
+        _no_wait(client.post_json)
+        try:
+            result = asyncio.run(client.post_json("/api/v1/x", {"a": 1}))
+        finally:
+            asyncio.run(client.close())
+
+        assert result == {"ok": True}
+        assert attempts["n"] == 3
+
+    def test_delete_json_survives_two_connect_errors(self, monkeypatch):
+        client = _client()
+        attempts = {"n": 0}
+
+        async def flaky_delete(url, **kwargs):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise httpx.ConnectError("connection dropped")
+            return _ok_response()
+
+        monkeypatch.setattr(client.client, "delete", flaky_delete)
+        _no_wait(client.delete_json)
+        try:
+            result = asyncio.run(client.delete_json("/api/v1/x"))
+        finally:
+            asyncio.run(client.close())
+
+        assert result == {"ok": True}
+        assert attempts["n"] == 3
+
+    def test_post_form_survives_two_connect_errors(self, monkeypatch):
+        client = _client()
+        attempts = {"n": 0}
+
+        async def flaky_post(url, **kwargs):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise httpx.ConnectError("connection dropped")
+            return _ok_response(text="<html>ok</html>")
+
+        monkeypatch.setattr(client.client, "post", flaky_post)
+        _no_wait(client.post_form)
+        try:
+            result = asyncio.run(client.post_form("/build.php", {"a": "1"}))
+        finally:
+            asyncio.run(client.close())
+
+        assert result == "<html>ok</html>"
+        assert attempts["n"] == 3
+
+
+class TestNonRetryableFailsFast:
+    def test_post_json_with_safe_to_retry_false_makes_one_attempt(self, monkeypatch):
+        """Non-idempotent actions (raid sends) must never re-dispatch: the
+        except block converts to NetworkError, which the retry machinery is
+        deliberately blind to."""
+        client = _client()
+        attempts = {"n": 0}
+
+        async def failing_post(url, **kwargs):
+            attempts["n"] += 1
+            raise httpx.ConnectError("connection dropped")
+
+        monkeypatch.setattr(client.client, "post", failing_post)
+        _no_wait(client.post_json)
+        try:
+            with pytest.raises(NetworkError, match="non-retryable"):
+                asyncio.run(client.post_json("/api/v1/x", {"a": 1}, safe_to_retry=False))
+        finally:
+            asyncio.run(client.close())
+
+        assert attempts["n"] == 1

--- a/tests/test_jwt_cache_restore.py
+++ b/tests/test_jwt_cache_restore.py
@@ -63,7 +63,17 @@ class _FakeHttp:
         if path == "/api/v1/graphql":
             if SERVER_COOKIE not in self.cookies:
                 return {}  # server sees no session
-            return {"data": {"ownPlayer": {"name": "FreshLogin", "tribeId": 2, "villages": []}}}
+            return {
+                "data": {
+                    "ownPlayer": {
+                        "name": "FreshLogin",
+                        "tribeId": 2,
+                        "villages": [
+                            {"id": 999, "name": "Settled", "x": 5, "y": 7, "isMainVillage": True}
+                        ],
+                    }
+                }
+            }
         if path == "/api/v1/auth/login":
             return {
                 "redirectTo": "/api/v1/auth?code=abc&response_type=redirect",
@@ -125,8 +135,22 @@ def test_a_valid_cache_avoids_a_credential_login(tmp_path):
     assert not any("auth/login" in request for request in http.requests), (
         f"credential login still performed: {http.requests}"
     )
-    # Identity came from the cache file, not from a fresh GraphQL enrichment.
-    assert state.player_name == "CachedPlayer"
+    # The liveness probe already carries the current identity, so a resumed
+    # session must not keep serving the cache file's snapshot.
+    assert state.player_name == "FreshLogin"
+
+
+def test_a_cached_resume_refreshes_the_village_list(tmp_path):
+    """Villages settle, get chiefed, or get renamed while a JWT stays valid;
+    resuming from cache must not serve the stale list — or a village_id that
+    is no longer on the account."""
+    http = _FakeHttp()
+    service = _service(http, tmp_path, _make_jwt())
+
+    state = asyncio.run(service.login())
+
+    assert [v.id for v in state.villages] == [999]
+    assert state.village_id == 999  # cached 20001 no longer exists
 
 
 def test_get_jwt_prefers_the_server_cookie_over_a_stale_lowercase_one(tmp_path):

--- a/tests/test_military_send_detection.py
+++ b/tests/test_military_send_detection.py
@@ -1,0 +1,32 @@
+"""Troop-send success detection must not be fooled by unrelated movements.
+
+An account with raids already in flight always renders a `troopMovement`
+element on the rally-point page. The old logic let that force success=True even
+when the confirmation form reappeared (send not processed) or an error div was
+present -- reporting a rejected raid/scout as dispatched.
+"""
+
+from travian_api.services.military_service import MilitaryService
+
+TOKEN = "abc123"
+
+
+def test_reappearing_form_is_a_failure_even_with_a_movement_on_the_page():
+    html = f'<input name="action" value="{TOKEN}"><div class="troopMovement">outgoing</div>'
+    assert MilitaryService._send_succeeded(html, TOKEN) is False
+
+
+def test_an_error_div_is_a_failure_even_with_a_movement_on_the_page():
+    html = '<div class="error">Not enough troops</div><div class="troopMovement">outgoing</div>'
+    assert MilitaryService._send_succeeded(html, TOKEN) is False
+
+
+def test_a_clean_rally_page_is_a_success():
+    html = '<div class="troopMovement">outgoing</div><button>confirmSendTroops</button>'
+    assert MilitaryService._send_succeeded(html, TOKEN) is True
+
+
+def test_a_clean_page_with_no_movement_is_still_a_success():
+    # The action token was consumed and there is no error: the send went out.
+    html = "<div>Rally point</div>"
+    assert MilitaryService._send_succeeded(html, TOKEN) is True

--- a/tests/test_operation_manager.py
+++ b/tests/test_operation_manager.py
@@ -28,14 +28,68 @@ from travian_api.web.operation_gate import active_ops, captcha_stop
 
 
 @pytest.fixture
-def fresh_manager():
-    """Each test gets its own manager with a clean active_ops state."""
+def fresh_manager(monkeypatch):
+    """Each test gets its own manager with a clean active_ops state.
+
+    start() now refuses to spawn against a session that is not the one
+    installed in session_manager (the disconnect-during-startup guard). These
+    unit tests pass throwaway sessions, so the fixture models production —
+    where the session handed to start() IS the installed one — by recording
+    each start()'s session as installed and pointing session_manager.get at
+    that record. Tests that want to exercise the guard's refusal patch get()
+    themselves.
+    """
+    from travian_api.web import sessions as sessions_mod
+
+    installed: dict[int, object] = {}
+    monkeypatch.setattr(sessions_mod.session_manager, "get", installed.get)
+
     mgr = OperationManager()
+    _orig_start = mgr.start
+
+    def _start(*args, **kwargs):
+        if "user_id" in kwargs and "session" in kwargs:
+            installed[kwargs["user_id"]] = kwargs["session"]
+        return _orig_start(*args, **kwargs)
+
+    mgr.start = _start
     yield mgr
     # Cleanup: best-effort cancel any leftover tasks so a flaky test doesn't
     # leak running tasks into the next one.
     for op in list(mgr._ops.values()):
         op.task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_start_refuses_a_session_torn_down_mid_startup(monkeypatch):
+    """The WS-handler race: a session was fetched, the client config awaited,
+    and /disconnect popped and closed the session in that gap. start() must
+    refuse rather than spawn a detached op against the dead HttpClient."""
+    from travian_api.web import sessions as sessions_mod
+
+    # session_manager reports a DIFFERENT (or no) session than the one passed.
+    monkeypatch.setattr(sessions_mod.session_manager, "get", lambda uid: None)
+    mgr = OperationManager()
+
+    ran = False
+
+    async def coro(ctx: OperationContext) -> None:
+        nonlocal ran
+        ran = True
+
+    op = mgr.start(
+        user_id=99,
+        label="doomed",
+        session_type="test",
+        session_label="Test",
+        session=SimpleNamespace(),
+        coro=coro,
+    )
+
+    assert op is None, "start must refuse when the session is no longer installed"
+    assert "doomed" not in active_ops.get_active(99)
+    await asyncio.sleep(0)
+    assert ran is False, "the coroutine must never have been scheduled"
 
 
 @pytest.mark.asyncio

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -125,16 +125,21 @@ class TestHTMLParsers:
         assert resources.max_lumber == 8000
         assert resources.max_crop == 10000
 
-    def test_parse_resources_starving_village_keeps_negative_crop_rates(self):
-        """A village whose troops outeat its fields has negative l4/l5 rates."""
+    def test_parse_resources_starving_village_keeps_negative_crop_rate(self):
+        """Real capture from a starving village (newdid=20003, 2026-08).
+
+        l4 is the net rate and is negative; l5 is POSITIVE at the same moment.
+        Verified against the warehouse overview, which flagged this village
+        `crit` with 43,899s to an empty granary: 67397 / 5556 = 43,670s.
+        """
         html_content = """
         <html>
         <head>
             <script>
                 var resources = {
-                    storage: {l1: 81, l2: 66, l3: 93, l4: 20831},
-                    production: {l1: 745, l2: 745, l3: 745, l4: -3292, l5: -6536},
-                    maxStorage: {l1: 80000, l2: 80000, l3: 80000, l4: 240000}
+                    storage: {l1: 88652, l2: 85167, l3: 93880, l4: 67397},
+                    production: {l1: 2875, l2: 3750, l3: 2175, l4: -5556, l5: 1481},
+                    maxStorage: {l1: 160000, l2: 160000, l3: 160000, l4: 240000}
                 };
             </script>
         </head>
@@ -143,9 +148,33 @@ class TestHTMLParsers:
 
         resources = parse_resources(html_content)
 
-        assert resources.crop == 20831
-        assert resources.crop_per_hour == -3292
-        assert resources.free_crop == -6536
+        assert resources.crop == 67397
+        assert resources.max_crop == 240000
+        # l4 -> the true net rate, negative while draining.
+        assert resources.crop_per_hour == -5556
+        # l5 is carried through verbatim and is NOT net crop: positive here.
+        assert resources.free_crop == 1481
+
+    def test_free_crop_must_not_be_used_as_the_starvation_signal(self):
+        """Guards the bug this replaced.
+
+        free_crop (l5) read positive on a village draining at -5,556/h, so any
+        `free_crop > 0` health check reported a starving village as fine.
+        """
+        html_content = """
+        <html><script>
+            var resources = {
+                storage: {l1: 0, l2: 0, l3: 0, l4: 67397},
+                production: {l1: 0, l2: 0, l3: 0, l4: -5556, l5: 1481},
+                maxStorage: {l1: 0, l2: 0, l3: 0, l4: 240000}
+            };
+        </script></html>
+        """
+
+        resources = parse_resources(html_content)
+
+        assert resources.free_crop > 0, "l5 is positive on this starving village"
+        assert resources.crop_per_hour < 0, "l4 is the field that reveals starvation"
 
     def test_parse_construction_queue_empty(self):
         """Test parsing empty construction queue."""

--- a/tests/test_rate_limit_eviction.py
+++ b/tests/test_rate_limit_eviction.py
@@ -1,0 +1,47 @@
+"""The rate limiter must not grow its key map without bound.
+
+On a remotely exposed instance, login attempts arrive from many source IPs.
+The old cleanup only pruned the current key (which was then immediately given
+a fresh timestamp), so the empty-key sweep never fired and expired keys
+accumulated forever. These tests pin that stale keys are actually evicted.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from travian_api.web.rate_limit import RateLimiter
+
+
+def _request(host: str):
+    return SimpleNamespace(state=SimpleNamespace(), client=SimpleNamespace(host=host))
+
+
+def test_expired_keys_are_evicted_once_over_the_threshold():
+    limiter = RateLimiter(max_calls=5, window_seconds=10)
+    # Seed 150 keys whose only timestamp is ancient (well outside the window).
+    for i in range(150):
+        limiter._calls[f"ip:stale-{i}"] = [0.0]
+
+    # One live call from a fresh IP crosses the >100 threshold and sweeps.
+    asyncio.run(limiter(_request("203.0.113.1")))
+
+    remaining = set(limiter._calls)
+    assert remaining == {"ip:203.0.113.1"}, (
+        f"stale keys were not evicted: {len(remaining)} keys remain"
+    )
+
+
+def test_a_key_with_in_window_activity_survives_the_sweep():
+    limiter = RateLimiter(max_calls=5, window_seconds=10)
+    for i in range(150):
+        limiter._calls[f"ip:stale-{i}"] = [0.0]
+    # A recently-active other key must be kept (pruned to its fresh timestamps).
+    import time
+
+    limiter._calls["ip:busy"] = [time.monotonic()]
+
+    asyncio.run(limiter(_request("203.0.113.2")))
+
+    assert "ip:busy" in limiter._calls
+    assert "ip:203.0.113.2" in limiter._calls
+    assert not any(k.startswith("ip:stale-") for k in limiter._calls)

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -268,6 +268,32 @@ class TestAssignRoleAndListName:
         roles = [p.target_list_role for p in ordered]
         assert roles == ["HIGH", "MID"]
 
+    def test_band_sizes_track_the_documented_split(self):
+        """Pin the whole curve, not just the sizes that happened to be noticed.
+
+        The bands are the nearest integer partition of 30/50/20, so no band may
+        sit further than one whole placement from its ideal share. Flooring a cut
+        breached this (n=6 put 67% in MID against a documented 50%), and because
+        only n=1,2,3,10 were pinned the drift was invisible for every other size.
+        """
+        for n in range(1, 31):
+            placements = [self._make_placement(1.0 - i * 0.01) for i in range(n)]
+            roles = [p.target_list_role for p in assign_role_and_list_name("V1", placements)]
+            got = (roles.count("HIGH"), roles.count("MID"), roles.count("INACTIVE"))
+
+            assert sum(got) == n, f"n={n}: placements lost, got {got}"
+            assert got[0] >= 1, f"n={n}: every village must keep a HIGH list"
+            # Roles are assigned best-first, so the bands must be contiguous.
+            assert roles == sorted(roles, key=["HIGH", "MID", "INACTIVE"].index), f"n={n}"
+            for band, share, count in zip(("HIGH", "MID", "INACTIVE"), (0.3, 0.5, 0.2), got):
+                # n=1..3 cannot honour the shares at all (a single placement is
+                # 100% HIGH by construction); above that the rounding must hold.
+                if n > 3:
+                    assert abs(count - n * share) < 1.0, (
+                        f"n={n} {band}={count} is more than one placement from "
+                        f"its {share:.0%} share ({n * share:.1f}); got {got}"
+                    )
+
     def test_list_name_uses_display_unit_and_village(self):
         p = self._make_placement(1.0, village="V3")
         assign_role_and_list_name("V3", [p])

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -549,6 +549,29 @@ class TestWaveStacking:
         for wave in waves:
             assert wave.of_total_waves == len(waves)
 
+    def test_an_undersupplied_pick_falls_back_to_later_candidates(self):
+        """The fastest candidate can have supply >= 1 (so it enumerates) but
+        fewer units than the wave needs; truncating there dropped feasible
+        placements from slower villages with plenty of troops."""
+        from travian_api.services.rebalance_planner import plan_waves_for_target
+
+        # V7 is fastest but has one clubswinger; V6 is farther with plenty.
+        vps = [VillagePosition("V7", 30, 82), VillagePosition("V6", 35, 83)]
+        supplies = {("V7", "t1"): 1, ("V6", "t1"): 1000}
+        target = FakeTarget(
+            coord=(31, 83),
+            avg_loot=480.0,
+            total_raids_all_lists=20,
+            last_raid_time_unix=int(NOW - 86400),
+        )
+
+        waves = plan_waves_for_target(target, vps, supplies)
+
+        assert waves, "the slower-but-supplied village must still get the wave"
+        assert waves[0].optimal_village == "V6"
+        assert waves[0].wave_index == 1
+        assert all(w.of_total_waves == len(waves) for w in waves)
+
     def test_dead_floor_returns_empty_plan(self):
         from travian_api.services.rebalance_planner import plan_waves_for_target
 

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -262,8 +262,17 @@ class TestAssignRoleAndListName:
     def test_list_name_uses_display_unit_and_village(self):
         p = self._make_placement(1.0, village="V3")
         assign_role_and_list_name("V3", [p])
-        # 1 placement, high_cut=0, mid_cut=0 → idx 0 >= mid_cut → INACTIVE
-        assert p.target_list_name == "V3-INACTIVE-Clubs"
+        # A village's single best target must land in HIGH, not INACTIVE.
+        assert p.target_list_name == "V3-HIGH-Clubs"
+
+    def test_small_placement_sets_always_get_a_high_list(self):
+        """Floored fraction cuts left 1-3 placement villages with no HIGH list
+        at all — a lone placement went straight to INACTIVE, deactivating the
+        village's only raid target by construction."""
+        for n in (1, 2, 3):
+            placements = [self._make_placement(1.0 - i * 0.1) for i in range(n)]
+            ordered = assign_role_and_list_name("V1", placements)
+            assert ordered[0].target_list_role == "HIGH", f"n={n}"
 
     def test_v4_v5_v6_v7_use_standard_roles(self):
         # v5.0 removed the LOCAL role; V4-V7 use HIGH/MID/INACTIVE like V1-V3.

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -518,6 +518,37 @@ class TestWaveStacking:
         # Supply was decremented.
         assert supplies[("V7", "t1")] == 100 - waves[0].optimal_count
 
+    def test_truncated_plans_advertise_the_waves_that_exist(self, monkeypatch):
+        """Supply can run out mid-plan; the surviving placements must not claim
+        wave 1/2 when only one wave was actually planned."""
+        import travian_api.services.rebalance_planner as rp
+
+        real_sizer = rp.size_wave_with_residual_carry
+
+        def demanding_second_wave(avg_loot, wave_index, cumulative_carry_taken, unit_carry, **kw):
+            if wave_index >= 1:
+                return 999_999, 100  # more troops than any village holds
+            return real_sizer(avg_loot, wave_index, cumulative_carry_taken, unit_carry, **kw)
+
+        monkeypatch.setattr(rp, "size_wave_with_residual_carry", demanding_second_wave)
+
+        # V6 sits far enough that its arrival clears the 15-min wave spacing
+        # and it survives into the greedy pick set as wave 2.
+        vps = [VillagePosition("V7", 30, 82), VillagePosition("V6", 35, 83)]
+        supplies = {("V7", "t1"): 1000, ("V6", "t1"): 100}
+        target = FakeTarget(
+            coord=(31, 83),
+            avg_loot=480.0,
+            total_raids_all_lists=20,
+            last_raid_time_unix=int(NOW - 86400),
+        )
+
+        waves = rp.plan_waves_for_target(target, vps, supplies)
+
+        assert waves, "the first wave must survive the truncation"
+        for wave in waves:
+            assert wave.of_total_waves == len(waves)
+
     def test_dead_floor_returns_empty_plan(self):
         from travian_api.services.rebalance_planner import plan_waves_for_target
 

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -259,6 +259,15 @@ class TestAssignRoleAndListName:
         assert all(r == "MID" for r in roles[3:8])
         assert all(r == "INACTIVE" for r in roles[8:])
 
+    def test_two_placements_keep_the_runner_up_active(self):
+        """Flooring the cut index (int(2*0.80)=1) dropped the 2nd of exactly two
+        placements straight to INACTIVE. The bottom 20% of two targets rounds to
+        zero deactivations, so the runner-up belongs in MID, not INACTIVE."""
+        placements = [self._make_placement(1.0), self._make_placement(0.5)]
+        ordered = assign_role_and_list_name("V1", placements)
+        roles = [p.target_list_role for p in ordered]
+        assert roles == ["HIGH", "MID"]
+
     def test_list_name_uses_display_unit_and_village(self):
         p = self._make_placement(1.0, village="V3")
         assign_role_and_list_name("V3", [p])

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -572,6 +572,32 @@ class TestWaveStacking:
         assert waves[0].wave_index == 1
         assert all(w.of_total_waves == len(waves) for w in waves)
 
+    def test_backfill_reaches_candidates_beyond_the_greedy_slice(self):
+        """Greedy pre-selection excluded candidates inside the spacing window
+        of an undersupplied pick; skipping that pick must reopen its window so
+        slower candidates can fill the wave."""
+        from travian_api.services.rebalance_planner import plan_waves_for_target
+
+        # VA fastest (12min) but one club; VB (19min) sits inside VA's spacing
+        # window so the old greedy slice never contained it; VC at 34min.
+        vps = [
+            VillagePosition("VA", 30, 82),
+            VillagePosition("VB", 33, 84),
+            VillagePosition("VC", 35, 83),
+        ]
+        supplies = {("VA", "t1"): 1, ("VB", "t1"): 1000, ("VC", "t1"): 1000}
+        target = FakeTarget(
+            coord=(31, 83),
+            avg_loot=480.0,
+            total_raids_all_lists=20,
+            last_raid_time_unix=int(NOW - 86400),
+        )
+
+        waves = plan_waves_for_target(target, vps, supplies)
+
+        assert [w.optimal_village for w in waves] == ["VB", "VC"]
+        assert [w.wave_index for w in waves] == [1, 2]
+
     def test_dead_floor_returns_empty_plan(self):
         from travian_api.services.rebalance_planner import plan_waves_for_target
 

--- a/tests/test_recon_authorization.py
+++ b/tests/test_recon_authorization.py
@@ -55,6 +55,21 @@ def test_every_mutating_recon_route_requires_the_operator():
         assert get_instance_operator in dependencies, route.__name__
 
 
+def test_the_operator_check_runs_before_the_session_dependency():
+    """FastAPI resolves dependencies in signature order: if the Travian session
+    comes first, a non-operator without a live session triggers a real
+    auto-reconnect login (or gets the wrong 403) before authorization runs."""
+    from travian_api.web.sessions import get_travian_session
+
+    dependencies = [
+        getattr(parameter.default, "dependency", None)
+        for parameter in inspect.signature(test_recon_credentials).parameters.values()
+    ]
+
+    assert get_instance_operator in dependencies
+    assert dependencies.index(get_instance_operator) < dependencies.index(get_travian_session)
+
+
 def test_status_hides_the_recon_username_from_non_operators():
     recon_account_manager.set_credentials("recon-user", "recon-pass")
     try:

--- a/tests/test_recon_authorization.py
+++ b/tests/test_recon_authorization.py
@@ -1,0 +1,65 @@
+"""The background-account credentials are process-global shared state.
+
+Any authenticated user being able to read the recon username or rotate/clear
+the credentials lets one web user silently break every other user's recon
+setup (Codex review P1). Management is therefore restricted to the instance
+operator — the earliest-registered user.
+"""
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from travian_api.services.recon_account import recon_account_manager
+from travian_api.web.routes.recon import (
+    _status,
+    clear_recon_credentials,
+    get_instance_operator,
+    set_recon_credentials,
+    test_recon_credentials,
+)
+
+
+class _Db:
+    """Answers the min-user-id query and nothing else."""
+
+    def __init__(self, first_id):
+        self.first_id = first_id
+
+    async def execute(self, _query):
+        return SimpleNamespace(scalar=lambda: self.first_id)
+
+
+def test_the_first_registered_user_is_the_operator():
+    user = SimpleNamespace(id=1)
+
+    assert asyncio.run(get_instance_operator(user, _Db(first_id=1))) is user
+
+
+def test_other_users_are_rejected_with_403():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_instance_operator(SimpleNamespace(id=2), _Db(first_id=1)))
+
+    assert exc.value.status_code == 403
+
+
+def test_every_mutating_recon_route_requires_the_operator():
+    for route in (set_recon_credentials, clear_recon_credentials, test_recon_credentials):
+        dependencies = [
+            getattr(parameter.default, "dependency", None)
+            for parameter in inspect.signature(route).parameters.values()
+        ]
+        assert get_instance_operator in dependencies, route.__name__
+
+
+def test_status_hides_the_recon_username_from_non_operators():
+    recon_account_manager.set_credentials("recon-user", "recon-pass")
+    try:
+        assert _status(manageable=True).username == "recon-user"
+        assert _status(manageable=False).username is None
+        assert _status(manageable=False).configured is True
+    finally:
+        recon_account_manager.clear_credentials()

--- a/tests/test_recon_authorization.py
+++ b/tests/test_recon_authorization.py
@@ -19,7 +19,14 @@ from travian_api.web.routes.recon import (
     clear_recon_credentials,
     get_instance_operator,
     set_recon_credentials,
-    test_recon_credentials,
+)
+from travian_api.web.routes.recon import (
+    # Aliased: this is a FastAPI route handler, not a test. Imported under its
+    # own name pytest collects it as one and calls the route body for real,
+    # which "passed" only on machines whose .env happens to configure a
+    # background account and failed in CI with "400: No background account
+    # configured" -- a green local run over a red pipeline.
+    test_recon_credentials as verify_recon_credentials_route,
 )
 
 
@@ -47,7 +54,7 @@ def test_other_users_are_rejected_with_403():
 
 
 def test_every_mutating_recon_route_requires_the_operator():
-    for route in (set_recon_credentials, clear_recon_credentials, test_recon_credentials):
+    for route in (set_recon_credentials, clear_recon_credentials, verify_recon_credentials_route):
         dependencies = [
             getattr(parameter.default, "dependency", None)
             for parameter in inspect.signature(route).parameters.values()
@@ -63,7 +70,7 @@ def test_the_operator_check_runs_before_the_session_dependency():
 
     dependencies = [
         getattr(parameter.default, "dependency", None)
-        for parameter in inspect.signature(test_recon_credentials).parameters.values()
+        for parameter in inspect.signature(verify_recon_credentials_route).parameters.values()
     ]
 
     assert get_instance_operator in dependencies

--- a/tests/test_recon_authorization.py
+++ b/tests/test_recon_authorization.py
@@ -70,6 +70,32 @@ def test_the_operator_check_runs_before_the_session_dependency():
     assert dependencies.index(get_instance_operator) < dependencies.index(get_travian_session)
 
 
+def test_stored_recon_credentials_scope_to_their_server():
+    """The recon account exists on ONE world; using it to mask logins on a
+    different server fails and silently falls back to the primary account,
+    defeating the stealth feature on every non-matching world."""
+    from travian_api.services.recon_account import ReconAccountManager
+
+    manager = ReconAccountManager()
+    manager.set_credentials("recon-user", "pw", server_url="https://ts1.x1.europe.travian.com/")
+
+    assert manager.credentials("https://ts1.x1.europe.travian.com") == ("recon-user", "pw")
+    assert manager.credentials("https://ts2.x1.europe.travian.com") == (None, None)
+    # The UI-level view stays global: the operator sees what is stored.
+    assert manager.is_configured() is True
+    assert manager.get_proxy_username() == "recon-user"
+
+
+def test_unscoped_recon_credentials_apply_to_any_server():
+    """Single-world deployments (and .env credentials) keep working unchanged."""
+    from travian_api.services.recon_account import ReconAccountManager
+
+    manager = ReconAccountManager()
+    manager.set_credentials("recon-user", "pw")
+
+    assert manager.credentials("https://anywhere.travian.com") == ("recon-user", "pw")
+
+
 def test_status_hides_the_recon_username_from_non_operators():
     recon_account_manager.set_credentials("recon-user", "recon-pass")
     try:

--- a/tests/test_scan_center_grid.py
+++ b/tests/test_scan_center_grid.py
@@ -8,9 +8,9 @@ center at (cx - radius, cy - radius) covered the bottom-left
 quadrant only. Tiles north or east of (cx, cy) within the actual
 requested radius were silently outside the fetched window.
 
-Real-world repro: center (42, 17), radius 13. Tile (17, 96) sits
-at distance 10 (well inside r=13) but at y=96 — outside the
-fetched window [60, 90] when the only scan center was (10, 75).
+Repro shape: center (42, 17), radius 13. Tile (36, 25) sits at
+distance 10 (well inside r=13) but north of the centre — outside
+the fetched window when the only scan center was (29, 4).
 """
 
 from __future__ import annotations
@@ -40,26 +40,26 @@ def _coverage_includes(centers: list[tuple[int, int]], x: int, y: int) -> bool:
 
 
 def test_small_radius_centers_on_requested_point() -> None:
-    """The user's actual repro: radius=13 around (42, 17). The fix
-    must put the (sole) scan center AT (42, 17), not at (10, 75)."""
-    centers = _build_scan_centers(23, 88, 13)
+    """The reported repro: radius=13 around (42, 17). The fix must
+    put the (sole) scan center AT (42, 17), not at (29, 4)."""
+    centers = _build_scan_centers(42, 17, 13)
     assert centers == [(42, 17)]
 
 
 def test_small_radius_covers_north_corner_of_radius() -> None:
-    """(17, 96) is at distance 10 from (42, 17) — well inside r=13.
-    The previous algorithm fetched only (10, 75)'s region, which
-    covered y up to 90 only — (17, 96) was outside the window."""
-    centers = _build_scan_centers(23, 88, 13)
-    assert _coverage_includes(centers, 17, 96), (
-        f"(17, 96) should be in fetched region for r=13 around (42, 17); centers were {centers}"
+    """(36, 25) is at distance 10 from (42, 17) — well inside r=13.
+    The previous algorithm fetched only (29, 4)'s region, which
+    stopped short to the north — (36, 25) was outside the window."""
+    centers = _build_scan_centers(42, 17, 13)
+    assert _coverage_includes(centers, 36, 25), (
+        f"(36, 25) should be in fetched region for r=13 around (42, 17); centers were {centers}"
     )
 
 
 def test_small_radius_covers_every_tile_inside_circle() -> None:
     """Every tile within euclidean radius must fall inside at least
     one scan center's 31x31 window. Brute-force check."""
-    cx, cy, r = 23, 88, 13
+    cx, cy, r = 42, 17, 13
     centers = _build_scan_centers(cx, cy, r)
     missing = []
     for x in range(cx - r, cx + r + 1):

--- a/tests/test_status_export_requests.py
+++ b/tests/test_status_export_requests.py
@@ -50,6 +50,15 @@ def _session(http: _RecordingHttp, village_ids: list[int]) -> SimpleNamespace:
     )
 
 
+def test_troop_names_tolerate_an_unknown_tribe():
+    """session.tribe_id falls back to 0 when GraphQL enrichment failed during
+    login; TribeType(0) raised ValueError and 500ed the whole export."""
+    from travian_api.web.routes.status_export import _troop_name
+
+    assert _troop_name(0, "t1") == "t1"
+    assert _troop_name(1, "t1") != "t1"  # a known tribe still resolves names
+
+
 def test_default_export_costs_one_troops_plus_one_dorf1_per_village():
     http = _RecordingHttp()
 

--- a/tests/test_status_export_requests.py
+++ b/tests/test_status_export_requests.py
@@ -85,12 +85,13 @@ def test_including_buildings_adds_one_dorf2_per_village_without_refetching_dorf1
     assert len(set(http.urls)) == len(http.urls)
 
 
+# Real capture, village 20003, 2026-08. Note l4 is negative while l5 is POSITIVE.
 DORF1_STARVING = """
 <html><script>
 var resources = {
-    storage: {l1: 81, l2: 66, l3: 93, l4: 20831},
-    production: {l1: 745, l2: 745, l3: 745, l4: -3292, l5: -6536},
-    maxStorage: {l1: 80000, l2: 80000, l3: 80000, l4: 240000}
+    storage: {l1: 88652, l2: 85167, l3: 93880, l4: 67397},
+    production: {l1: 2875, l2: 3750, l3: 2175, l4: -5556, l5: 1481},
+    maxStorage: {l1: 160000, l2: 160000, l3: 160000, l4: 240000}
 };
 </script></html>
 """
@@ -99,7 +100,7 @@ var resources = {
 GROSS_PRODUCTION_HTML = """
 <table id="production"><tbody>
 <tr><td class="vil"><a href="/dorf1.php?newdid=20003">03</a></td>
-<td>745</td><td>745</td><td>745</td><td>3244</td></tr>
+<td>2875</td><td>3750</td><td>2175</td><td>1481</td></tr>
 </tbody></table>
 """
 
@@ -113,22 +114,50 @@ class _StarvingVillageHttp:
         return "<html></html>"
 
 
-def test_export_reports_net_crop_from_the_village_page():
-    """Crop must be NET of troop feeding, as the game shows it.
-
-    The /village/statistics production table only carries gross crop (+3,244
-    for this village); the real net rate lives in the per-village ``var
-    resources`` blob and is negative (-3,292) when troops outgrow production.
-    """
-    result = asyncio.run(
+def _starving_export() -> dict:
+    return asyncio.run(
         export_player_status(
             include_buildings=False, session=_session(_StarvingVillageHttp(), [20003])
         )
     )
 
-    res = result["villages"][0]["resources"]
-    assert res["crop_per_hour"] == -3292
-    assert res["free_crop"] == -6536
+
+def test_export_reports_net_crop_from_the_village_page():
+    """Crop must be NET of troop feeding, as the game shows it.
+
+    The account-wide production table cannot supply this: it carries gross crop
+    only. The net rate lives in the per-village ``var resources`` blob and is
+    negative when troops outgrow the fields.
+    """
+    res = _starving_export()["villages"][0]["resources"]
+
+    assert res["crop_per_hour"] == -5556
+
+
+def test_export_flags_a_starving_village_from_the_net_rate():
+    """The starvation flag must come from l4, never from l5.
+
+    This village's l5 is +1481 at the same moment its granary is draining at
+    -5,556/h, so a free_crop-based check would call it healthy.
+    """
+    village = _starving_export()["villages"][0]
+
+    assert village["crop"]["starving"] is True
+    assert village["crop"]["net_per_hour"] == -5556
+    # 67,397 crop / 5,556 per hour -- matches the warehouse countdown (43,899s).
+    assert village["crop"]["hours_until_empty"] == 12.13
+    assert village["resources"]["free_crop"] > 0
+
+
+def test_export_does_not_flag_a_healthy_village():
+    http = _RecordingHttp()
+
+    village = asyncio.run(
+        export_player_status(include_buildings=False, session=_session(http, [11]))
+    )["villages"][0]
+
+    assert village["crop"]["starving"] is False
+    assert village["crop"]["hours_until_empty"] is None
 
 
 def test_export_reports_whether_buildings_were_included():

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -152,10 +152,7 @@ def test_saving_the_same_server_twice_updates_instead_of_duplicating(monkeypatch
 
     class _Db:
         async def execute(self, _query):
-            return SimpleNamespace(
-                scalar_one_or_none=lambda: existing,
-                scalars=lambda: SimpleNamespace(first=lambda: existing),
-            )
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [existing]))
 
         def add(self, obj):
             added.append(obj)
@@ -181,36 +178,36 @@ def test_saving_the_same_server_twice_updates_instead_of_duplicating(monkeypatch
     assert res.id == 5
 
 
-def test_resaving_tolerates_duplicate_rows_from_older_databases(monkeypatch):
-    """Legacy databases can hold duplicate rows for one account; resaving the
-    account must update the newest row, not 500 with MultipleResultsFound —
-    these are exactly the users the upsert exists to repair."""
-    from sqlalchemy.exc import MultipleResultsFound
-
+def test_resaving_repairs_legacy_duplicate_rows(monkeypatch):
+    """Legacy databases can hold duplicate rows for one account. Resaving must
+    update the newest row AND delete the stale ones: auto-restore sorts by
+    last_connected, so a more recently stamped older row would otherwise keep
+    shadowing the rotated password forever."""
     monkeypatch.setattr(auth_routes, "encrypt_credential", lambda p: f"enc:{p}")
-    newest = SimpleNamespace(
-        id=9,
-        user_id=1,
-        server_url="https://ts1.x1.europe.travian.com",
-        travian_username="alice",
-        encrypted_password="enc:old",
-        label=None,
-        last_connected=None,
-    )
 
-    class _Result:
-        def scalar_one_or_none(self):
-            raise MultipleResultsFound()
+    def row(row_id, stamped):
+        return SimpleNamespace(
+            id=row_id,
+            user_id=1,
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password="enc:old",
+            label=None,
+            last_connected=stamped,
+        )
 
-        def scalars(self):
-            return SimpleNamespace(first=lambda: newest)
+    newest, stale = row(9, None), row(3, "2026-01-01")
+    deleted = []
 
     class _Db:
         async def execute(self, _query):
-            return _Result()
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [newest, stale]))
 
         def add(self, _obj):
             raise AssertionError("must update the newest duplicate, not insert another")
+
+        async def delete(self, obj):
+            deleted.append(obj)
 
         async def commit(self):
             pass
@@ -228,6 +225,7 @@ def test_resaving_tolerates_duplicate_rows_from_older_databases(monkeypatch):
     res = asyncio.run(auth_routes.save_server(body, SimpleNamespace(id=1), _Db()))
 
     assert newest.encrypted_password == "enc:rotated"
+    assert deleted == [stale], "stale duplicates must be removed so restore cannot pick them"
     assert res.id == 9
 
 

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -152,7 +152,10 @@ def test_saving_the_same_server_twice_updates_instead_of_duplicating(monkeypatch
 
     class _Db:
         async def execute(self, _query):
-            return SimpleNamespace(scalar_one_or_none=lambda: existing)
+            return SimpleNamespace(
+                scalar_one_or_none=lambda: existing,
+                scalars=lambda: SimpleNamespace(first=lambda: existing),
+            )
 
         def add(self, obj):
             added.append(obj)
@@ -176,6 +179,56 @@ def test_saving_the_same_server_twice_updates_instead_of_duplicating(monkeypatch
     assert existing.encrypted_password == "enc:rotated"
     assert existing.label == "main"
     assert res.id == 5
+
+
+def test_resaving_tolerates_duplicate_rows_from_older_databases(monkeypatch):
+    """Legacy databases can hold duplicate rows for one account; resaving the
+    account must update the newest row, not 500 with MultipleResultsFound —
+    these are exactly the users the upsert exists to repair."""
+    from sqlalchemy.exc import MultipleResultsFound
+
+    monkeypatch.setattr(auth_routes, "encrypt_credential", lambda p: f"enc:{p}")
+    newest = SimpleNamespace(
+        id=9,
+        user_id=1,
+        server_url="https://ts1.x1.europe.travian.com",
+        travian_username="alice",
+        encrypted_password="enc:old",
+        label=None,
+        last_connected=None,
+    )
+
+    class _Result:
+        def scalar_one_or_none(self):
+            raise MultipleResultsFound()
+
+        def scalars(self):
+            return SimpleNamespace(first=lambda: newest)
+
+    class _Db:
+        async def execute(self, _query):
+            return _Result()
+
+        def add(self, _obj):
+            raise AssertionError("must update the newest duplicate, not insert another")
+
+        async def commit(self):
+            pass
+
+        async def refresh(self, _obj):
+            pass
+
+    body = auth_routes.SavedServerRequest(
+        server_url="https://ts1.x1.europe.travian.com",
+        username="alice",
+        password="rotated",
+        label=None,
+    )
+
+    res = asyncio.run(auth_routes.save_server(body, SimpleNamespace(id=1), _Db()))
+
+    assert newest.encrypted_password == "enc:rotated"
+    assert res.id == 9
 
 
 def test_stamping_tolerates_duplicate_rows_from_older_databases():

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -107,10 +107,16 @@ def test_saved_server_connect_succeeds_even_if_the_stamp_fails(monkeypatch):
     assert res.connected is True
 
 
-def test_saved_server_connect_stamps_the_password_matching_row(monkeypatch):
-    """connect_saved_server routes its last_connected stamp through the shared
-    duplicate-aware helper: among legacy duplicates the row whose password just
-    authenticated is stamped, not merely whichever row the id lookup returned."""
+def test_saved_server_connect_stamps_the_row_the_user_clicked(monkeypatch):
+    """The card the user pressed must be the card that lights up.
+
+    Routing this stamp through the duplicate-aware _update_last_connected helper
+    looks tidier but is wrong here: the password is decrypted from the clicked
+    row, so every duplicate sharing it matches, and the helper (ordering by id
+    desc) stamped the *other* row -- leaving the clicked card reading stale while
+    an accidental duplicate showed 'just now', and moving which row auto-restore
+    treats as canonical.
+    """
     live = SimpleNamespace(
         server_url="https://ts1.x1.europe.travian.com",
         player_name="Chieftain",
@@ -125,34 +131,34 @@ def test_saved_server_connect_stamps_the_password_matching_row(monkeypatch):
     monkeypatch.setattr(auth_routes.session_manager, "connect", ok_connect)
     monkeypatch.setattr(auth_routes, "decrypt_credential", lambda s: s.removeprefix("enc:"))
 
-    def row(row_id, password):
+    def row(row_id, label):
         return SimpleNamespace(
             id=row_id,
             server_url="https://ts1.x1.europe.travian.com",
             travian_username="alice",
-            encrypted_password=f"enc:{password}",
+            encrypted_password="enc:same-pw",
+            label=label,
             last_connected=None,
         )
 
-    clicked = row(3, "current-pw")  # the row addressed by server_id
-    newest_stale = row(9, "old-pw")  # a legacy duplicate holding the wrong password
-    older_correct = row(3, "current-pw")  # same account/password, distinct object
+    clicked = row(5, "Main")
+    duplicate = row(9, "Accidental duplicate")  # same account AND same password
 
     class _Db:
         async def execute(self, _query):
             return SimpleNamespace(
                 scalar_one_or_none=lambda: clicked,
-                scalars=lambda: SimpleNamespace(all=lambda: [newest_stale, older_correct]),
+                scalars=lambda: SimpleNamespace(all=lambda: [duplicate, clicked]),
             )
 
         async def commit(self):
             pass
 
-    res = asyncio.run(auth_routes.connect_saved_server(3, SimpleNamespace(id=1), _Db()))
+    res = asyncio.run(auth_routes.connect_saved_server(5, SimpleNamespace(id=1), _Db()))
 
     assert res.connected is True
-    assert older_correct.last_connected is not None
-    assert newest_stale.last_connected is None
+    assert clicked.last_connected is not None
+    assert duplicate.last_connected is None
 
 
 def test_status_attempts_a_saved_credential_restore(monkeypatch):

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -365,6 +365,32 @@ def test_stamping_tolerates_duplicate_rows_from_older_databases():
     assert stale.last_connected is None
 
 
+def test_reconnect_restores_from_saved_credentials_when_no_live_session(monkeypatch):
+    """The endpoint advertises reconnecting from the current OR LAST session;
+    after a backend restart there is no in-memory session, which is exactly
+    when a reconnect is needed most."""
+    restored = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        player_name="Chieftain",
+        tribe_id=1,
+        active_village_id=20003,
+        auth_state=SimpleNamespace(
+            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+        ),
+    )
+    monkeypatch.setattr(auth_routes.session_manager, "get", lambda user_id: None)
+
+    async def fake_restore(user_id):
+        return restored
+
+    monkeypatch.setattr(auth_routes, "try_restore_session", fake_restore)
+
+    res = asyncio.run(auth_routes.reconnect(SimpleNamespace(id=1), None))
+
+    assert res.connected is True
+    assert res.player_name == "Chieftain"
+
+
 def test_reconnect_preserves_the_409_from_the_session_manager(monkeypatch):
     live = SimpleNamespace(
         server_url="https://ts1.x1.europe.travian.com",

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -188,6 +188,32 @@ def test_status_attempts_a_saved_credential_restore(monkeypatch):
     assert res.active_village_id == 20003
 
 
+def test_last_connected_serializes_with_a_utc_offset():
+    """SQLite hands DateTime(timezone=True) columns back WITHOUT tzinfo, even
+    though the value was written with datetime.now(UTC). A bare isoformat()
+    then carries no offset, so a browser outside UTC parses the UTC wall time
+    as local and shows a wrong last-connected age."""
+    from datetime import datetime
+
+    from travian_api.web.routes.travian_auth import _credential_to_response
+
+    cred = SimpleNamespace(
+        id=1,
+        server_url="https://ts1.x1.europe.travian.com",
+        travian_username="alice",
+        label=None,
+        # Exactly what SQLite returns: the UTC wall time, tzinfo stripped.
+        last_connected=datetime(2026, 8, 16, 12, 0, 0),
+    )
+
+    rendered = _credential_to_response(cred).last_connected
+
+    assert rendered is not None
+    assert rendered.endswith(("+00:00", "Z")), (
+        f"timestamp has no UTC marker; a non-UTC browser will misread it: {rendered}"
+    )
+
+
 def test_saving_the_same_server_twice_updates_instead_of_duplicating(monkeypatch):
     """Duplicate (user, server, username) rows break last_connected stamping
     (MultipleResultsFound) and let auto-restore pick an older row with an

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -47,7 +47,7 @@ def test_connect_succeeds_even_if_the_last_connected_stamp_fails(monkeypatch):
         tribe_id=1,
         active_village_id=20003,
         auth_state=SimpleNamespace(
-            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+            villages=[SimpleNamespace(id=20003, name="03", x=42, y=17, is_main_village=True)]
         ),
     )
 
@@ -78,7 +78,7 @@ def test_saved_server_connect_succeeds_even_if_the_stamp_fails(monkeypatch):
         tribe_id=1,
         active_village_id=20003,
         auth_state=SimpleNamespace(
-            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+            villages=[SimpleNamespace(id=20003, name="03", x=42, y=17, is_main_village=True)]
         ),
     )
 
@@ -171,7 +171,7 @@ def test_status_attempts_a_saved_credential_restore(monkeypatch):
         tribe_id=1,
         active_village_id=20003,
         auth_state=SimpleNamespace(
-            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+            villages=[SimpleNamespace(id=20003, name="03", x=42, y=17, is_main_village=True)]
         ),
     )
 
@@ -429,7 +429,7 @@ def test_reconnect_restores_from_saved_credentials_when_no_live_session(monkeypa
         tribe_id=1,
         active_village_id=20003,
         auth_state=SimpleNamespace(
-            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+            villages=[SimpleNamespace(id=20003, name="03", x=42, y=17, is_main_village=True)]
         ),
     )
     monkeypatch.setattr(auth_routes.session_manager, "get", lambda user_id: None)

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -391,6 +391,65 @@ def test_reconnect_restores_from_saved_credentials_when_no_live_session(monkeypa
     assert res.player_name == "Chieftain"
 
 
+def test_reconnect_bypasses_the_restore_backoff(monkeypatch):
+    """An explicit reconnect must clear the failed-restore backoff — that
+    throttle exists for per-request auto-reconnects, not an intentional retry
+    the user just clicked."""
+    import travian_api.web.sessions as sessions_module
+
+    monkeypatch.setattr(auth_routes.session_manager, "get", lambda user_id: None)
+    cleared = []
+    monkeypatch.setattr(auth_routes, "reset_restore_backoff", lambda uid: cleared.append(uid))
+
+    restored = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        player_name="Chieftain",
+        tribe_id=1,
+        active_village_id=20003,
+        auth_state=SimpleNamespace(villages=[]),
+    )
+
+    async def fake_restore(user_id):
+        return restored
+
+    monkeypatch.setattr(auth_routes, "try_restore_session", fake_restore)
+    monkeypatch.setattr(
+        sessions_module.session_manager, "clear_explicit_disconnect", lambda uid: None
+    )
+
+    res = asyncio.run(auth_routes.reconnect(SimpleNamespace(id=7), None))
+
+    assert res.connected is True
+    assert cleared == [7]
+
+
+def test_saved_server_connect_422s_on_undecryptable_credentials(monkeypatch):
+    """A row that cannot be decrypted (rotated secret, corrupt legacy row)
+    is a controlled error, not a 500 from an unguarded decrypt."""
+    cred = SimpleNamespace(
+        id=3,
+        user_id=1,
+        server_url="https://ts1.x1.europe.travian.com",
+        travian_username="alice",
+        encrypted_password="corrupt",
+        last_connected=None,
+    )
+
+    def boom(_ciphertext):
+        raise ValueError("invalid token")
+
+    monkeypatch.setattr(auth_routes, "decrypt_credential", boom)
+
+    class _Db:
+        async def execute(self, _query):
+            return SimpleNamespace(scalar_one_or_none=lambda: cred)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth_routes.connect_saved_server(3, SimpleNamespace(id=1), _Db()))
+
+    assert exc.value.status_code == 422
+
+
 def test_reconnect_preserves_the_409_from_the_session_manager(monkeypatch):
     live = SimpleNamespace(
         server_url="https://ts1.x1.europe.travian.com",

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -1,0 +1,51 @@
+"""Connect routes must pass through control-flow HTTPExceptions.
+
+SessionManager raises a 409 when a reconnect would tear a live session out
+from under running operations; the blanket `except Exception` in the connect
+endpoints used to rewrap it as a 502 backend error, hiding an operator action
+the user can actually resolve.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import travian_api.web.routes.travian_auth as auth_routes
+from travian_api.web.routes.travian_auth import TravianConnectRequest
+
+
+def _conflict(**_kwargs):
+    raise HTTPException(status_code=409, detail="Cannot reconnect while operations are running")
+
+
+async def _raise_conflict(**kwargs):
+    _conflict(**kwargs)
+
+
+def test_connect_preserves_the_409_from_the_session_manager(monkeypatch):
+    monkeypatch.setattr(auth_routes.session_manager, "connect", _raise_conflict)
+
+    body = TravianConnectRequest(
+        server_url="https://ts1.x1.europe.travian.com", username="u", password="p"
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth_routes.connect(body, SimpleNamespace(id=1), None))
+
+    assert exc.value.status_code == 409
+
+
+def test_reconnect_preserves_the_409_from_the_session_manager(monkeypatch):
+    live = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        settings=SimpleNamespace(username="u", password="p"),
+    )
+    monkeypatch.setattr(auth_routes.session_manager, "get", lambda user_id: live)
+    monkeypatch.setattr(auth_routes.session_manager, "connect", _raise_conflict)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(auth_routes.reconnect(SimpleNamespace(id=1), None))
+
+    assert exc.value.status_code == 409

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -107,6 +107,54 @@ def test_saved_server_connect_succeeds_even_if_the_stamp_fails(monkeypatch):
     assert res.connected is True
 
 
+def test_saved_server_connect_stamps_the_password_matching_row(monkeypatch):
+    """connect_saved_server routes its last_connected stamp through the shared
+    duplicate-aware helper: among legacy duplicates the row whose password just
+    authenticated is stamped, not merely whichever row the id lookup returned."""
+    live = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        player_name="Chieftain",
+        tribe_id=1,
+        active_village_id=20003,
+        auth_state=SimpleNamespace(villages=[]),
+    )
+
+    async def ok_connect(**kwargs):
+        return live
+
+    monkeypatch.setattr(auth_routes.session_manager, "connect", ok_connect)
+    monkeypatch.setattr(auth_routes, "decrypt_credential", lambda s: s.removeprefix("enc:"))
+
+    def row(row_id, password):
+        return SimpleNamespace(
+            id=row_id,
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password=f"enc:{password}",
+            last_connected=None,
+        )
+
+    clicked = row(3, "current-pw")  # the row addressed by server_id
+    newest_stale = row(9, "old-pw")  # a legacy duplicate holding the wrong password
+    older_correct = row(3, "current-pw")  # same account/password, distinct object
+
+    class _Db:
+        async def execute(self, _query):
+            return SimpleNamespace(
+                scalar_one_or_none=lambda: clicked,
+                scalars=lambda: SimpleNamespace(all=lambda: [newest_stale, older_correct]),
+            )
+
+        async def commit(self):
+            pass
+
+    res = asyncio.run(auth_routes.connect_saved_server(3, SimpleNamespace(id=1), _Db()))
+
+    assert res.connected is True
+    assert older_correct.last_connected is not None
+    assert newest_stale.last_connected is None
+
+
 def test_status_attempts_a_saved_credential_restore(monkeypatch):
     """After a backend restart the frontend's first call is /status; answering
     connected=false without trying the saved-credential restore sends users

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -69,6 +69,44 @@ def test_connect_succeeds_even_if_the_last_connected_stamp_fails(monkeypatch):
     assert res.connected is True
 
 
+def test_saved_server_connect_succeeds_even_if_the_stamp_fails(monkeypatch):
+    """Same contract as /connect: the timestamp is bookkeeping and must not
+    turn a successful saved-server login into a 500."""
+    live = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        player_name="Chieftain",
+        tribe_id=1,
+        active_village_id=20003,
+        auth_state=SimpleNamespace(
+            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+        ),
+    )
+
+    async def ok_connect(**kwargs):
+        return live
+
+    monkeypatch.setattr(auth_routes.session_manager, "connect", ok_connect)
+
+    cred = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        travian_username="alice",
+        encrypted_password="sealed",
+        last_connected=None,
+    )
+    monkeypatch.setattr(auth_routes, "decrypt_credential", lambda _s: "pw")
+
+    class _StampFailsDb:
+        async def execute(self, _query):
+            return SimpleNamespace(scalar_one_or_none=lambda: cred)
+
+        async def commit(self):
+            raise RuntimeError("database is locked")
+
+    res = asyncio.run(auth_routes.connect_saved_server(1, SimpleNamespace(id=1), _StampFailsDb()))
+
+    assert res.connected is True
+
+
 def test_status_attempts_a_saved_credential_restore(monkeypatch):
     """After a backend restart the frontend's first call is /status; answering
     connected=false without trying the saved-credential restore sends users

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -134,6 +134,79 @@ def test_status_attempts_a_saved_credential_restore(monkeypatch):
     assert res.active_village_id == 20003
 
 
+def test_saving_the_same_server_twice_updates_instead_of_duplicating(monkeypatch):
+    """Duplicate (user, server, username) rows break last_connected stamping
+    (MultipleResultsFound) and let auto-restore pick an older row with an
+    outdated password. Saving again must update the existing row."""
+    monkeypatch.setattr(auth_routes, "encrypt_credential", lambda p: f"enc:{p}")
+    existing = SimpleNamespace(
+        id=5,
+        user_id=1,
+        server_url="https://ts1.x1.europe.travian.com",
+        travian_username="alice",
+        encrypted_password="enc:old",
+        label=None,
+        last_connected=None,
+    )
+    added = []
+
+    class _Db:
+        async def execute(self, _query):
+            return SimpleNamespace(scalar_one_or_none=lambda: existing)
+
+        def add(self, obj):
+            added.append(obj)
+
+        async def commit(self):
+            pass
+
+        async def refresh(self, _obj):
+            pass
+
+    body = auth_routes.SavedServerRequest(
+        server_url="https://ts1.x1.europe.travian.com",
+        username="alice",
+        password="rotated",
+        label="main",
+    )
+
+    res = asyncio.run(auth_routes.save_server(body, SimpleNamespace(id=1), _Db()))
+
+    assert added == []
+    assert existing.encrypted_password == "enc:rotated"
+    assert existing.label == "main"
+    assert res.id == 5
+
+
+def test_stamping_tolerates_duplicate_rows_from_older_databases():
+    """Existing databases may already hold duplicates; scalar_one_or_none
+    raised MultipleResultsFound, which the best-effort guard swallowed — so
+    last_connected silently never advanced."""
+    from sqlalchemy.exc import MultipleResultsFound
+
+    cred = SimpleNamespace(last_connected=None)
+
+    class _Result:
+        def scalar_one_or_none(self):
+            raise MultipleResultsFound()
+
+        def scalars(self):
+            return SimpleNamespace(first=lambda: cred)
+
+    class _Db:
+        async def execute(self, _query):
+            return _Result()
+
+        async def commit(self):
+            pass
+
+    asyncio.run(
+        auth_routes._update_last_connected(_Db(), 1, "https://ts1.x1.europe.travian.com", "alice")
+    )
+
+    assert cred.last_connected is not None
+
+
 def test_reconnect_preserves_the_409_from_the_session_manager(monkeypatch):
     live = SimpleNamespace(
         server_url="https://ts1.x1.europe.travian.com",

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -229,24 +229,60 @@ def test_resaving_repairs_legacy_duplicate_rows(monkeypatch):
     assert res.id == 9
 
 
-def test_stamping_tolerates_duplicate_rows_from_older_databases():
-    """Existing databases may already hold duplicates; scalar_one_or_none
-    raised MultipleResultsFound, which the best-effort guard swallowed — so
-    last_connected silently never advanced."""
-    from sqlalchemy.exc import MultipleResultsFound
-
-    cred = SimpleNamespace(last_connected=None)
-
-    class _Result:
-        def scalar_one_or_none(self):
-            raise MultipleResultsFound()
-
-        def scalars(self):
-            return SimpleNamespace(first=lambda: cred)
+def test_resaving_with_a_trailing_slash_updates_the_same_row(monkeypatch):
+    """The runtime identity normalizes server URLs with rstrip('/'); the saved
+    rows must dedupe the same way or a trailing slash forks a second row and
+    auto-restore can pick the stale password."""
+    monkeypatch.setattr(auth_routes, "encrypt_credential", lambda p: f"enc:{p}")
+    existing = SimpleNamespace(
+        id=5,
+        user_id=1,
+        server_url="https://ts1.x1.europe.travian.com/",
+        travian_username="alice",
+        encrypted_password="enc:old",
+        label=None,
+        last_connected=None,
+    )
+    added = []
 
     class _Db:
         async def execute(self, _query):
-            return _Result()
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [existing]))
+
+        def add(self, obj):
+            added.append(obj)
+
+        async def commit(self):
+            pass
+
+        async def refresh(self, _obj):
+            pass
+
+    body = auth_routes.SavedServerRequest(
+        server_url="https://ts1.x1.europe.travian.com",  # no trailing slash
+        username="alice",
+        password="rotated",
+        label=None,
+    )
+
+    res = asyncio.run(auth_routes.save_server(body, SimpleNamespace(id=1), _Db()))
+
+    assert added == []
+    assert existing.encrypted_password == "enc:rotated"
+    assert existing.server_url == "https://ts1.x1.europe.travian.com"  # repaired in place
+    assert res.id == 5
+
+
+def test_stamping_matches_across_trailing_slashes():
+    cred = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com/",
+        travian_username="alice",
+        last_connected=None,
+    )
+
+    class _Db:
+        async def execute(self, _query):
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [cred]))
 
         async def commit(self):
             pass
@@ -256,6 +292,37 @@ def test_stamping_tolerates_duplicate_rows_from_older_databases():
     )
 
     assert cred.last_connected is not None
+
+
+def test_stamping_tolerates_duplicate_rows_from_older_databases():
+    """Existing databases may already hold duplicates; stamping must update
+    the newest matching row instead of erroring out (the old
+    scalar_one_or_none raised MultipleResultsFound, silently swallowed by the
+    best-effort guard, so last_connected never advanced)."""
+
+    def row(row_id):
+        return SimpleNamespace(
+            id=row_id,
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            last_connected=None,
+        )
+
+    newest, stale = row(9), row(3)
+
+    class _Db:
+        async def execute(self, _query):
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [newest, stale]))
+
+        async def commit(self):
+            pass
+
+    asyncio.run(
+        auth_routes._update_last_connected(_Db(), 1, "https://ts1.x1.europe.travian.com", "alice")
+    )
+
+    assert newest.last_connected is not None
+    assert stale.last_connected is None
 
 
 def test_reconnect_preserves_the_409_from_the_session_manager(monkeypatch):

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -37,6 +37,33 @@ def test_connect_preserves_the_409_from_the_session_manager(monkeypatch):
     assert exc.value.status_code == 409
 
 
+def test_status_attempts_a_saved_credential_restore(monkeypatch):
+    """After a backend restart the frontend's first call is /status; answering
+    connected=false without trying the saved-credential restore sends users
+    back to /connect despite the advertised seamless recovery."""
+    restored = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        player_name="Chieftain",
+        tribe_id=1,
+        active_village_id=20003,
+        auth_state=SimpleNamespace(
+            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+        ),
+    )
+
+    monkeypatch.setattr(auth_routes.session_manager, "get", lambda user_id: None)
+
+    async def fake_restore(user_id):
+        return restored
+
+    monkeypatch.setattr(auth_routes, "try_restore_session", fake_restore, raising=False)
+
+    res = asyncio.run(auth_routes.get_status(SimpleNamespace(id=1)))
+
+    assert res.connected is True
+    assert res.active_village_id == 20003
+
+
 def test_reconnect_preserves_the_409_from_the_session_manager(monkeypatch):
     live = SimpleNamespace(
         server_url="https://ts1.x1.europe.travian.com",

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -294,6 +294,46 @@ def test_stamping_matches_across_trailing_slashes():
     assert cred.last_connected is not None
 
 
+def test_stamping_prefers_the_row_whose_password_actually_logged_in(monkeypatch):
+    """Legacy duplicates can hold different passwords; bumping last_connected
+    on the newest row regardless keeps auto-restore pinned to the stale
+    password even though the user just proved which one works."""
+    monkeypatch.setattr(auth_routes, "decrypt_credential", lambda s: s.removeprefix("enc:"))
+
+    def row(row_id, password):
+        return SimpleNamespace(
+            id=row_id,
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password=f"enc:{password}",
+            last_connected=None,
+        )
+
+    newest_stale, older_correct = row(9, "old-pw"), row(3, "current-pw")
+
+    class _Db:
+        async def execute(self, _query):
+            return SimpleNamespace(
+                scalars=lambda: SimpleNamespace(all=lambda: [newest_stale, older_correct])
+            )
+
+        async def commit(self):
+            pass
+
+    asyncio.run(
+        auth_routes._update_last_connected(
+            _Db(),
+            1,
+            "https://ts1.x1.europe.travian.com",
+            "alice",
+            password="current-pw",
+        )
+    )
+
+    assert older_correct.last_connected is not None
+    assert newest_stale.last_connected is None
+
+
 def test_stamping_tolerates_duplicate_rows_from_older_databases():
     """Existing databases may already hold duplicates; stamping must update
     the newest matching row instead of erroring out (the old

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -37,6 +37,38 @@ def test_connect_preserves_the_409_from_the_session_manager(monkeypatch):
     assert exc.value.status_code == 409
 
 
+def test_connect_succeeds_even_if_the_last_connected_stamp_fails(monkeypatch):
+    """The timestamp is bookkeeping: a DB hiccup after the Travian login
+    succeeded must not report the connect as failed while the live session
+    sits installed in the manager."""
+    live = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        player_name="Chieftain",
+        tribe_id=1,
+        active_village_id=20003,
+        auth_state=SimpleNamespace(
+            villages=[SimpleNamespace(id=20003, name="03", x=23, y=88, is_main_village=True)]
+        ),
+    )
+
+    async def ok_connect(**kwargs):
+        return live
+
+    monkeypatch.setattr(auth_routes.session_manager, "connect", ok_connect)
+
+    class _BrokenDb:
+        async def execute(self, _query):
+            raise RuntimeError("database is locked")
+
+    body = TravianConnectRequest(
+        server_url="https://ts1.x1.europe.travian.com", username="u", password="p"
+    )
+
+    res = asyncio.run(auth_routes.connect(body, SimpleNamespace(id=1), _BrokenDb()))
+
+    assert res.connected is True
+
+
 def test_status_attempts_a_saved_credential_restore(monkeypatch):
     """After a backend restart the frontend's first call is /status; answering
     connected=false without trying the saved-credential restore sends users

--- a/tests/test_travian_auth_routes.py
+++ b/tests/test_travian_auth_routes.py
@@ -391,6 +391,38 @@ def test_reconnect_restores_from_saved_credentials_when_no_live_session(monkeypa
     assert res.player_name == "Chieftain"
 
 
+def test_successful_connect_clears_the_restore_backoff(monkeypatch):
+    """A proven-good explicit login must clear any failed-restore backoff so a
+    session that vanishes again can auto-restore immediately."""
+    cleared = []
+    monkeypatch.setattr(auth_routes, "reset_restore_backoff", lambda uid: cleared.append(uid))
+
+    live = SimpleNamespace(
+        server_url="https://ts1.x1.europe.travian.com",
+        player_name="Chieftain",
+        tribe_id=1,
+        active_village_id=20003,
+        auth_state=SimpleNamespace(villages=[]),
+    )
+
+    async def ok_connect(**kwargs):
+        return live
+
+    monkeypatch.setattr(auth_routes.session_manager, "connect", ok_connect)
+
+    class _NoRowDb:
+        async def execute(self, _query):
+            return SimpleNamespace(scalars=lambda: SimpleNamespace(all=list))
+
+    body = TravianConnectRequest(
+        server_url="https://ts1.x1.europe.travian.com", username="u", password="p"
+    )
+
+    asyncio.run(auth_routes.connect(body, SimpleNamespace(id=9), _NoRowDb()))
+
+    assert cleared == [9]
+
+
 def test_reconnect_bypasses_the_restore_backoff(monkeypatch):
     """An explicit reconnect must clear the failed-restore backoff — that
     throttle exists for per-request auto-reconnects, not an intentional retry

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -1,0 +1,106 @@
+"""SSRF guard for user-supplied server URLs.
+
+The backend logs into whatever URL the user supplies and follows its
+redirects. These tests pin that loopback, private and link-local targets are
+refused in every disguise: wrong scheme, IP literal, custom port, and -- the
+one format checks cannot catch -- a public DNS name resolving to a private
+address.
+"""
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+import travian_api.web.url_guard as url_guard
+from travian_api.web.url_guard import ensure_safe_server_url
+
+
+def _check(url: str) -> None:
+    asyncio.run(ensure_safe_server_url(url))
+
+
+def _expect_reject(url: str, reason_fragment: str) -> None:
+    with pytest.raises(HTTPException) as exc:
+        _check(url)
+    assert exc.value.status_code == 400
+    assert reason_fragment in exc.value.detail, exc.value.detail
+
+
+class TestFormatRules:
+    def test_plain_http_is_refused(self):
+        _expect_reject("http://ts1.x1.europe.travian.com", "https")
+
+    def test_ip_literals_are_refused_even_public_ones(self):
+        _expect_reject("https://127.0.0.1", "hostname, not an IP")
+        _expect_reject("https://10.0.0.5", "hostname, not an IP")
+        _expect_reject("https://[::1]", "hostname, not an IP")
+        _expect_reject("https://8.8.8.8", "hostname, not an IP")
+
+    def test_custom_ports_are_refused(self):
+        _expect_reject("https://ts1.x1.europe.travian.com:8000", "default https port")
+
+    def test_embedded_credentials_are_refused(self):
+        _expect_reject("https://user:pw@ts1.x1.europe.travian.com", "credentials")
+
+    def test_a_schemeless_string_is_refused(self):
+        _expect_reject("ts1.x1.europe.travian.com", "https")
+
+
+class TestResolvedAddresses:
+    def test_a_public_name_resolving_private_is_refused(self, monkeypatch):
+        """The DNS-rebinding shape: innocent-looking public hostname, A record
+        pointing into the LAN. Format checks pass; resolution must not."""
+
+        async def resolves_private(host):
+            return ["192.168.1.10"]
+
+        monkeypatch.setattr(url_guard, "_resolve_host", resolves_private)
+        _expect_reject("https://innocent.example.com", "private or local")
+
+    def test_loopback_and_linklocal_resolutions_are_refused(self, monkeypatch):
+        for address in ["127.0.0.1", "169.254.1.1", "::1", "fe80::1%eth0"]:
+
+            async def resolves(host, _address=address):
+                return [_address]
+
+            monkeypatch.setattr(url_guard, "_resolve_host", resolves)
+            _expect_reject("https://innocent.example.com", "private or local")
+
+    def test_one_private_address_amongst_public_ones_is_refused(self, monkeypatch):
+        async def resolves_mixed(host):
+            return ["8.8.8.8", "10.0.0.1"]
+
+        monkeypatch.setattr(url_guard, "_resolve_host", resolves_mixed)
+        _expect_reject("https://innocent.example.com", "private or local")
+
+    def test_an_unresolvable_name_is_refused(self, monkeypatch):
+        import socket
+
+        async def cannot_resolve(host):
+            raise socket.gaierror("no such host")
+
+        monkeypatch.setattr(url_guard, "_resolve_host", cannot_resolve)
+        _expect_reject("https://no-such-world.travian.com", "resolved")
+
+    def test_a_real_public_travian_url_passes(self, monkeypatch):
+        async def resolves_public(host):
+            return ["8.8.8.8"]
+
+        monkeypatch.setattr(url_guard, "_resolve_host", resolves_public)
+        _check("https://ts20.x2.europe.travian.com")
+        _check("https://ts20.x2.europe.travian.com/")
+
+
+class TestConnectIsGuarded:
+    def test_session_manager_refuses_a_private_target_before_logging_in(self):
+        """The guard must run before any session object exists: a refused URL
+        performs zero network actions against the target."""
+        from travian_api.web.sessions import SessionManager
+
+        manager = SessionManager()
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(manager.connect(1, "http://127.0.0.1:8000", "u", "p"))
+
+        assert exc.value.status_code == 400
+        assert manager.get(1) is None

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -47,6 +47,29 @@ class TestFormatRules:
         _expect_reject("ts1.x1.europe.travian.com", "https")
 
 
+class TestHostAllowlist:
+    def test_a_public_but_non_travian_host_is_refused(self):
+        """The phishing shape: a plausible, publicly-resolvable host that is
+        not Travian. The address checks would pass it; the allowlist must not,
+        or the user's Travian credentials get POSTed to the attacker."""
+        _expect_reject("https://travian-login.example.com", "not an allowed Travian host")
+
+    def test_a_lookalike_suffix_is_refused(self):
+        # endswith must be on a dot boundary: nottravian.com is not travian.com
+        _expect_reject("https://nottravian.com", "not an allowed Travian host")
+
+    def test_the_allowlist_is_configurable(self, monkeypatch):
+        monkeypatch.setattr(
+            url_guard.settings, "allowed_server_hosts", "travian.com,myfanserver.net"
+        )
+
+        async def resolves_public(host):
+            return ["8.8.8.8"]
+
+        monkeypatch.setattr(url_guard, "_resolve_host", resolves_public)
+        _check("https://play.myfanserver.net")
+
+
 class TestResolvedAddresses:
     def test_a_public_name_resolving_private_is_refused(self, monkeypatch):
         """The DNS-rebinding shape: innocent-looking public hostname, A record
@@ -56,7 +79,7 @@ class TestResolvedAddresses:
             return ["192.168.1.10"]
 
         monkeypatch.setattr(url_guard, "_resolve_host", resolves_private)
-        _expect_reject("https://innocent.example.com", "private or local")
+        _expect_reject("https://ts5.x1.internal.travian.com", "private or local")
 
     def test_loopback_and_linklocal_resolutions_are_refused(self, monkeypatch):
         for address in ["127.0.0.1", "169.254.1.1", "::1", "fe80::1%eth0"]:
@@ -65,14 +88,14 @@ class TestResolvedAddresses:
                 return [_address]
 
             monkeypatch.setattr(url_guard, "_resolve_host", resolves)
-            _expect_reject("https://innocent.example.com", "private or local")
+            _expect_reject("https://ts5.x1.internal.travian.com", "private or local")
 
     def test_one_private_address_amongst_public_ones_is_refused(self, monkeypatch):
         async def resolves_mixed(host):
             return ["8.8.8.8", "10.0.0.1"]
 
         monkeypatch.setattr(url_guard, "_resolve_host", resolves_mixed)
-        _expect_reject("https://innocent.example.com", "private or local")
+        _expect_reject("https://ts5.x1.internal.travian.com", "private or local")
 
     def test_an_unresolvable_name_is_refused(self, monkeypatch):
         import socket

--- a/tests/test_url_guard.py
+++ b/tests/test_url_guard.py
@@ -127,3 +127,17 @@ class TestConnectIsGuarded:
 
         assert exc.value.status_code == 400
         assert manager.get(1) is None
+
+    def test_the_locked_core_validates_so_restore_paths_are_covered(self):
+        """Auto-restore replays a saved URL by calling _connect_locked directly.
+        The guard lives there (not only in connect()), so a saved host that is
+        now unsafe -- moved DNS, or a legacy row from before the guard -- is
+        rejected at connection time rather than trusted."""
+        from travian_api.web.sessions import SessionManager
+
+        manager = SessionManager()
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(manager._connect_locked(1, "https://192.168.0.5", "u", "p"))
+
+        assert exc.value.status_code == 400
+        assert manager.get(1) is None

--- a/tests/test_user_registration.py
+++ b/tests/test_user_registration.py
@@ -60,7 +60,29 @@ def test_login_with_an_overlong_password_is_401_not_500():
 
 
 def test_losing_a_registration_race_returns_409_not_500():
+    # Called directly (not through FastAPI), so the Depends-injected limiter
+    # never runs; a stub Request satisfies the added positional parameter.
+    request = SimpleNamespace(state=SimpleNamespace(), client=SimpleNamespace(host="127.0.0.1"))
     with pytest.raises(HTTPException) as exc:
-        asyncio.run(register(UserCreate(username="dup", password="hunter2"), _RacingDb()))
+        asyncio.run(register(UserCreate(username="dup", password="hunter2"), request, _RacingDb()))
 
     assert exc.value.status_code == 409
+
+
+def test_auth_endpoints_are_rate_limited_by_ip():
+    """A flood of unauthenticated register/login calls from one IP must be
+    throttled: each runs bcrypt, so an unlimited burst is both a DoS on the
+    event loop and a brute-force channel."""
+    from travian_api.web.rate_limit import RateLimiter
+
+    limiter = RateLimiter(max_calls=3, window_seconds=60)
+    request = SimpleNamespace(state=SimpleNamespace(), client=SimpleNamespace(host="10.1.1.1"))
+
+    async def hammer():
+        for _ in range(3):
+            await limiter(request)  # within budget
+        await limiter(request)  # the fourth trips it
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(hammer())
+    assert exc.value.status_code == 429

--- a/tests/test_user_registration.py
+++ b/tests/test_user_registration.py
@@ -1,0 +1,38 @@
+"""Concurrent registration must resolve deterministically.
+
+The duplicate check is read-then-insert while users.username is also unique at
+the database level: two simultaneous /register calls for one name can both pass
+the SELECT, and the loser used to surface the IntegrityError as a 500.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+from travian_api.web.routes.users import UserCreate, register
+
+
+class _RacingDb:
+    """Passes the duplicate SELECT but loses the insert race on commit."""
+
+    async def execute(self, _query):
+        return SimpleNamespace(scalar_one_or_none=lambda: None)
+
+    def add(self, _user):
+        pass
+
+    async def commit(self):
+        raise IntegrityError("INSERT INTO users", {}, Exception("UNIQUE constraint failed"))
+
+    async def rollback(self):
+        pass
+
+
+def test_losing_a_registration_race_returns_409_not_500():
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(register(UserCreate(username="dup", password="hunter2"), _RacingDb()))
+
+    assert exc.value.status_code == 409

--- a/tests/test_user_registration.py
+++ b/tests/test_user_registration.py
@@ -31,6 +31,34 @@ class _RacingDb:
         pass
 
 
+def test_a_long_password_is_rejected_with_422_not_a_500():
+    """bcrypt 5 raises ValueError for passwords over 72 BYTES. Without a
+    byte-aware limit on the model, a long (or emoji-heavy: 4 bytes each)
+    password sails through validation and detonates inside hash_password(),
+    turning a user mistake into a server error."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        UserCreate(username="longpass", password="x" * 73)
+
+    # Byte-aware, not character-aware: 19 four-byte emoji = 76 bytes.
+    with pytest.raises(pydantic.ValidationError):
+        UserCreate(username="emoji", password="\U0001f600" * 19)
+
+    # 72 bytes exactly is bcrypt's limit and must still be accepted.
+    UserCreate(username="edge", password="x" * 72)
+
+
+def test_login_with_an_overlong_password_is_401_not_500():
+    """An existing user typing garbage past 72 bytes must get the normal
+    invalid-credentials answer, not a traceback from bcrypt.checkpw."""
+    from travian_api.web.auth import hash_password, verify_password
+
+    hashed = hash_password("correct-password")
+
+    assert verify_password("x" * 100, hashed) is False
+
+
 def test_losing_a_registration_race_returns_409_not_500():
     with pytest.raises(HTTPException) as exc:
         asyncio.run(register(UserCreate(username="dup", password="hunter2"), _RacingDb()))

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -47,27 +47,45 @@ class TestVillageContext:
 
 
 class TestVillageSwitch:
-    def test_switch_updates_the_session_default(self):
-        """GET /api/villages and /api/travian/status derive active_village_id
-        from the session; leaving it stale after /switch means a status refresh
-        or a fresh tab shows the old village as active. Explicit village_id
-        parameters on action routes keep per-tab isolation regardless."""
+    def test_switch_is_tab_local_and_does_not_mutate_shared_state(self):
+        """The active village is per-tab. Mutating session.active_village_id
+        would let one tab retarget every other tab's fallback village, and a
+        fallback firing on the wrong village costs a corrective Travian
+        re-fetch — extra requests and an irregular fingerprint. The response
+        still echoes the caller's own choice."""
         from travian_api.web.routes.villages import SwitchVillageRequest, switch_village
 
         session = SimpleNamespace(
             active_village_id=111,
             auth_state=SimpleNamespace(
                 villages=[
-                    SimpleNamespace(id=111, name="Old", x=0, y=0, is_main_village=True),
-                    SimpleNamespace(id=222, name="New", x=5, y=5, is_main_village=False),
+                    SimpleNamespace(id=111, name="Login", x=0, y=0, is_main_village=True),
+                    SimpleNamespace(id=222, name="Other", x=5, y=5, is_main_village=False),
                 ]
             ),
         )
 
         res = asyncio.run(switch_village(SwitchVillageRequest(village_id=222), session))
 
-        assert res.active_village_id == 222
-        assert session.active_village_id == 222
+        assert res.active_village_id == 222  # the caller's tab-local truth
+        assert session.active_village_id == 111  # shared default untouched
+
+    def test_switch_rejects_a_village_the_player_does_not_own(self):
+        from fastapi import HTTPException
+
+        from travian_api.web.routes.villages import SwitchVillageRequest, switch_village
+
+        session = SimpleNamespace(
+            active_village_id=111,
+            auth_state=SimpleNamespace(
+                villages=[SimpleNamespace(id=111, name="Login", x=0, y=0, is_main_village=True)]
+            ),
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(switch_village(SwitchVillageRequest(village_id=999), session))
+
+        assert exc.value.status_code == 404
 
 
 class TestSessionCacheIsolation:

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -584,6 +584,51 @@ class TestHttpReconnectBackoff:
         assert len(attempts) == 1, "second request re-attempted a real login during backoff"
 
 
+class TestRestoreBackoffOnPreLoginFailure:
+    def test_a_corrupt_credential_backs_off_like_a_failed_login(self, monkeypatch):
+        """A decrypt/DB error before the login step must set the backoff too, or
+        reconnecting sockets repeat the restore work on every retry."""
+        import travian_api.web.auth as auth_module
+        import travian_api.web.models.db as db_module
+        import travian_api.web.sessions as sessions_module
+
+        fresh = sessions_module.SessionManager()
+        monkeypatch.setattr(sessions_module, "session_manager", fresh)
+        backoff = {}
+        monkeypatch.setattr(sessions_module, "_restore_backoff", backoff, raising=False)
+
+        def boom(_ciphertext):
+            raise ValueError("invalid token")
+
+        monkeypatch.setattr(auth_module, "decrypt_credential", boom)
+
+        cred = SimpleNamespace(
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password="corrupt",
+            last_connected=None,
+        )
+
+        class _FakeDb:
+            async def execute(self, _query):
+                return SimpleNamespace(scalar_one_or_none=lambda: cred)
+
+        class _FakeFactory:
+            def __call__(self):
+                return self
+
+            async def __aenter__(self):
+                return _FakeDb()
+
+            async def __aexit__(self, *args):
+                return False
+
+        monkeypatch.setattr(db_module, "async_session_factory", _FakeFactory())
+
+        assert asyncio.run(sessions_module.try_restore_session(7)) is None
+        assert 7 in backoff  # backoff armed, so the next socket retry is throttled
+
+
 class TestRestoreBackoff:
     def test_a_failed_restore_is_not_retried_on_every_poll(self, monkeypatch):
         """/status polls call try_restore_session whenever no session exists;

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -70,6 +70,34 @@ class TestVillageSwitch:
         assert res.active_village_id == 222  # the caller's tab-local truth
         assert session.active_village_id == 111  # shared default untouched
 
+    def test_list_reflects_the_callers_tab_local_selection(self):
+        """The switch/list pair must round-trip: passing the tab's selection
+        to /api/villages marks it active, not the stale login default."""
+        from travian_api.web.routes.villages import list_villages
+
+        session = SimpleNamespace(
+            active_village_id=111,
+            auth_state=SimpleNamespace(
+                villages=[
+                    SimpleNamespace(id=111, name="Login", x=0, y=0, is_main_village=True),
+                    SimpleNamespace(id=222, name="Other", x=5, y=5, is_main_village=False),
+                ]
+            ),
+        )
+
+        res = asyncio.run(list_villages(active_village_id=222, session=session))
+
+        assert res.active_village_id == 222
+        assert [v.id for v in res.villages if v.is_active] == [222]
+
+        # Without an override, the server default is reported.
+        res_default = asyncio.run(list_villages(active_village_id=None, session=session))
+        assert res_default.active_village_id == 111
+
+        # An unowned override is ignored, falling back to the default.
+        res_bad = asyncio.run(list_villages(active_village_id=999, session=session))
+        assert res_bad.active_village_id == 111
+
     def test_switch_rejects_a_village_the_player_does_not_own(self):
         from fastapi import HTTPException
 

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -46,6 +46,24 @@ class TestVillageContext:
         assert exc.value.status_code == 400
 
 
+class TestSessionCacheIsolation:
+    def test_cache_files_are_keyed_by_travian_identity_not_just_web_user(self):
+        """A web user reconnecting to the same world with DIFFERENT Travian
+        credentials must not resume the previous account's cached JWT/cookies —
+        that silently authenticates the wrong player until the cache expires."""
+        from travian_api.web.sessions import TravianSession
+
+        server = "https://ts1.x1.europe.travian.com"
+        alice = TravianSession(1, server, "alice", "pw-a")
+        bob = TravianSession(1, server, "bob", "pw-b")
+        alice_again = TravianSession(1, server, "alice", "pw-a")
+
+        assert alice.settings.jwt_cache_path != bob.settings.jwt_cache_path
+        assert alice._cookie_file != bob._cookie_file
+        # Same identity still shares its cache, so stealth session resume works.
+        assert alice.settings.jwt_cache_path == alice_again.settings.jwt_cache_path
+
+
 class _StubSession:
     """Stands in for TravianSession; login outcome is configurable."""
 

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -46,6 +46,30 @@ class TestVillageContext:
         assert exc.value.status_code == 400
 
 
+class TestVillageSwitch:
+    def test_switch_updates_the_session_default(self):
+        """GET /api/villages and /api/travian/status derive active_village_id
+        from the session; leaving it stale after /switch means a status refresh
+        or a fresh tab shows the old village as active. Explicit village_id
+        parameters on action routes keep per-tab isolation regardless."""
+        from travian_api.web.routes.villages import SwitchVillageRequest, switch_village
+
+        session = SimpleNamespace(
+            active_village_id=111,
+            auth_state=SimpleNamespace(
+                villages=[
+                    SimpleNamespace(id=111, name="Old", x=0, y=0, is_main_village=True),
+                    SimpleNamespace(id=222, name="New", x=5, y=5, is_main_village=False),
+                ]
+            ),
+        )
+
+        res = asyncio.run(switch_village(SwitchVillageRequest(village_id=222), session))
+
+        assert res.active_village_id == 222
+        assert session.active_village_id == 222
+
+
 class TestSessionCacheIsolation:
     def test_cache_files_are_keyed_by_travian_identity_not_just_web_user(self):
         """A web user reconnecting to the same world with DIFFERENT Travian

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -419,6 +419,96 @@ class TestRestoreSessionBookkeeping:
         assert result is live
 
 
+class TestConnectVsOperationStartRace:
+    def test_an_operation_starting_during_the_login_still_blocks_the_swap(self, monkeypatch):
+        """The pre-login guard only snapshots; a job started while the login
+        was in flight would still have its HttpClient closed by the swap. The
+        re-check inside the install lock must catch it and tear down the fresh
+        session instead."""
+        from fastapi import HTTPException
+
+        import travian_api.operation_manager as op_module
+        import travian_api.web.sessions as sessions_module
+
+        manager = SessionManager()
+        old = SimpleNamespace(server_url="https://ts1.x1.europe.travian.com")
+        manager._sessions[1] = old
+
+        class _RunningTask:
+            def done(self):
+                return False
+
+        calls = []
+
+        def ops_appear_after_the_precheck(user_id):
+            calls.append(1)
+            if len(calls) == 1:
+                return []  # pre-login snapshot: nothing running yet
+            return [SimpleNamespace(label="farm-loop", task=_RunningTask())]
+
+        monkeypatch.setattr(
+            op_module.operation_manager, "list_for_user", ops_appear_after_the_precheck
+        )
+        monkeypatch.setattr(sessions_module, "TravianSession", _StubSession)
+        _StubSession.instances.clear()
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(manager.connect(1, "https://ts1.x1.europe.travian.com", "u", "p"))
+
+        assert exc.value.status_code == 409
+        assert manager.get(1) is old
+        # The freshly logged-in session must not leak its HttpClient.
+        assert _StubSession.instances[-1].disconnected is True
+
+
+class TestHttpReconnectBackoff:
+    def test_failed_http_reconnects_are_not_retried_per_request(self, monkeypatch):
+        """A page load fans out several protected API calls; each one running a
+        real login against stale credentials or a downed world is the same
+        login storm the /status path already avoids."""
+        from fastapi import HTTPException
+
+        import travian_api.web.auth as auth_module
+        import travian_api.web.sessions as sessions_module
+
+        fresh = SessionManager()
+        monkeypatch.setattr(sessions_module, "session_manager", fresh)
+        monkeypatch.setattr(sessions_module, "_restore_backoff", {}, raising=False)
+
+        attempts = []
+
+        async def failing_connect(**kwargs):
+            attempts.append(1)
+            raise RuntimeError("login blocked")
+
+        monkeypatch.setattr(fresh, "connect", failing_connect)
+        monkeypatch.setattr(fresh, "_connect_locked", failing_connect, raising=False)
+        monkeypatch.setattr(auth_module, "decrypt_credential", lambda _s: "pw")
+
+        cred = SimpleNamespace(
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password="sealed",
+            last_connected=None,
+        )
+
+        class _FakeDb:
+            async def execute(self, _query):
+                return SimpleNamespace(scalar_one_or_none=lambda: cred)
+
+            async def commit(self):
+                pass
+
+        user = SimpleNamespace(id=7)
+
+        for _ in range(2):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(sessions_module.get_travian_session(user, _FakeDb()))
+            assert exc.value.status_code == 403
+
+        assert len(attempts) == 1, "second request re-attempted a real login during backoff"
+
+
 class TestRestoreBackoff:
     def test_a_failed_restore_is_not_retried_on_every_poll(self, monkeypatch):
         """/status polls call try_restore_session whenever no session exists;

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -16,6 +16,22 @@ from travian_api.web.routes.buildings import ConstructRequest, UpgradeRequest
 from travian_api.web.sessions import SessionManager, try_restore_session
 
 
+class TestRequireVillageId:
+    def test_missing_village_id_is_a_400(self):
+        from fastapi import HTTPException
+
+        from travian_api.web.sessions import require_village_id
+
+        with pytest.raises(HTTPException) as exc:
+            require_village_id(None)
+        assert exc.value.status_code == 400
+
+    def test_explicit_village_id_passes_through(self):
+        from travian_api.web.sessions import require_village_id
+
+        assert require_village_id(20003) == 20003
+
+
 class TestVillageContext:
     def test_upgrade_request_carries_the_target_village(self):
         body = UpgradeRequest(slot_id=1, village_id=20003)

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -1,0 +1,155 @@
+"""Village-context and session-recovery regressions (Codex review round 3).
+
+Since /api/villages/switch became client-side-only, `session.active_village_id`
+is pinned to the login village forever. Any action route without an explicit
+`village_id` therefore executes against a village the UI is not showing.
+Reconnects likewise must not destroy a working session on failure, and
+WebSocket auth must be able to restore a session the way HTTP dependencies do.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from travian_api.web.routes.buildings import ConstructRequest, UpgradeRequest
+from travian_api.web.sessions import SessionManager, try_restore_session
+
+
+class TestVillageContext:
+    def test_upgrade_request_carries_the_target_village(self):
+        body = UpgradeRequest(slot_id=1, village_id=20003)
+
+        assert body.village_id == 20003
+
+    def test_construct_request_carries_the_target_village(self):
+        body = ConstructRequest(slot_id=20, building_name="Granary", village_id=20003)
+
+        assert body.village_id == 20003
+
+
+class _StubSession:
+    """Stands in for TravianSession; login outcome is configurable."""
+
+    instances: list = []
+
+    def __init__(self, user_id, server_url, username, password):
+        self.user_id = user_id
+        self.server_url = server_url
+        self.player_name = username
+        self.fail_login = False
+        self.disconnected = False
+        _StubSession.instances.append(self)
+
+    async def connect(self):
+        if self.fail_login:
+            raise RuntimeError("login failed")
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+class TestNonDestructiveConnect:
+    def test_a_failed_login_keeps_the_existing_session(self, monkeypatch):
+        """Reconnect on a transient Travian failure must not leave the user
+        fully disconnected when they had a working session."""
+        import travian_api.web.sessions as sessions_module
+
+        manager = SessionManager()
+        old = SimpleNamespace(disconnect_called=False)
+
+        async def old_disconnect():
+            old.disconnect_called = True
+
+        old.disconnect = old_disconnect
+        manager._sessions[1] = old
+
+        class _FailingSession(_StubSession):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.fail_login = True
+
+        monkeypatch.setattr(sessions_module, "TravianSession", _FailingSession)
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(manager.connect(1, "https://ts1.x1.europe.travian.com", "u", "p"))
+
+        assert manager.get(1) is old
+        assert old.disconnect_called is False
+
+    def test_a_successful_login_replaces_and_disconnects_the_old_session(self, monkeypatch):
+        import travian_api.web.sessions as sessions_module
+
+        manager = SessionManager()
+        old = SimpleNamespace(disconnect_called=False)
+
+        async def old_disconnect():
+            old.disconnect_called = True
+
+        old.disconnect = old_disconnect
+        manager._sessions[1] = old
+
+        monkeypatch.setattr(sessions_module, "TravianSession", _StubSession)
+
+        new = asyncio.run(manager.connect(1, "https://ts1.x1.europe.travian.com", "u", "p"))
+
+        assert manager.get(1) is new
+        assert old.disconnect_called is True
+
+
+class _FakeWebSocket:
+    def __init__(self, token="t"):
+        self.query_params = {"token": token}
+        self.closed_with = None
+
+    async def accept(self):
+        pass
+
+    async def close(self, code=None, reason=None):
+        self.closed_with = reason
+
+
+class TestWebSocketReconnect:
+    def test_ws_auth_restores_a_session_instead_of_rejecting(self, monkeypatch):
+        """After a backend restart, HTTP recovers via saved credentials while
+        sockets used to hard-fail with 'No active Travian session'."""
+        import travian_api.web.ws.manager as ws_module
+
+        manager = ws_module.ConnectionManager()
+        monkeypatch.setattr(ws_module, "decode_access_token", lambda token: {"user_id": 7})
+        monkeypatch.setattr(ws_module.session_manager, "get", lambda user_id: None)
+
+        async def restored(user_id):
+            return SimpleNamespace(user_id=user_id)
+
+        monkeypatch.setattr(ws_module, "try_restore_session", restored)
+
+        ws = _FakeWebSocket()
+        assert asyncio.run(manager.authenticate(ws)) == 7
+        assert ws.closed_with is None
+
+    def test_ws_auth_still_rejects_when_restore_fails(self, monkeypatch):
+        import travian_api.web.ws.manager as ws_module
+
+        manager = ws_module.ConnectionManager()
+        monkeypatch.setattr(ws_module, "decode_access_token", lambda token: {"user_id": 7})
+        monkeypatch.setattr(ws_module.session_manager, "get", lambda user_id: None)
+
+        async def not_restored(user_id):
+            return None
+
+        monkeypatch.setattr(ws_module, "try_restore_session", not_restored)
+
+        ws = _FakeWebSocket()
+        assert asyncio.run(manager.authenticate(ws)) is None
+        assert "No active Travian session" in ws.closed_with
+
+
+class TestTryRestoreSession:
+    def test_returns_the_live_session_without_touching_the_db(self, monkeypatch):
+        import travian_api.web.sessions as sessions_module
+
+        live = SimpleNamespace()
+        monkeypatch.setattr(sessions_module.session_manager, "get", lambda user_id: live)
+
+        assert asyncio.run(try_restore_session(7)) is live

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -27,6 +27,24 @@ class TestVillageContext:
 
         assert body.village_id == 20003
 
+    def test_construct_request_accepts_gid_only(self):
+        """building_gid is documented as the preferred identifier; requiring
+        building_name anyway 422s the preferred calling convention."""
+        body = ConstructRequest(slot_id=20, building_gid=17)
+
+        assert body.building_gid == 17
+        assert body.building_name is None
+
+    def test_construct_with_neither_identifier_is_a_400(self):
+        from fastapi import HTTPException
+
+        from travian_api.web.routes.buildings import construct_building
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(construct_building(ConstructRequest(slot_id=20)))
+
+        assert exc.value.status_code == 400
+
 
 class _StubSession:
     """Stands in for TravianSession; login outcome is configurable."""

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -133,6 +133,54 @@ class TestNonDestructiveConnect:
         assert old.disconnect_called is True
 
 
+class TestDisconnectVsReconnectRace:
+    def test_an_explicit_disconnect_is_not_undone_by_an_inflight_reconnect(self):
+        """A logout that lands while an auto-reconnect is mid-login must win:
+        the user pressed disconnect, so the session installed by the racing
+        login has to come down, not linger as a silent re-connect."""
+
+        async def scenario():
+            manager = SessionManager()
+            lock = manager.get_reconnect_lock(1)
+            login_started = asyncio.Event()
+            finish_login = asyncio.Event()
+
+            class _Restored:
+                disconnected = False
+                server_url = "https://ts1.x1.europe.travian.com"
+
+                async def disconnect(self):
+                    self.disconnected = True
+
+            restored = _Restored()
+
+            async def reconnect():
+                # Mirrors get_travian_session/try_restore_session: the lock is
+                # held across the whole login + install.
+                async with lock:
+                    login_started.set()
+                    await finish_login.wait()
+                    async with manager._lock:
+                        manager._sessions[1] = restored
+
+            async def logout():
+                await login_started.wait()
+                disconnect_task = asyncio.create_task(manager.disconnect(1))
+                # Give the disconnect every chance to (wrongly) complete while
+                # the login is still in flight.
+                await asyncio.sleep(0.05)
+                finish_login.set()
+                await disconnect_task
+
+            await asyncio.gather(reconnect(), logout())
+            return manager.get(1), restored.disconnected
+
+        session_after, torn_down = asyncio.run(scenario())
+
+        assert session_after is None
+        assert torn_down is True
+
+
 class _FakeWebSocket:
     def __init__(self, token="t"):
         self.query_params = {"token": token}

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -320,6 +320,38 @@ class TestDisconnectVsReconnectRace:
         assert exc.value.status_code == 409
         assert manager.get(1) is old
 
+    def test_disconnect_is_rejected_while_operations_run(self, monkeypatch):
+        """Same hazard as reconnect, same answer: a logout mid-operation
+        closes the HttpClient the detached job still holds, and loops that
+        treat request failures as nonfatal then fail forever. Refuse with a
+        409 and keep the session until the operations are stopped."""
+        from fastapi import HTTPException
+
+        import travian_api.operation_manager as op_module
+
+        manager = SessionManager()
+        live = SimpleNamespace(server_url="https://ts1.x1.europe.travian.com")
+        manager._sessions[1] = live
+
+        class _RunningTask:
+            def done(self):
+                return False
+
+        running_op = SimpleNamespace(label="oasis-raider", task=_RunningTask())
+        monkeypatch.setattr(
+            op_module.operation_manager, "list_for_user", lambda user_id: [running_op]
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(manager.disconnect(1))
+
+        assert exc.value.status_code == 409
+        assert "oasis-raider" in exc.value.detail
+        assert manager.get(1) is live, "a refused logout must leave the session running"
+        assert manager.auto_reconnect_allowed(1), (
+            "a refused logout is no logout: it must not flip the explicit-disconnect latch"
+        )
+
     def test_manual_connect_serializes_with_the_reconnect_lock(self, monkeypatch):
         """/api/travian/connect and /reconnect call SessionManager.connect
         directly; without the reconnect lock a logout that returned while that

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -352,6 +352,28 @@ class TestDisconnectVsReconnectRace:
             "a refused logout is no logout: it must not flip the explicit-disconnect latch"
         )
 
+    def test_a_websocket_only_operation_also_blocks_disconnect(self, monkeypatch):
+        """The raid analyzer registers only in active_ops, never as an
+        OperationManager task. It still holds this session's HttpClient, so
+        the guard must see it too -- otherwise a logout closes the client
+        mid-analysis."""
+        from fastapi import HTTPException
+
+        import travian_api.web.operation_gate as gate
+
+        manager = SessionManager()
+        manager._sessions[1] = SimpleNamespace(server_url="https://ts1.x1.europe.travian.com")
+        gate.active_ops.register(1, "raid-analyzer")
+        try:
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(manager.disconnect(1))
+        finally:
+            gate.active_ops.unregister(1, "raid-analyzer")
+
+        assert exc.value.status_code == 409
+        assert "raid-analyzer" in exc.value.detail
+        assert manager.get(1) is not None
+
     def test_manual_connect_serializes_with_the_reconnect_lock(self, monkeypatch):
         """/api/travian/connect and /reconnect call SessionManager.connect
         directly; without the reconnect lock a logout that returned while that
@@ -744,6 +766,9 @@ class TestRestoreBackoff:
 class _FakeWebSocket:
     def __init__(self, token="t"):
         self.query_params = {"token": token}
+        # No subprotocol header: these tests exercise the legacy query-param
+        # fallback, so authenticate() reads the token from query_params.
+        self.headers = {}
         self.closed_with = None
 
     async def accept(self):

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -180,6 +180,29 @@ class TestDisconnectVsReconnectRace:
         assert session_after is None
         assert torn_down is True
 
+    def test_manual_connect_serializes_with_the_reconnect_lock(self, monkeypatch):
+        """/api/travian/connect and /reconnect call SessionManager.connect
+        directly; without the reconnect lock a logout that returned while that
+        login was in flight is undone when the new session installs."""
+        import travian_api.web.sessions as sessions_module
+
+        monkeypatch.setattr(sessions_module, "TravianSession", _StubSession)
+
+        async def scenario():
+            manager = SessionManager()
+            lock = manager.get_reconnect_lock(1)
+            await lock.acquire()
+            task = asyncio.create_task(
+                manager.connect(1, "https://ts1.x1.europe.travian.com", "u", "p")
+            )
+            await asyncio.sleep(0.05)
+            finished_while_lock_held = task.done()
+            lock.release()
+            await task
+            return finished_while_lock_held
+
+        assert asyncio.run(scenario()) is False
+
     def test_the_reconnect_lock_identity_survives_a_disconnect(self):
         """Removing the lock entry on disconnect hands later reconnects a
         brand-new lock while earlier waiters still hold the old one — two
@@ -213,6 +236,7 @@ class TestRestoreSessionBookkeeping:
             return live
 
         monkeypatch.setattr(fresh, "connect", fake_connect)
+        monkeypatch.setattr(fresh, "_connect_locked", fake_connect, raising=False)
 
         cred = SimpleNamespace(
             server_url="https://ts1.x1.europe.travian.com",
@@ -242,6 +266,46 @@ class TestRestoreSessionBookkeeping:
         monkeypatch.setattr(auth_module, "decrypt_credential", lambda _s: "pw")
 
         assert asyncio.run(sessions_module.try_restore_session(7)) is live
+
+    def test_http_restore_returns_the_session_even_if_the_stamp_commit_fails(self, monkeypatch):
+        """Same contract for the HTTP dependency: a failed last_connected
+        commit after a successful login must not 403 the request while the
+        live session sits installed."""
+        import travian_api.web.auth as auth_module
+        import travian_api.web.sessions as sessions_module
+
+        fresh = sessions_module.SessionManager()
+        monkeypatch.setattr(sessions_module, "session_manager", fresh)
+
+        live = SimpleNamespace(server_url="https://ts1.x1.europe.travian.com")
+
+        async def fake_connect(**kwargs):
+            fresh._sessions[7] = live
+            return live
+
+        monkeypatch.setattr(fresh, "connect", fake_connect)
+        monkeypatch.setattr(fresh, "_connect_locked", fake_connect, raising=False)
+        monkeypatch.setattr(auth_module, "decrypt_credential", lambda _s: "pw")
+
+        cred = SimpleNamespace(
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password="sealed",
+            last_connected=None,
+        )
+
+        class _FakeDb:
+            async def execute(self, _query):
+                return SimpleNamespace(scalar_one_or_none=lambda: cred)
+
+            async def commit(self):
+                raise RuntimeError("database is locked")
+
+        user = SimpleNamespace(id=7)
+
+        result = asyncio.run(sessions_module.get_travian_session(user, _FakeDb()))
+
+        assert result is live
 
 
 class _FakeWebSocket:

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -61,6 +61,27 @@ class TestVillageContext:
 
         assert exc.value.status_code == 400
 
+    def test_upgrade_without_a_village_is_a_400_not_a_502(self):
+        """require_village_id raises a deliberate 400; when it ran inside the
+        service-error try it was rewrapped as a misleading 502. It must reach
+        the client as the 400 it is."""
+        from types import SimpleNamespace
+
+        from fastapi import HTTPException
+
+        from travian_api.web.routes.buildings import upgrade_building
+
+        # A session whose service must never be reached: if the 400 is raised
+        # first (before the try), this stub is untouched.
+        session = SimpleNamespace(building_service=None)
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(
+                upgrade_building(UpgradeRequest(slot_id=1, village_id=None), session=session)
+            )
+
+        assert exc.value.status_code == 400
+
 
 class TestVillageSwitch:
     def test_switch_is_tab_local_and_does_not_mutate_shared_state(self):

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -199,6 +199,31 @@ class TestNonDestructiveConnect:
         assert manager.get(1) is old
         assert old.disconnect_called is False
 
+    def test_a_failed_login_closes_the_session_it_created(self, monkeypatch):
+        """The session whose connect() failed was never installed anywhere,
+        but its httpx/curl clients already exist. Abandoning it leaks a
+        connection pool per failed attempt -- and auto-reconnect retries turn
+        that into a steady drip."""
+        import travian_api.web.sessions as sessions_module
+
+        manager = SessionManager()
+
+        class _FailingSession(_StubSession):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.fail_login = True
+
+        _StubSession.instances.clear()
+        monkeypatch.setattr(sessions_module, "TravianSession", _FailingSession)
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(manager.connect(1, "https://ts1.x1.europe.travian.com", "u", "p"))
+
+        assert len(_StubSession.instances) == 1
+        assert _StubSession.instances[0].disconnected is True, (
+            "the failed session's clients were never closed"
+        )
+
     def test_a_successful_login_replaces_and_disconnects_the_old_session(self, monkeypatch):
         import travian_api.web.sessions as sessions_module
 

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -180,6 +180,35 @@ class TestDisconnectVsReconnectRace:
         assert session_after is None
         assert torn_down is True
 
+    def test_reconnect_is_rejected_while_operations_run_on_the_old_session(self, monkeypatch):
+        """Long-running jobs hold the old session's HttpClient; replacing and
+        closing it mid-run makes every following request in the job fail.
+        Reconnecting must be refused until the operations are stopped."""
+        from fastapi import HTTPException
+
+        import travian_api.operation_manager as op_module
+        import travian_api.web.sessions as sessions_module
+
+        manager = SessionManager()
+        old = SimpleNamespace(server_url="https://ts1.x1.europe.travian.com")
+        manager._sessions[1] = old
+
+        class _RunningTask:
+            def done(self):
+                return False
+
+        running_op = SimpleNamespace(label="oasis-raider", task=_RunningTask())
+        monkeypatch.setattr(
+            op_module.operation_manager, "list_for_user", lambda user_id: [running_op]
+        )
+        monkeypatch.setattr(sessions_module, "TravianSession", _StubSession)
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(manager.connect(1, "https://ts1.x1.europe.travian.com", "u", "p"))
+
+        assert exc.value.status_code == 409
+        assert manager.get(1) is old
+
     def test_manual_connect_serializes_with_the_reconnect_lock(self, monkeypatch):
         """/api/travian/connect and /reconnect call SessionManager.connect
         directly; without the reconnect lock a logout that returned while that

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -419,6 +419,61 @@ class TestRestoreSessionBookkeeping:
         assert result is live
 
 
+class TestRestoreBackoff:
+    def test_a_failed_restore_is_not_retried_on_every_poll(self, monkeypatch):
+        """/status polls call try_restore_session whenever no session exists;
+        with stale credentials or a downed world, every poll performing another
+        real login is unbounded traffic and bot-detection pressure."""
+        import travian_api.web.auth as auth_module
+        import travian_api.web.models.db as db_module
+        import travian_api.web.sessions as sessions_module
+
+        fresh = SessionManager()
+        monkeypatch.setattr(sessions_module, "session_manager", fresh)
+        monkeypatch.setattr(sessions_module, "_restore_backoff", {}, raising=False)
+
+        attempts = []
+
+        async def failing_connect(**kwargs):
+            attempts.append(1)
+            raise RuntimeError("login blocked")
+
+        monkeypatch.setattr(fresh, "connect", failing_connect)
+        monkeypatch.setattr(fresh, "_connect_locked", failing_connect, raising=False)
+        monkeypatch.setattr(auth_module, "decrypt_credential", lambda _s: "pw")
+
+        cred = SimpleNamespace(
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password="sealed",
+            last_connected=None,
+        )
+
+        class _FakeDb:
+            async def execute(self, _query):
+                return SimpleNamespace(scalar_one_or_none=lambda: cred)
+
+            async def commit(self):
+                pass
+
+        class _FakeFactory:
+            def __call__(self):
+                return self
+
+            async def __aenter__(self):
+                return _FakeDb()
+
+            async def __aexit__(self, *args):
+                return False
+
+        monkeypatch.setattr(db_module, "async_session_factory", _FakeFactory())
+
+        assert asyncio.run(sessions_module.try_restore_session(7)) is None
+        assert asyncio.run(sessions_module.try_restore_session(7)) is None
+
+        assert len(attempts) == 1, "second poll re-attempted a real login during backoff"
+
+
 class _FakeWebSocket:
     def __init__(self, token="t"):
         self.query_params = {"token": token}

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -270,6 +270,64 @@ class TestDisconnectVsReconnectRace:
         assert asyncio.run(scenario()) is True
 
 
+class TestExplicitDisconnectIsPersistent:
+    """Auto-restore exists for crashes and restarts, not to override the user:
+    after DELETE /api/travian/disconnect, the very next protected request or
+    status poll must NOT silently log back in from saved credentials."""
+
+    def test_disconnect_disables_auto_restore(self):
+        async def scenario():
+            manager = SessionManager()
+            live = SimpleNamespace(server_url="https://ts1.x1.europe.travian.com")
+
+            async def teardown():
+                pass
+
+            live.disconnect = teardown
+            manager._sessions[1] = live
+            await manager.disconnect(1)
+            return manager.auto_reconnect_allowed(1)
+
+        assert asyncio.run(scenario()) is False
+
+    def test_try_restore_respects_an_explicit_disconnect(self, monkeypatch):
+        import travian_api.web.sessions as sessions_module
+
+        fresh = SessionManager()
+        fresh._explicit_disconnects.add(7)
+        monkeypatch.setattr(sessions_module, "session_manager", fresh)
+
+        # No db patching: the flag must short-circuit before any query or login.
+        assert asyncio.run(try_restore_session(7)) is None
+
+    def test_a_manual_connect_reenables_auto_restore(self, monkeypatch):
+        import travian_api.web.sessions as sessions_module
+
+        monkeypatch.setattr(sessions_module, "TravianSession", _StubSession)
+
+        async def scenario():
+            manager = SessionManager()
+            manager._explicit_disconnects.add(1)
+            await manager.connect(1, "https://ts1.x1.europe.travian.com", "u", "p")
+            return manager.auto_reconnect_allowed(1)
+
+        assert asyncio.run(scenario()) is True
+
+    def test_http_dependency_refuses_auto_restore_after_disconnect(self, monkeypatch):
+        from fastapi import HTTPException
+
+        import travian_api.web.sessions as sessions_module
+
+        fresh = SessionManager()
+        fresh._explicit_disconnects.add(7)
+        monkeypatch.setattr(sessions_module, "session_manager", fresh)
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(sessions_module.get_travian_session(SimpleNamespace(id=7), None))
+
+        assert exc.value.status_code == 403
+
+
 class TestRestoreSessionBookkeeping:
     def test_restore_returns_the_live_session_even_if_the_stamp_commit_fails(self, monkeypatch):
         """A failed last_connected commit is bookkeeping, not a login failure:

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -328,6 +328,19 @@ class TestExplicitDisconnectIsPersistent:
         assert exc.value.status_code == 403
 
 
+class TestCredentialSelection:
+    def test_restore_prefers_the_newest_row_on_timestamp_ties(self):
+        """last_connected is commonly NULL on fresh rows and legacy duplicates;
+        without a tie-break SQLite may pick an older row with an outdated
+        password, making auto-restore fail nondeterministically."""
+        from travian_api.web.sessions import latest_credential_query
+
+        sql = str(latest_credential_query(1))
+
+        assert "last_connected DESC NULLS LAST" in sql
+        assert "id DESC" in sql
+
+
 class TestRestoreSessionBookkeeping:
     def test_restore_returns_the_live_session_even_if_the_stamp_commit_fails(self, monkeypatch):
         """A failed last_connected commit is bookkeeping, not a login failure:

--- a/tests/test_village_context.py
+++ b/tests/test_village_context.py
@@ -180,6 +180,69 @@ class TestDisconnectVsReconnectRace:
         assert session_after is None
         assert torn_down is True
 
+    def test_the_reconnect_lock_identity_survives_a_disconnect(self):
+        """Removing the lock entry on disconnect hands later reconnects a
+        brand-new lock while earlier waiters still hold the old one — two
+        locks means two concurrent reconnects, the exact race again."""
+
+        async def scenario():
+            manager = SessionManager()
+            lock = manager.get_reconnect_lock(1)
+            await manager.disconnect(1)
+            return lock is manager.get_reconnect_lock(1)
+
+        assert asyncio.run(scenario()) is True
+
+
+class TestRestoreSessionBookkeeping:
+    def test_restore_returns_the_live_session_even_if_the_stamp_commit_fails(self, monkeypatch):
+        """A failed last_connected commit is bookkeeping, not a login failure:
+        returning None here closes the WebSocket with 'No active Travian
+        session' while a live session sits installed in the manager."""
+        import travian_api.web.auth as auth_module
+        import travian_api.web.models.db as db_module
+        import travian_api.web.sessions as sessions_module
+
+        fresh = sessions_module.SessionManager()
+        monkeypatch.setattr(sessions_module, "session_manager", fresh)
+
+        live = SimpleNamespace(server_url="https://ts1.x1.europe.travian.com")
+
+        async def fake_connect(**kwargs):
+            fresh._sessions[7] = live
+            return live
+
+        monkeypatch.setattr(fresh, "connect", fake_connect)
+
+        cred = SimpleNamespace(
+            server_url="https://ts1.x1.europe.travian.com",
+            travian_username="alice",
+            encrypted_password="sealed",
+            last_connected=None,
+        )
+
+        class _FakeDb:
+            async def execute(self, _query):
+                return SimpleNamespace(scalar_one_or_none=lambda: cred)
+
+            async def commit(self):
+                raise RuntimeError("database is locked")
+
+        class _FakeFactory:
+            def __call__(self):
+                return self
+
+            async def __aenter__(self):
+                return _FakeDb()
+
+            async def __aexit__(self, *args):
+                return False
+
+        monkeypatch.setattr(db_module, "async_session_factory", _FakeFactory())
+        monkeypatch.setattr(auth_module, "decrypt_credential", lambda _s: "pw")
+
+        assert asyncio.run(sessions_module.try_restore_session(7)) is live
+
 
 class _FakeWebSocket:
     def __init__(self, token="t"):

--- a/tests/test_village_statistics_parsers.py
+++ b/tests/test_village_statistics_parsers.py
@@ -147,8 +147,25 @@ def test_resources_table_maps_village_id_to_stocks():
     out = parse_village_stats_resources(RESOURCES_HTML)
 
     assert set(out) == {20001, 20002}
-    assert out[20001] == {"lumber": 95506, "clay": 87834, "iron": 89677, "crop": 43254}
+    assert out[20001]["lumber"] == 95506
+    assert out[20001]["clay"] == 87834
+    assert out[20001]["iron"] == 89677
+    assert out[20001]["crop"] == 43254
     assert out[20002]["lumber"] == 620875
+
+
+def test_resources_table_reads_the_merchant_count_directly():
+    """Settles open question #2: read the count, do not derive it.
+
+    The cell is ``free/total``; the count is the second number. Taking the first
+    would understate a busy village -- 19/20 means 20 merchants, 19 idle.
+    """
+    out = parse_village_stats_resources(RESOURCES_HTML)
+
+    assert out[20001]["merchants_free"] == 19
+    assert out[20001]["merchants_total"] == 20
+    assert out[20002]["merchants_free"] == 15
+    assert out[20002]["merchants_total"] == 20
 
 
 def test_production_table_maps_village_id_to_hourly_rates():
@@ -231,7 +248,10 @@ def test_localised_number_formats_are_parsed():
     """Other Travian locales group with dots or spaces and use a Unicode minus."""
     out = parse_village_stats_resources(LOCALISED_HTML)
 
-    assert out[7] == {"lumber": 1234, "clay": 5678, "iron": 9012, "crop": -345}
+    assert out[7]["lumber"] == 1234
+    assert out[7]["clay"] == 5678
+    assert out[7]["iron"] == 9012
+    assert out[7]["crop"] == -345
 
 
 NON_NUMERIC_HTML = """

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -5,6 +5,7 @@ extra) crashed with ModuleNotFoundError, and a custom TRAVIAN_DB_PATH pointing
 into a directory that does not exist yet made the web app unable to boot.
 """
 
+import asyncio
 import os
 import subprocess
 import sys
@@ -35,6 +36,25 @@ def test_travian_web_does_not_mask_app_bugs_as_missing_extras(monkeypatch):
 
     with pytest.raises(ImportError):
         web.main()
+
+
+def test_a_missing_frontend_build_explains_itself():
+    """`pip install .[web]` alone ships no static assets; the server must say
+    how to get a UI instead of serving a blank 404."""
+    from travian_api.web.app import serve_ui_not_built
+
+    res = asyncio.run(serve_ui_not_built(None, ""))
+
+    assert res.status_code == 503
+    assert b"npm run build" in res.body
+
+
+def test_the_unbuilt_ui_handler_still_404s_api_paths():
+    from travian_api.web.app import serve_ui_not_built
+
+    res = asyncio.run(serve_ui_not_built(None, "api/travian/status"))
+
+    assert res.status_code == 404
 
 
 def test_custom_db_path_parent_directory_is_created(tmp_path):

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -85,6 +85,65 @@ def test_custom_db_path_parent_directory_is_created(tmp_path):
     assert target.parent.is_dir()
 
 
+def test_web_keys_follow_a_custom_db_path(tmp_path):
+    """The Fernet/JWT keys must live next to the database they encrypt for:
+    with keys pinned to ~/.travian, moving or reusing a custom-path DB on
+    another setup cannot decrypt its own credential rows."""
+    db_file = tmp_path / "data" / "app.db"
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    subprocess.run(
+        [sys.executable, "-c", "import travian_api.web.auth"],
+        env={
+            **os.environ,
+            "TRAVIAN_DB_PATH": str(db_file),
+            "USERPROFILE": str(fake_home),
+            "HOME": str(fake_home),
+        },
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert (db_file.parent / ".web_keys").is_file()
+
+
+def test_legacy_keys_are_migrated_next_to_a_custom_db(tmp_path):
+    """Deployments that already ran with a custom TRAVIAN_DB_PATH have their
+    keys in ~/.travian; those must move with the DB, not be regenerated —
+    regeneration would orphan every encrypted credential row."""
+    db_file = tmp_path / "data" / "app.db"
+    fake_home = tmp_path / "home"
+    legacy_dir = fake_home / ".travian"
+    legacy_dir.mkdir(parents=True)
+    import json
+
+    from cryptography.fernet import Fernet
+
+    legacy_keys = legacy_dir / ".web_keys"
+    legacy_keys.write_text(
+        json.dumps({"jwt_secret": "legacy-jwt", "fernet_key": Fernet.generate_key().decode()})
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", "import travian_api.web.auth"],
+        env={
+            **os.environ,
+            "TRAVIAN_DB_PATH": str(db_file),
+            "USERPROFILE": str(fake_home),
+            "HOME": str(fake_home),
+        },
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    migrated = db_file.parent / ".web_keys"
+    assert migrated.is_file()
+    assert "legacy-jwt" in migrated.read_text()
+
+
 def test_init_db_backfills_columns_added_after_first_release(tmp_path):
     """create_all() never ALTERs an existing table, so upgrading a live
     travian_web.db from before label/last_connected left reconnect queries

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -83,3 +83,39 @@ def test_custom_db_path_parent_directory_is_created(tmp_path):
     )
 
     assert target.parent.is_dir()
+
+
+def test_init_db_backfills_columns_added_after_first_release(tmp_path):
+    """create_all() never ALTERs an existing table, so upgrading a live
+    travian_web.db from before label/last_connected left reconnect queries
+    failing with 'no such column' until the DB was rebuilt by hand."""
+    db_file = tmp_path / "travian_web.db"
+
+    import sqlite3
+
+    with sqlite3.connect(db_file) as conn:
+        conn.execute(
+            "CREATE TABLE travian_credentials ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "user_id INTEGER NOT NULL, "
+            "server_url VARCHAR(256) NOT NULL, "
+            "travian_username VARCHAR(128) NOT NULL, "
+            "encrypted_password VARCHAR(512) NOT NULL, "
+            "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+        )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import asyncio; from travian_api.web.models.db import init_db; asyncio.run(init_db())",
+        ],
+        env={**os.environ, "TRAVIAN_DB_PATH": str(db_file)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    with sqlite3.connect(db_file) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(travian_credentials)")}
+    assert {"label", "last_connected"} <= columns

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -15,14 +15,26 @@ import pytest
 def test_travian_web_fails_helpfully_without_the_web_extra(monkeypatch):
     import travian_api.web as web
 
-    # Simulate the base install: the app module (and its fastapi import chain)
-    # is not importable.
-    monkeypatch.setitem(sys.modules, "travian_api.web.app", None)
+    # Simulate the base install: fastapi itself is not importable, so loading
+    # the app module halts on its fastapi import.
+    monkeypatch.delitem(sys.modules, "travian_api.web.app", raising=False)
+    monkeypatch.setitem(sys.modules, "fastapi", None)
 
     with pytest.raises(SystemExit) as exc:
         web.main()
 
     assert "travian-api[web]" in str(exc.value)
+
+
+def test_travian_web_does_not_mask_app_bugs_as_missing_extras(monkeypatch):
+    """An import failure inside the app itself must surface as itself; blaming
+    the packaging would hide a broken release behind install instructions."""
+    import travian_api.web as web
+
+    monkeypatch.setitem(sys.modules, "travian_api.web.app", None)
+
+    with pytest.raises(ImportError):
+        web.main()
 
 
 def test_custom_db_path_parent_directory_is_created(tmp_path):

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -65,15 +65,23 @@ def test_loose_static_files_do_not_count_as_a_frontend_build(tmp_path):
     (tmp_path / "favicon.svg").write_text("<svg/>")
     assert ui_build_exists(tmp_path) is False
 
-    # index.html referencing a chunk that was never written = interrupted build.
+    # index.html referencing assets that were never written = interrupted build.
     (tmp_path / "assets").mkdir()
     (tmp_path / "index.html").write_text(
-        '<html><body><script type="module" src="/assets/index-abc123.js"></script></body></html>'
+        "<html><head>"
+        '<link rel="stylesheet" href="/assets/index-abc123.css">'
+        "</head><body>"
+        '<script type="module" src="/assets/index-abc123.js"></script>'
+        "</body></html>"
     )
     assert ui_build_exists(tmp_path) is False
 
-    # The referenced chunk now exists on disk → a complete build.
+    # The script exists but the linked stylesheet is still missing → not ready.
     (tmp_path / "assets" / "index-abc123.js").write_text("// built")
+    assert ui_build_exists(tmp_path) is False
+
+    # Every referenced asset exists → a complete build.
+    (tmp_path / "assets" / "index-abc123.css").write_text("/* built */")
     assert ui_build_exists(tmp_path) is True
 
 

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -65,8 +65,13 @@ def test_loose_static_files_do_not_count_as_a_frontend_build(tmp_path):
     (tmp_path / "favicon.svg").write_text("<svg/>")
     assert ui_build_exists(tmp_path) is False
 
+    # index.html + an empty assets dir is a half-written build → still not ready.
     (tmp_path / "assets").mkdir()
     (tmp_path / "index.html").write_text("<html></html>")
+    assert ui_build_exists(tmp_path) is False
+
+    # A real build has hashed JS chunks under assets/.
+    (tmp_path / "assets" / "index-abc123.js").write_text("// built")
     assert ui_build_exists(tmp_path) is True
 
 

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -70,6 +70,22 @@ def test_loose_static_files_do_not_count_as_a_frontend_build(tmp_path):
     assert ui_build_exists(tmp_path) is True
 
 
+def test_spa_file_serving_rejects_path_traversal():
+    """`/../../.env` must not escape the build directory: only api/ and ws/
+    prefixes were filtered, so any readable file on disk could be downloaded."""
+    import asyncio
+
+    from travian_api.web.app import STATIC_DIR, serve_spa
+
+    escape = "../routes/distribution.py"
+    assert (STATIC_DIR / escape).resolve().is_file(), "traversal target must exist for the test"
+
+    response = asyncio.run(serve_spa(None, escape))
+
+    served = getattr(response, "path", "")
+    assert not str(served).endswith("distribution.py"), "traversal escaped the build directory"
+
+
 def test_custom_db_path_parent_directory_is_created(tmp_path):
     target = tmp_path / "nested" / "state" / "app.db"
     assert not target.parent.exists()

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -65,12 +65,14 @@ def test_loose_static_files_do_not_count_as_a_frontend_build(tmp_path):
     (tmp_path / "favicon.svg").write_text("<svg/>")
     assert ui_build_exists(tmp_path) is False
 
-    # index.html + an empty assets dir is a half-written build → still not ready.
+    # index.html referencing a chunk that was never written = interrupted build.
     (tmp_path / "assets").mkdir()
-    (tmp_path / "index.html").write_text("<html></html>")
+    (tmp_path / "index.html").write_text(
+        '<html><body><script type="module" src="/assets/index-abc123.js"></script></body></html>'
+    )
     assert ui_build_exists(tmp_path) is False
 
-    # A real build has hashed JS chunks under assets/.
+    # The referenced chunk now exists on disk → a complete build.
     (tmp_path / "assets" / "index-abc123.js").write_text("// built")
     assert ui_build_exists(tmp_path) is True
 

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -57,6 +57,19 @@ def test_the_unbuilt_ui_handler_still_404s_api_paths():
     assert res.status_code == 404
 
 
+def test_loose_static_files_do_not_count_as_a_frontend_build(tmp_path):
+    """favicon.svg alone must not trip the SPA mount: StaticFiles raises on a
+    missing assets/ dir, crashing the server before the 503 fallback exists."""
+    from travian_api.web.app import ui_build_exists
+
+    (tmp_path / "favicon.svg").write_text("<svg/>")
+    assert ui_build_exists(tmp_path) is False
+
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "index.html").write_text("<html></html>")
+    assert ui_build_exists(tmp_path) is True
+
+
 def test_custom_db_path_parent_directory_is_created(tmp_path):
     target = tmp_path / "nested" / "state" / "app.db"
     assert not target.parent.exists()

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -1,0 +1,40 @@
+"""The published entry points must fail usefully, not with a traceback.
+
+Pins two Codex review findings: `travian-web` on a base install (no ``web``
+extra) crashed with ModuleNotFoundError, and a custom TRAVIAN_DB_PATH pointing
+into a directory that does not exist yet made the web app unable to boot.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def test_travian_web_fails_helpfully_without_the_web_extra(monkeypatch):
+    import travian_api.web as web
+
+    # Simulate the base install: the app module (and its fastapi import chain)
+    # is not importable.
+    monkeypatch.setitem(sys.modules, "travian_api.web.app", None)
+
+    with pytest.raises(SystemExit) as exc:
+        web.main()
+
+    assert "travian-api[web]" in str(exc.value)
+
+
+def test_custom_db_path_parent_directory_is_created(tmp_path):
+    target = tmp_path / "nested" / "state" / "app.db"
+    assert not target.parent.exists()
+
+    subprocess.run(
+        [sys.executable, "-c", "import travian_api.web.models.db"],
+        env={**os.environ, "TRAVIAN_DB_PATH": str(target)},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert target.parent.is_dir()

--- a/tests/test_web_entry.py
+++ b/tests/test_web_entry.py
@@ -162,6 +162,13 @@ def test_init_db_backfills_columns_added_after_first_release(tmp_path):
             "encrypted_password VARCHAR(512) NOT NULL, "
             "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)"
         )
+        conn.execute(
+            "CREATE TABLE recon_credentials ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "travian_username VARCHAR(128) NOT NULL, "
+            "encrypted_password VARCHAR(512) NOT NULL, "
+            "updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP)"
+        )
 
     subprocess.run(
         [
@@ -177,4 +184,6 @@ def test_init_db_backfills_columns_added_after_first_release(tmp_path):
 
     with sqlite3.connect(db_file) as conn:
         columns = {row[1] for row in conn.execute("PRAGMA table_info(travian_credentials)")}
+        recon_columns = {row[1] for row in conn.execute("PRAGMA table_info(recon_credentials)")}
     assert {"label", "last_connected"} <= columns
+    assert "server_url" in recon_columns

--- a/tests/test_ws_token_channel.py
+++ b/tests/test_ws_token_channel.py
@@ -1,0 +1,74 @@
+"""The WS bearer token must travel by subprotocol, and never reach the logs.
+
+Two layers, tested independently:
+- the server reads the JWT from the `travian-jwt` subprotocol (so it stays out
+  of the URL uvicorn logs), with the legacy query param still honored;
+- a logging filter scrubs any secret query param that still reaches a record,
+  so even the fallback path cannot write a reusable token to the logs.
+"""
+
+import logging
+from types import SimpleNamespace
+
+from travian_api.logging_config import QueryStringRedactionFilter
+from travian_api.web.ws.manager import _token_from_subprotocol
+
+
+def _ws(header: str | None = None, query: dict | None = None) -> SimpleNamespace:
+    headers = {"sec-websocket-protocol": header} if header is not None else {}
+    return SimpleNamespace(headers=headers, query_params=query or {})
+
+
+class TestSubprotocolToken:
+    def test_token_is_read_from_the_subprotocol(self):
+        ws = _ws(header="travian-jwt, header.payload.sig")
+        assert _token_from_subprotocol(ws) == "header.payload.sig"
+
+    def test_absent_marker_returns_none_for_query_fallback(self):
+        assert _token_from_subprotocol(_ws(header="some-other-proto")) is None
+        assert _token_from_subprotocol(_ws()) is None
+
+    def test_marker_without_a_following_value_returns_none(self):
+        assert _token_from_subprotocol(_ws(header="travian-jwt")) is None
+
+
+class TestQueryRedactionFilter:
+    def _record(self, msg, args):
+        return logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg=msg,
+            args=args,
+            exc_info=None,
+        )
+
+    def test_a_token_in_the_uvicorn_access_request_line_is_redacted(self):
+        flt = QueryStringRedactionFilter()
+        # uvicorn.access shape: msg is a format string, args carry the fields.
+        record = self._record(
+            '%s - "%s %s HTTP/%s" %d',
+            ("127.0.0.1:1", "GET", "/ws/logs?token=header.payload.sig&level=INFO", "1.1", 200),
+        )
+        flt.filter(record)
+        rendered = record.getMessage()
+        assert "header.payload.sig" not in rendered
+        assert "token=[REDACTED]" in rendered
+        assert "level=INFO" in rendered, "non-secret params must survive"
+
+    def test_a_websocket_upgrade_line_is_redacted(self):
+        flt = QueryStringRedactionFilter()
+        record = self._record(
+            '%s - "%s %s" [accepted]', ("127.0.0.1:1", "WebSocket", "/ws/logs?token=abc.def.ghi")
+        )
+        flt.filter(record)
+        assert "abc.def.ghi" not in record.getMessage()
+
+    def test_a_clean_line_is_untouched(self):
+        flt = QueryStringRedactionFilter()
+        record = self._record(
+            '%s - "%s %s HTTP/%s" %d', ("127.0.0.1:1", "GET", "/api/status", "1.1", 200)
+        )
+        flt.filter(record)
+        assert record.getMessage().endswith('"GET /api/status HTTP/1.1" 200')


### PR DESCRIPTION
Resource distribution planner: design doc, technical review, and the complete planning backend. Also a general improvement to crop reading that the planner depends on.

**592 tests passing · `ruff check` clean · no frontend changes**

## What this does

Replaces manual resource-distribution planning. A run takes fetched account state plus allocation targets and produces a setup sheet:

```
state + targets -> allocation -> routing -> beat -> integer cargo -> sheet
```

Every stage is a pure function. Nothing performs I/O, so a plan is reproducible from its inputs and the whole thing is testable without a session or a single game request.

## Generic over account size, by requirement

The account grows — 22 villages, 23 landing — and every figure differs between runs. So **no module hardcodes an account**: village lists, counts, hubs and roles are all passed in. A village appearing for the first time has no allocation and generates no routes, and there is a test asserting an existing plan is byte-identical when village 23 is added.

Consequently there is **no golden fixture**. A snapshot of a 20-village plan would have been stale the day it was written. Correctness is pinned by properties checked across account sizes 1, 2, 3, 5, 6, 12, 22, 23, 35 and 40.

## Modules

| Module | Responsibility |
|---|---|
| `geometry.py` | toroidal distance and travel time |
| `merchants.py` | capacity model, calibration, route cost, cycle choice |
| `allocation.py` | five allocation modes → per-village ship gaps |
| `rounding.py` | sum-preserving integer cargo |
| `optimizer.py` | flows → routes, merchant budgets, infeasibilities |
| `schedule.py` | the repeating 24-hour beat |
| `planner.py` | orchestration and the setup sheet |

Plus `parse_village_stats_warehouse` and `BuildingService.get_all_villages_net_crop`, which take true net crop for the whole account from **22 requests to 2**.

## Design decisions worth reviewing

**Two known issues turned out to be structurally impossible.** Because `allocation` nets each village to one figure per resource, a village cannot be both sender and receiver of the same resource. So two-way pairs (#2) and W/C/I waterfalls cannot be generated. Asserted as invariants rather than defended with runtime guards, since the property comes from the data model.

**Cycles default to the divisors of 24.** Otherwise the schedule's period is the LCM of all cycles and the output is not a table anyone can read. `ALL_CYCLES` remains exported so the optimizer can *price* the restriction rather than hide it.

**Capacity rounds down, and unknown Trade Office defaults to 0.** Understating capacity over-provisions merchants, which wastes a few; overstating it breaches the merchant budget invisibly. Only the first is recoverable.

**`derive_net_crop_per_hour` returns `None`, never `0`.** A village reported at "0 net crop" is indistinguishable from a healthy one. This codebase has shipped that silent zero three times; this PR fixes the third and refuses to add a fourth.

**Nothing is trimmed to look feasible.** Over-budget villages, unroutable demand and unmet spacing targets are all reported in the plan.

## Verification beyond the test suite

Three operations were checked against something other than my own tests:

- **`sets_in_flight`** — validated against a discrete-event simulation, 384 combinations of round trip × cycle, zero mismatches, including every boundary.
- **Distance and speed** — reproduce the operator's own hand-derived figures: `531.6 min` against a stated 532, and `105.34 fields` against a stated 105.
- **Net crop** — the draining branch reproduces village 61837's own `production.l4 = -5556` to 0.5%.

That process found three defects the unit tests missed: calibration was ill-conditioned at adjacent Trade Office levels (and *overstated* capacity in 8% of cases), the silent-zero above, and a proposed `max_merchants` filter that turned out to be dead logic — since `cheapest_cycle` already minimises merchants, the cheapest cycle is the most affordable one, so filtering could never change the answer. It was removed and the reasoning recorded.

Also confirmed the invariant tests aren't vacuous: the generated accounts produce 194 routes, 38 over-budget detections and 190 warnings.

## Corrections to the review in the doc

**R1 was wrong.** The review argued `base 2200 / +20%` had to be a mistake because published Teuton values are `1000 / +10%`. A live reading settled it: a TO 13 village carries **7,920**, and `2200 × (1 + 0.2 × 13) = 7920` exactly. Europe 2 is not a stock server. The docs and code have been corrected.

**§5.3's Trade Office table is stale** — it lists V16 at TO 0 and V05 at TO 11; both are actually TO 13, so its merchant figures are wrong independently of the formula.

## Deliberately not built

- **Hub consolidation** and escalation steps 2–3 (reroute via a nearer hub, split cargo). The optimizer sweeps cycles, recommends a Trade Office upgrade, then declares infeasibility.
- **Crop relay through a sub-hub**, which §3.5 permits. Netting makes a relay inexpressible; it needs multi-leg flows, not a scheduling change.
- **NPC, storage safety, apply and monitoring** (§6–§9), and **the UI**.

## Known limits of the first pass

Routing is greedy nearest-sender matching with no hub consolidation, so on a spread-out account latencies exceed the 2h target and it says so per route. It is deterministic and explainable, and it is the baseline the hub pass has to beat — it does not claim optimality.

## Reviewer's guide

Highest-value files: `optimizer.py` (the matching and budget logic), `schedule.py` (the beat placement), and `allocation.py` (where the ship-vs-target guard lives). `docs/25-resource-distribution-planner.md` carries the full design, the review, and a UI design.

The crop-balance work (`parse_village_stats_warehouse`, `get_all_villages_net_crop`, `CropBalance`) is general infrastructure rather than planner-specific and could be split into its own PR if you would rather review in smaller pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
