### PR TITLE
fix(deps): raise the declared floors to the versions that clear the advisories

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.2",
-        "axios": "^1.14.0",
+        "axios": "^1.19.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.14.0",
+        "react-router-dom": "^7.18.2",
         "tailwindcss": "^4.2.2",
         "zustand": "^5.0.12"
       },
@@ -25,7 +25,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
-        "vite": "^8.0.4",
+        "vite": "^8.2.2",
         "vitest": "^4.1.11"
       }
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,10 +12,10 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",
-    "axios": "^1.14.0",
+    "axios": "^1.19.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.14.0",
+    "react-router-dom": "^7.18.2",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.12"
   },
@@ -28,7 +28,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
-    "vite": "^8.0.4",
+    "vite": "^8.2.2",
     "vitest": "^4.1.11"
   }
 }


### PR DESCRIPTION
## What

Raises three semver floors in `frontend/package.json`, and the matching root range block in `frontend/package-lock.json`:

```
axios             ^1.14.0 -> ^1.19.0
react-router-dom  ^7.14.0 -> ^7.18.2
vite              ^8.0.4  -> ^8.2.2
```

That is the whole change: 6 insertions, 6 deletions, 2 files.

## Why

`8e06374` cleared all 11 frontend advisories in the **lockfile**, but deliberately left `package.json` alone, reasoning that the existing caret ranges already admitted every fix. True of resolution, false of declaration — the manifest went on naming the vulnerable minimums as supported: axios `^1.14.0` against an advisory range of 1.0.0–1.17.0, react-router-dom `^7.14.0` against 6.0.0–7.18.1, vite `^8.0.4` against 8.0.0–8.0.15.

A lockfile records what one install happened to resolve; the range records what the project claims is safe to run. Those two disagreed.

Plain `npm install` reports "up to date" and silently leaves the lockfile's root range block stale, which desyncs it from `package.json` and fails the `npm ci` step in CI. Regenerated with `--package-lock-only` to keep them in sync — that is why the lockfile is in the diff.

## Scope

- **0 of 270 resolved versions change** (verified by before/after snapshot of every `packages{}` entry).
- `npm audit` = 0 vulnerabilities, before and after.
- `postcss` (8.5.26) and `@babel/core` (7.29.7) are transitive via `@tailwindcss/vite` and `@vitejs/plugin-react` and already resolve clear, so no `overrides` entry was added.

## Reachability

Neither runtime advisory class is reachable in this app, verified per-sink rather than asserted:

- **axios SSRF via NO_PROXY** — the `browser` field maps `lib/adapters/http.js` to `lib/helpers/null.js`, so the Node adapter holding all proxy handling is absent from the bundle. `src/api.js` is the sole axios importer, `baseURL: '/api'`, same-origin.
- **axios null-byte via `params`** — all 7 `params:` sites pass a numeric id, a boolean literal, or a `parseInt`-coerced value.
- **react-router RCE via vendored turbo-stream** — `App.jsx` is declarative mode only (`Routes`/`Route`/`Navigate`/`Outlet`/`NavLink`/`useLocation`/`useNavigate`). No `createBrowserRouter`, no `loader`/`action`, no `<Form>`, no SSR. turbo-stream is loaded only by data/framework mode.
- **open redirect** — every navigation sink is a hardcoded literal or a static-map lookup (`typeRoutes`, `quickActions`, two nav arrays).
- **CSRF** — no ambient credentials. Zero hits for `document.cookie`/`withCredentials`/`xsrf*`; auth is `Authorization: Bearer` from localStorage.
- **vite / postcss / @babel/core** — build-time only, never shipped. The vite dev-server findings additionally need `vite dev` running, and `vite.config.js` sets no `server.host`.

## Verification

- `npx eslint . --max-warnings=20` — 0 errors, 18 warnings (all pre-existing, in untouched files)
- `npm test` — 33/33 passing
- `npm audit` — 0 vulnerabilities
- `npm ci` — accepts the synced lockfile

**No production rebuild was performed, and none is needed.** Built the new manifest to a scratch directory and compared against the deployed output in `src/travian_api/web/static`: all 29 files identical by sha256, production hash and mtime unchanged. Since `npm run build` writes straight into the directory the :80 server serves, not rebuilding was the correct call.

## Review

Codex adversarial review returned **no P1/P2/P3 — EXHAUSTED**. Its four initial findings all challenged the reachability *justification* rather than the shipped versions; each was then verified against the code, which is where the per-sink analysis above comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)